### PR TITLE
feat: dynamic tenant loading and tenant switcher

### DIFF
--- a/sdk/shared/proxyClient.ts
+++ b/sdk/shared/proxyClient.ts
@@ -49,6 +49,11 @@ class ProxyClient {
       if (token) {
         headers['Authorization'] = `Bearer ${token}`;
       }
+      // Forward selected tenant ID so proxy routes to correct tenant database
+      const selectedTenantId = safeStorage.getItem('selectedTenantId');
+      if (selectedTenantId && selectedTenantId !== 'default') {
+        headers['X-Tenant-ID'] = selectedTenantId;
+      }
     }
 
     const config: RequestInit = {

--- a/web/src/app/api/whatsapp-conversations/utils/python-proxy.ts
+++ b/web/src/app/api/whatsapp-conversations/utils/python-proxy.ts
@@ -57,9 +57,9 @@ export async function proxyToPythonService(
     }
   }
 
-  // Also check for X-Tenant-ID passed directly from the client
+  // Explicit X-Tenant-ID from client takes priority (supports tenant switching)
   const directTenantId = req.headers.get('x-tenant-id');
-  if (directTenantId && !headers['X-Tenant-ID']) {
+  if (directTenantId) {
     headers['X-Tenant-ID'] = directTenantId;
   }
 

--- a/web/src/components/conversations/ConversationSidebar.tsx
+++ b/web/src/components/conversations/ConversationSidebar.tsx
@@ -133,6 +133,13 @@ async function fetchWithAuth(url: string, options: RequestInit = {}) {
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
   }
+  // Forward selected tenant ID for correct tenant routing
+  if (typeof window !== 'undefined') {
+    const selectedTenantId = localStorage.getItem('selectedTenantId');
+    if (selectedTenantId && selectedTenantId !== 'default') {
+      headers['X-Tenant-ID'] = selectedTenantId;
+    }
+  }
   return fetch(url, {
     ...options,
     headers,

--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -30,11 +30,14 @@ import { useQueryClient } from "@tanstack/react-query";
 import { logout as logoutAction } from "@/store/slices/authSlice";
 import authService from "@/services/authService";
 import { useAuth } from "@/contexts/AuthContext";
+import { useTenant } from "@/contexts/TenantContext";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
+  DropdownMenuSeparator,
+  DropdownMenuLabel,
 } from "@/components/ui/dropdown-menu";
 import LAD3DShowcase from "@/app/page";
 type RootState = {
@@ -66,6 +69,7 @@ export function Sidebar() {
   const dispatch = useDispatch();
   const queryClient = useQueryClient();
   const { hasFeature } = useAuth();
+  const { tenant, setTenantById, tenants } = useTenant();
   const user = useSelector((state: RootState) => state.auth.user);
   const companyLogo = useSelector((state: RootState) => state.settings.companyLogo);
   const [isExpanded, setIsExpanded] = useState(false);
@@ -496,6 +500,18 @@ export function Sidebar() {
               side="top"
               className="w-56 mb-2 ml-2"
             >
+              <DropdownMenuLabel className="text-xs text-muted-foreground">Tenant</DropdownMenuLabel>
+              {tenants.map((t) => (
+                <DropdownMenuItem
+                  key={t.id}
+                  onClick={() => setTenantById(t.id)}
+                  className={cn("cursor-pointer", tenant.id === t.id && "bg-accent font-medium")}
+                >
+                  {tenant.id === t.id && <span className="mr-1">✓</span>}
+                  <span>{t.name}</span>
+                </DropdownMenuItem>
+              ))}
+              <DropdownMenuSeparator />
               {/* <DropdownMenuItem asChild>
                 <NavLink
                   href="/pricing"

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -3,6 +3,14 @@ import React, { createContext, useContext, useState, useEffect, ReactNode } from
 import { useRouter } from 'next/navigation';
 import { safeStorage } from '../utils/storage';
 import { logger } from '@/lib/logger';
+interface UserTenant {
+  id: string;
+  name: string;
+  planTier?: string;
+  status?: string;
+  role?: string;
+}
+
 interface User {
   id: string;
   email: string;
@@ -10,6 +18,8 @@ interface User {
   firstName?: string;
   lastName?: string;
   role?: string;
+  tenantId?: string;
+  tenants?: UserTenant[];
   capabilities?: string[];
   tenantFeatures?: string[];
 }

--- a/web/src/contexts/TenantContext.tsx
+++ b/web/src/contexts/TenantContext.tsx
@@ -1,29 +1,11 @@
 'use client';
-import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useEffect, useMemo, ReactNode } from 'react';
 import { safeStorage } from '../utils/storage';
 
 export interface Tenant {
   id: string;
   name: string;
-  /** Optional override URL for conversations API (e.g. unified-comms service) */
-  conversationsUrl?: string;
 }
-
-/** Known tenants. Add new tenants here. */
-export const TENANTS: Tenant[] = [
-  {
-    id: 'default',
-    name: 'TPF (Default)',
-    // Uses the main backend — no override
-  },
-  {
-    id: '9ca4012a-2e02-5593-8cc1-fd5bd81483f9',
-    name: 'BNI Rising Phoenix',
-    conversationsUrl:
-      process.env.NEXT_PUBLIC_UNIFIED_COMMS_URL ||
-      'https://unified-comms-160078175457.us-central1.run.app',
-  },
-];
 
 interface TenantContextType {
   tenant: Tenant;
@@ -36,32 +18,72 @@ const TenantContext = createContext<TenantContextType | undefined>(undefined);
 
 const STORAGE_KEY = 'selectedTenantId';
 
-export function TenantProvider({ children }: { children: ReactNode }) {
-  const [tenant, setTenant] = useState<Tenant>(TENANTS[0]);
+/**
+ * Build the tenants list dynamically from the logged-in user's data
+ * (returned by /api/auth/me and stored in safeStorage as 'user').
+ */
+function loadTenantsFromAuth(): Tenant[] {
+  try {
+    const raw = safeStorage.getItem('user');
+    if (!raw) return [];
+    const user = JSON.parse(raw);
+    if (Array.isArray(user.tenants)) {
+      return user.tenants.map((t: { id: string; name: string }) => ({
+        id: t.id,
+        name: t.name,
+      }));
+    }
+  } catch { /* ignore parse errors */ }
+  return [];
+}
 
+export function TenantProvider({ children }: { children: ReactNode }) {
+  const [tenants, setTenants] = useState<Tenant[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  // Load tenants from auth data + restore last selection
   useEffect(() => {
+    const loaded = loadTenantsFromAuth();
+    setTenants(loaded);
     const stored = safeStorage.getItem(STORAGE_KEY);
-    if (stored) {
-      const found = TENANTS.find((t) => t.id === stored);
-      if (found) setTenant(found);
+    if (stored && loaded.find((t) => t.id === stored)) {
+      setSelectedId(stored);
+    } else if (loaded.length > 0) {
+      // Default to first tenant (primary tenant is first from backend)
+      setSelectedId(loaded[0].id);
     }
   }, []);
 
+  // Re-sync when storage changes (e.g. after login in another tab)
+  useEffect(() => {
+    const onStorage = () => {
+      const loaded = loadTenantsFromAuth();
+      setTenants(loaded);
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const tenant = useMemo(
+    () => tenants.find((t) => t.id === selectedId) || tenants[0] || { id: 'default', name: 'Default' },
+    [tenants, selectedId],
+  );
+
   const setTenantById = (id: string) => {
-    const found = TENANTS.find((t) => t.id === id);
+    const found = tenants.find((t) => t.id === id);
     if (found) {
-      setTenant(found);
+      setSelectedId(id);
       safeStorage.setItem(STORAGE_KEY, id);
-      // Reload conversations when tenant changes
+      // Reload so all components refetch with the new tenant
       window.location.reload();
     }
   };
 
-  // tenantId to send as X-Tenant-ID header (null for default tenant)
+  // tenantId sent as X-Tenant-ID header
   const tenantId = tenant.id === 'default' ? null : tenant.id;
 
   return (
-    <TenantContext.Provider value={{ tenant, tenantId, setTenantById, tenants: TENANTS }}>
+    <TenantContext.Provider value={{ tenant, tenantId, setTenantById, tenants }}>
       {children}
     </TenantContext.Provider>
   );


### PR DESCRIPTION
- Load tenants dynamically from /api/auth/me instead of hardcoded array
- Add tenant switcher to sidebar
- Pass X-Tenant-ID header in proxy client and python-proxy
- Update AuthContext with tenant-aware routing
- Update ConversationSidebar for multi-tenant support