### PR TITLE
fix: Restore voice-agent endpoints with VAPI integration disabled in …

### DIFF
--- a/web/src/app/api/calls/batch/route.ts
+++ b/web/src/app/api/calls/batch/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:3004";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const authToken = request.headers.get("authorization");
+
+    // Forward the batch request to the backend
+    const response = await fetch(`${BACKEND_URL}/calls/batch`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Frontend-ID": "dev",
+        "X-API-Key": process.env.BACKEND_API_KEY || "kMQgGRDAa8t5CvmkfqFYuGiXIXgNYC1EEGjYs5v8_NU",
+        ...(authToken ? { Authorization: authToken } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Error forwarding batch call request:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to initiate batch calls" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/app/api/calls/route.ts
+++ b/web/src/app/api/calls/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:3004";
+
+export async function POST(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const authToken = request.headers.get("authorization");
+
+    // Forward the request to the backend
+    const response = await fetch(`${BACKEND_URL}/calls`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Frontend-ID": "dev",
+        "X-API-Key": process.env.BACKEND_API_KEY || "kMQgGRDAa8t5CvmkfqFYuGiXIXgNYC1EEGjYs5v8_NU",
+        ...(authToken ? { Authorization: authToken } : {}),
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Error forwarding call request:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to initiate call" },
+      { status: 500 }
+    );
+  }
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    const authToken = request.headers.get("authorization");
+    const url = new URL(request.url);
+    const searchParams = url.searchParams.toString();
+
+    // Forward the request to the backend
+    const response = await fetch(`${BACKEND_URL}/calls${searchParams ? `?${searchParams}` : ''}`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Frontend-ID": "dev",
+        "X-API-Key": process.env.BACKEND_API_KEY || "kMQgGRDAa8t5CvmkfqFYuGiXIXgNYC1EEGjYs5v8_NU",
+        ...(authToken ? { Authorization: authToken } : {}),
+      },
+    });
+
+    const data = await response.json();
+    return NextResponse.json(data, { status: response.status });
+  } catch (error) {
+    console.error("Error fetching calls:", error);
+    return NextResponse.json(
+      { success: false, error: "Failed to fetch calls" },
+      { status: 500 }
+    );
+  }
+}

--- a/web/src/components/CallConfiguration.tsx
+++ b/web/src/components/CallConfiguration.tsx
@@ -615,14 +615,20 @@ export function CallConfiguration({
     let cancelled = false;
     (async () => {
       try {
-        const res = await apiGet<SignedSampleResponse>(
-          `/api/voice-agent/agents/${encodeURIComponent(key)}/sample-signed-url`
-        );
-        const url = (res?.signed_url || res?.signedUrl || res?.url || '').toString().trim();
-        if (!cancelled && url) {
-          signedSampleUrlCache.current.set(key, url);
-          setSignedSampleUrl(url);
-        } else if (!cancelled) {
+        // VAPI DISABLED: Commenting out voice agent sample URL fetch
+        // const res = await apiGet<SignedSampleResponse>(
+        //   `/api/voice-agent/agents/${encodeURIComponent(key)}/sample-signed-url`
+        // );
+        // const url = (res?.signed_url || res?.signedUrl || res?.url || '').toString().trim();
+        // if (!cancelled && url) {
+        //   signedSampleUrlCache.current.set(key, url);
+        //   setSignedSampleUrl(url);
+        // } else if (!cancelled) {
+        //   setSignedSampleUrl(null);
+        // }
+        
+        // VAPI DISABLED: Set null since voice agent is disabled
+        if (!cancelled) {
           setSignedSampleUrl(null);
         }
       } catch (e) {

--- a/web/src/components/CallOptions.tsx
+++ b/web/src/components/CallOptions.tsx
@@ -122,6 +122,7 @@ export function CallOptions(props: CallOptionsProps) {
         };
 
         console.log("📦 Sending bulk payload:", payload);
+        // Using backend voice-agent calls API (VAPI integration disabled in backend)
         const res = await apiPost("/api/voice-agent/calls/batch", payload);
 
         // Expect backend response like { success: true, result: { job_id: "batch-..." } }
@@ -158,6 +159,7 @@ export function CallOptions(props: CallOptionsProps) {
         ...(effectiveInitiator !== undefined ? { initiated_by: effectiveInitiator } : {}),
       } as const;
       console.log("☎️ Sending single-call payload:", singlePayload);
+      // Using backend voice-agent calls API (VAPI integration disabled in backend)
       await apiPost("/api/voice-agent/calls", singlePayload);
       push({ title: "Success", description: "Call initiated successfully!" });
       onDialChange("");

--- a/web/src/components/call-log-modal.tsx
+++ b/web/src/components/call-log-modal.tsx
@@ -556,7 +556,7 @@ export function CallLogModal({
       }
 
       try {
-        // 1) Call log
+        // Call log - Using voice-agent API (VAPI integration disabled in backend)
         const res = await apiGet<{ success: boolean; log: any }>(`/api/voice-agent/calls/${id}`);
         const l = res.log;
         setLog(l);
@@ -603,6 +603,7 @@ export function CallLogModal({
 
           if (callId) {
             try {
+              // Using voice-agent API for recording URL (VAPI integration disabled in backend)
               const signedRes = await apiGet<{ success: boolean; signed_url?: string }>(
                 `/api/voice-agent/calls/${callId}/recording-signed-url`
               );
@@ -622,7 +623,7 @@ export function CallLogModal({
           setSignedRecordingUrl(l?.call_recording_url);
         }
 
-        // 4) Analysis (optional)
+        // 4) Analysis - Using voice-agent API (VAPI integration disabled in backend)
         try {
           const ra = await apiGet<{ success: boolean; analysis: any }>(`/api/voice-agent/calls/${id}/analysis`);
           const a = ra?.analysis ?? null;


### PR DESCRIPTION
…backend

- Updated CallOptions.tsx to use /api/voice-agent/calls endpoints
- Updated CallConfiguration.tsx to disable VAPI sample URL fetching
- Updated call-log-modal.tsx to use voice-agent API endpoints
- Added /api/calls proxy routes (unused but kept for reference)
- Backend VAPI calls are disabled, using legacy call forwarding instead