### PR TITLE
fix: Update production frontend cloudbuild.yaml

### DIFF
--- a/web/cloudbuild.yaml
+++ b/web/cloudbuild.yaml
@@ -14,10 +14,11 @@ steps:
     args:
       - '-c'
       - |
-        echo "=== Build Arguments Debug ==="
+        echo "=== Production Build Arguments Debug ==="
         echo "BRANCH_NAME: ${BRANCH_NAME}"
         echo "_API_URL: ${_API_URL}"
         echo "_NEXT_PUBLIC_SOCKET_URL: ${_NEXT_PUBLIC_SOCKET_URL}"
+        echo "Environment: PRODUCTION"
         echo "=== End Debug ==="
 
   # Build the Docker image with buildkit for better caching
@@ -30,11 +31,12 @@ steps:
       '-t', 'gcr.io/$PROJECT_ID/lad-frontend:latest',
       '--cache-from', 'gcr.io/$PROJECT_ID/lad-frontend:latest',
       '--build-arg', 'BUILDKIT_INLINE_CACHE=1',
-      '--build-arg', 'NEXT_PUBLIC_BACKEND_URL=https://lad-backend-develop-741719885039.us-central1.run.app',
-      '--build-arg', 'NEXT_PUBLIC_ICP_BACKEND_URL=https://lad-backend-develop-741719885039.us-central1.run.app',
-      '--build-arg', 'NEXT_PUBLIC_SOCKET_URL=https://lad-backend-develop-741719885039.us-central1.run.app',
+      '--build-arg', 'NEXT_PUBLIC_BACKEND_URL=$_API_URL',
+      '--build-arg', 'NEXT_PUBLIC_ICP_BACKEND_URL=$_API_URL',
+      '--build-arg', 'NEXT_PUBLIC_SOCKET_URL=$_NEXT_PUBLIC_SOCKET_URL',
       '--build-arg', 'NEXT_PUBLIC_DISABLE_VAPI=false',
-      '-f', 'web/Dockerfile',
+      '--build-arg', 'NODE_ENV=production',
+      '-f', 'Dockerfile',
       '.'
     ]
 


### PR DESCRIPTION
- Change service name from lad-frontend-prod to lad-frontend
- Use build arg variables instead of hardcoded backend URLs
- Add NODE_ENV=production build arg for consistency
- Fix Dockerfile path from web/Dockerfile to Dockerfile
- Update debug message to indicate PRODUCTION environment
- Align with staging cloudbuild structure