### PR TITLE
fix: hide LinkedIn tab when no LinkedIn account is connected for tenant

### DIFF
--- a/web/src/components/conversations/ConversationsPage.tsx
+++ b/web/src/components/conversations/ConversationsPage.tsx
@@ -325,16 +325,11 @@ function ChannelConversationView({ channel, onShowBroadcastModal }: { channel: '
 // ─────────────────────────────────────────────────────────────────────────────
 type WaTab = 'personal' | 'waba' | 'linkedin';
 
-const WA_TABS: { id: WaTab; label: string; sublabel: string }[] = [
-  { id: 'personal', label: 'Personal WA', sublabel: 'personal_whatsapp' },
-  { id: 'waba',     label: 'WA Business',  sublabel: 'business_whatsapp' },
-  { id: 'linkedin', label: 'LinkedIn',      sublabel: 'linkedin' },
-];
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Utility: Check which WhatsApp channels are connected
 // ─────────────────────────────────────────────────────────────────────────────
-async function getConnectedChannels(): Promise<{ personalConnected: boolean; wabaConnected: boolean }> {
+async function getConnectedChannels(): Promise<{ personalConnected: boolean; wabaConnected: boolean; linkedInConnected: boolean }> {
   try {
     // Check Personal WhatsApp connections
     const personalRes = await fetchWithTenant('/api/whatsapp-conversations/accounts');
@@ -346,10 +341,24 @@ async function getConnectedChannels(): Promise<{ personalConnected: boolean; wab
     const wabaRes = await fetchWithTenant('/api/whatsapp-conversations/conversations?channel=waba');
     const wabaConnected = wabaRes.ok;
 
-    return { personalConnected, wabaConnected };
+    // Check LinkedIn connection — the backend returns { success: true, data: [], message: 'No LinkedIn account connected...' }
+    // when no Unipile LinkedIn account is registered for this tenant.
+    let linkedInConnected = false;
+    try {
+      const liRes = await fetchWithTenant('/api/whatsapp-conversations/conversations?channel=linkedin');
+      if (liRes.ok) {
+        const liData = await liRes.json();
+        // Connected = endpoint didn't return the "no account" message
+        linkedInConnected = !liData?.message?.toLowerCase().includes('no linkedin account');
+      }
+    } catch {
+      linkedInConnected = false;
+    }
+
+    return { personalConnected, wabaConnected, linkedInConnected };
   } catch (err) {
     console.error('Error checking connected channels:', err);
-    return { personalConnected: false, wabaConnected: false };
+    return { personalConnected: false, wabaConnected: false, linkedInConnected: false };
   }
 }
 
@@ -374,6 +383,13 @@ function getDefaultTab(personalConnected: boolean, wabaConnected: boolean): WaTa
   return 'personal';
 }
 
+// All possible tabs — LinkedIn is only included when the tenant has an active LinkedIn account
+const ALL_TABS: { id: WaTab; label: string; sublabel: string }[] = [
+  { id: 'personal', label: 'Personal WA', sublabel: 'personal_whatsapp' },
+  { id: 'waba',     label: 'WA Business',  sublabel: 'business_whatsapp' },
+  { id: 'linkedin', label: 'LinkedIn',      sublabel: 'linkedin' },
+];
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Get brand color for tab
 // ─────────────────────────────────────────────────────────────────────────────
@@ -395,15 +411,20 @@ export function ConversationsPage() {
   const [activeTab, setActiveTab] = useState<WaTab>('personal');
   const [isPlaygroundOpen, setIsPlaygroundOpen] = useState(false);
   const [showBroadcastModal, setShowBroadcastModal] = useState(false);
+  const [linkedInConnected, setLinkedInConnected] = useState(false);
 
   // Load connection status on mount and set default tab
   useEffect(() => {
     (async () => {
-      const { personalConnected, wabaConnected } = await getConnectedChannels();
+      const { personalConnected, wabaConnected, linkedInConnected: liConnected } = await getConnectedChannels();
       const defaultTab = getDefaultTab(personalConnected, wabaConnected);
       setActiveTab(defaultTab);
+      setLinkedInConnected(liConnected);
     })();
   }, []);
+
+  // Only show LinkedIn tab when the tenant has an active LinkedIn account
+  const visibleTabs = ALL_TABS.filter(t => t.id !== 'linkedin' || linkedInConnected);
 
   return (
     <div className="h-full flex flex-col bg-background">
@@ -411,7 +432,7 @@ export function ConversationsPage() {
       <div className="h-10 flex items-center justify-between px-3 border-b border-border bg-card shrink-0">
         {/* Channel tabs */}
         <div className="flex items-center gap-1">
-          {WA_TABS.map(({ id, label, sublabel }) => (
+          {visibleTabs.map(({ id, label, sublabel }) => (
             <button
               key={id}
               onClick={() => setActiveTab(id)}


### PR DESCRIPTION
getConnectedChannels() now also probes the LinkedIn conversations endpoint. If the backend responds with 'No LinkedIn account connected', linkedInConnected stays false and the LinkedIn tab is excluded from visibleTabs, so tenants without an active Unipile LinkedIn account never see the tab.