### PR TITLE
feat: fix message send from UI and add AI takeover confirmation

### DIFF
--- a/web/src/components/conversations/ChatWindow.tsx
+++ b/web/src/components/conversations/ChatWindow.tsx
@@ -79,6 +79,8 @@ export const ChatWindow = memo(function ChatWindow({
         onSendMessage={onSendMessage}
         disabled={conversation.status === 'resolved'}
         contactName={conversation.contact?.name}
+        conversationId={conversation.id}
+        owner={conversation.owner}
       />
     </div>
   );

--- a/web/src/components/conversations/MessageComposer.tsx
+++ b/web/src/components/conversations/MessageComposer.tsx
@@ -10,6 +10,16 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
 import { QuickReplyPicker } from './QuickReplyPicker';
 
 type AgentType = 'human' | 'ai';
@@ -19,25 +29,40 @@ interface MessageComposerProps {
   onSendMessage: (content: string, attachments?: Attachment[]) => void;
   disabled?: boolean;
   contactName?: string;
+  conversationId?: string;
+  owner?: string | null;
 }
 
-const channelPlaceholders: Record<Channel, string> = {
+const channelPlaceholders: Partial<Record<Channel, string>> = {
   whatsapp: 'Type a message...',
   linkedin: 'Write a professional message...',
   gmail: 'Compose your email...',
 };
+const DEFAULT_PLACEHOLDER = 'Type a message...';
+
+const CONV_API = '/api/whatsapp-conversations/conversations';
 
 export const MessageComposer = memo(function MessageComposer({
   channel,
   onSendMessage,
   disabled = false,
   contactName,
+  conversationId,
+  owner,
 }: MessageComposerProps) {
   const [message, setMessage] = useState('');
   const [attachments, setAttachments] = useState<Attachment[]>([]);
-  const [agentType, setAgentType] = useState<AgentType>('human');
+  const [agentType, setAgentType] = useState<AgentType>(
+    owner === 'human_agent' ? 'human' : 'ai'
+  );
+  const [showTakeoverDialog, setShowTakeoverDialog] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Sync agentType when owner prop changes (e.g. conversation switch)
+  useEffect(() => {
+    setAgentType(owner === 'human_agent' ? 'human' : 'ai');
+  }, [owner, conversationId]);
 
   // Auto-resize textarea
   useEffect(() => {
@@ -47,6 +72,36 @@ export const MessageComposer = memo(function MessageComposer({
       textarea.style.height = `${Math.min(textarea.scrollHeight, 150)}px`;
     }
   }, [message]);
+
+  const updateOwnership = useCallback(async (newOwner: 'AI' | 'human_agent') => {
+    if (!conversationId) return;
+    try {
+      await fetch(`${CONV_API}/${conversationId}/ownership`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ owner: newOwner }),
+      });
+    } catch (err) {
+      console.error('Failed to update ownership:', err);
+    }
+  }, [conversationId]);
+
+  const handleAgentTypeChange = useCallback((type: AgentType) => {
+    if (type === 'human' && agentType === 'ai') {
+      // Show confirmation before switching to human control
+      setShowTakeoverDialog(true);
+    } else if (type === 'ai' && agentType === 'human') {
+      // Switch back to AI without confirmation
+      setAgentType('ai');
+      updateOwnership('AI');
+    }
+  }, [agentType, updateOwnership]);
+
+  const confirmTakeover = useCallback(() => {
+    setAgentType('human');
+    updateOwnership('human_agent');
+    setShowTakeoverDialog(false);
+  }, [updateOwnership]);
 
   const handleSend = useCallback(() => {
     if ((message.trim() || attachments.length > 0) && !disabled) {
@@ -70,7 +125,7 @@ export const MessageComposer = memo(function MessageComposer({
     const newAttachments: Attachment[] = Array.from(files).map((file, idx) => ({
       id: `attach-${Date.now()}-${idx}`,
       name: file.name,
-      type: file.type.startsWith('image/') ? 'image' : 'file',
+      type: file.type.startsWith('image/') ? 'image' as const : 'document' as const,
       url: URL.createObjectURL(file),
       size: file.size,
     }));
@@ -100,6 +155,25 @@ export const MessageComposer = memo(function MessageComposer({
 
   return (
     <div className="border-t border-border bg-card p-3">
+      {/* Takeover confirmation dialog */}
+      <AlertDialog open={showTakeoverDialog} onOpenChange={setShowTakeoverDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Take over from AI Agent?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will pause the AI agent and give you manual control of this conversation.
+              The AI will not respond to incoming messages until you switch back.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmTakeover}>
+              Yes, take control
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
       {/* Hidden file input */}
       <input
         ref={fileInputRef}
@@ -140,14 +214,20 @@ export const MessageComposer = memo(function MessageComposer({
       )}
 
       <div className="flex items-end gap-2">
-        {/* Agent type dropdown */}
+        {/* Agent type dropdown with ownership indicator */}
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button
               variant="ghost"
               size="icon"
-              className="h-9 w-9 flex-shrink-0 text-muted-foreground hover:text-foreground"
+              className={cn(
+                "h-9 w-9 flex-shrink-0",
+                agentType === 'human'
+                  ? "text-orange-500 hover:text-orange-600"
+                  : "text-green-500 hover:text-green-600"
+              )}
               disabled={disabled}
+              title={agentType === 'human' ? 'Human agent controls this chat' : 'AI agent controls this chat'}
             >
               {agentType === 'human' ? (
                 <User className="h-5 w-5" />
@@ -158,18 +238,20 @@ export const MessageComposer = memo(function MessageComposer({
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="bg-popover z-50">
             <DropdownMenuItem
-              onClick={() => setAgentType('human')}
+              onClick={() => handleAgentTypeChange('human')}
               className={cn(agentType === 'human' && 'bg-accent')}
             >
               <User className="h-4 w-4 mr-2" />
               Human Agent
+              {agentType === 'human' && <span className="ml-auto text-xs text-muted-foreground">Active</span>}
             </DropdownMenuItem>
             <DropdownMenuItem
-              onClick={() => setAgentType('ai')}
+              onClick={() => handleAgentTypeChange('ai')}
               className={cn(agentType === 'ai' && 'bg-accent')}
             >
               <Bot className="h-4 w-4 mr-2" />
               AI Agent
+              {agentType === 'ai' && <span className="ml-auto text-xs text-muted-foreground">Active</span>}
             </DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
@@ -199,7 +281,7 @@ export const MessageComposer = memo(function MessageComposer({
             value={message}
             onChange={(e) => setMessage(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder={channelPlaceholders[channel]}
+            placeholder={channelPlaceholders[channel] || DEFAULT_PLACEHOLDER}
             disabled={disabled}
             className={cn(
               'min-h-[40px] max-h-[150px] resize-none py-2.5 pr-10',
@@ -230,9 +312,12 @@ export const MessageComposer = memo(function MessageComposer({
         </Button>
       </div>
 
-      {/* Channel hint */}
+      {/* Channel hint + ownership status */}
       <p className="text-[10px] text-muted-foreground mt-2 px-1">
         Press Enter to send · Shift+Enter for new line
+        {agentType === 'human' && (
+          <span className="ml-2 text-orange-500 font-medium">· You have manual control</span>
+        )}
       </p>
     </div>
   );

--- a/web/src/features/conversations/useConversations.ts
+++ b/web/src/features/conversations/useConversations.ts
@@ -93,13 +93,17 @@ export function useConversations(): UseConversationsReturn {
     dispatch(markConversationRead(id));
   }, [dispatch]);
 
-  const sendMessage = useCallback((content: string) => {
+  const sendMessage = useCallback(async (content: string) => {
     if (!selectedId || !content.trim()) return;
 
-    const newMessage: Message = {
-      id: `msg-${Date.now()}`,
-    };
+    const conv = conversationsFromRedux.find((c) => String(c.id) === String(selectedId));
+    const leadId = conv?.leadId;
 
+    // Optimistically add to local state
+    const tempId = `msg-${Date.now()}`;
+    const newMessage: Message = {
+      id: tempId,
+    };
     dispatch(
       addMessageToConversation({
         conversationId: selectedId,
@@ -107,7 +111,28 @@ export function useConversations(): UseConversationsReturn {
         isActive: true,
       })
     );
-  }, [selectedId, dispatch]);
+
+    // Send to backend API (which sends via WhatsApp)
+    try {
+      const res = await fetch(
+        `/api/whatsapp-conversations/conversations/${selectedId}/messages`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            content: content.trim(),
+            lead_id: leadId ? String(leadId) : undefined,
+          }),
+        }
+      );
+      const data = await res.json();
+      if (!data.success) {
+        console.error('Failed to send message via WhatsApp:', data.error);
+      }
+    } catch (err) {
+      console.error('Error sending message:', err);
+    }
+  }, [selectedId, conversationsFromRedux, dispatch]);
 
   const markAsResolved = useCallback((id: string | number) => {
     dispatch(


### PR DESCRIPTION
- useConversations.sendMessage now calls backend API to actually deliver messages via WhatsApp (was only updating Redux locally)
- MessageComposer shows confirmation dialog when switching from AI to Human Agent control ("Are you sure?")
- Agent toggle icon shows orange (human) / green (AI) to indicate current ownership
- Ownership status hint shown in composer footer
- Syncs agent type with conversation owner prop on switch