### PR TITLE
feat: add cloudbuild-stage.yaml for staging deployments

### DIFF
--- a/cloudbuild-stage.yaml
+++ b/cloudbuild-stage.yaml
@@ -1,0 +1,67 @@
+steps:
+  # Build Docker image for STAGING
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - 'gcr.io/$PROJECT_ID/lad-frontend-stage:$SHORT_SHA'
+      - '-t'
+      - 'gcr.io/$PROJECT_ID/lad-frontend-stage:latest'
+      - '--build-arg'
+      - 'VITE_BACKEND_URL=https://lad-backend-stage-741719885039.us-central1.run.app'
+      - '--build-arg'
+      - 'NEXT_PUBLIC_API_URL=https://lad-backend-stage-741719885039.us-central1.run.app'
+      - '--build-arg'
+      - 'NEXT_PUBLIC_BACKEND_URL=https://lad-backend-stage-741719885039.us-central1.run.app'
+      - '--build-arg'
+      - 'NEXT_PUBLIC_ICP_BACKEND_URL=https://lad-backend-stage-741719885039.us-central1.run.app'
+      - '--build-arg'
+      - 'NEXT_PUBLIC_SOCKET_URL=https://lad-backend-stage-741719885039.us-central1.run.app'
+      - '--build-arg'
+      - 'NEXT_PUBLIC_DISABLE_VAPI=false'
+      - '-f'
+      - 'Dockerfile'
+      - '.'
+
+  # Push image to Container Registry
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'gcr.io/$PROJECT_ID/lad-frontend-stage:$SHORT_SHA'
+
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'gcr.io/$PROJECT_ID/lad-frontend-stage:latest'
+
+  # Deploy to Cloud Run (STAGING)
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        gcloud run deploy lad-frontend-stage \
+          --image gcr.io/$PROJECT_ID/lad-frontend-stage:$SHORT_SHA \
+          --region us-central1 \
+          --platform managed \
+          --allow-unauthenticated \
+          --memory 2Gi \
+          --cpu 2 \
+          --min-instances 0 \
+          --max-instances 5 \
+          --concurrency 80 \
+          --timeout 300 \
+          --set-env-vars NODE_ENV=production,BRANCH=$BRANCH_NAME,COMMIT_SHA=$SHORT_SHA,NEXT_PUBLIC_BACKEND_URL=https://lad-backend-stage-741719885039.us-central1.run.app,NEXT_PUBLIC_ICP_BACKEND_URL=https://lad-backend-stage-741719885039.us-central1.run.app,NEXT_PUBLIC_SOCKET_URL=https://lad-backend-stage-741719885039.us-central1.run.app,NEXT_PUBLIC_DISABLE_VAPI=false
+        
+        echo "✅ Staging deployment completed successfully"
+
+images:
+  - 'gcr.io/$PROJECT_ID/lad-frontend-stage:$SHORT_SHA'
+  - 'gcr.io/$PROJECT_ID/lad-frontend-stage:latest'
+
+options:
+  logging: CLOUD_LOGGING_ONLY
+  machineType: 'E2_HIGHCPU_8'
+  substitutionOption: 'ALLOW_LOOSE'
+
+timeout: '1800s'


### PR DESCRIPTION
- Create cloudbuild-stage.yaml for stage branch deployments
- Uses lad-frontend-stage service name
- Points to staging backend URLs (lad-backend-stage)
- Resources: 2Gi/2CPU, min-instances=0, max-instances=5
- Follows same pattern as develop and production configs