### PR TITLE
feat: Remove polling and implement pure SSE for campaign live updates

### DIFF
--- a/sdk/features/campaigns/hooks/useCampaignAnalytics.ts
+++ b/sdk/features/campaigns/hooks/useCampaignAnalytics.ts
@@ -49,13 +49,7 @@ export function useCampaignAnalytics(campaignId: string | null): UseCampaignAnal
 
   useEffect(() => {
     fetchAnalytics();
-    
-    // Auto-refresh every 15 seconds for live analytics updates
-    const interval = setInterval(() => {
-      fetchAnalytics();
-    }, 15000);
-    
-    return () => clearInterval(interval);
+    // No polling - live updates come via SSE from useCampaignStatsLive
   }, [fetchAnalytics]);
 
   return {


### PR DESCRIPTION
- Updated useCampaignStatsLive: Removed polling fallback, pure SSE with infinite reconnection
- Updated useCampaignActivityFeed: Removed polling, added proper SSE URL with auth token
- Updated useCampaignAnalytics: Removed 15-second polling interval
- All hooks now use pure Server-Sent Events (SSE) for real-time updates
- Implemented exponential backoff reconnection strategy
- Added proper error handling and connection state management