### PR TITLE
Improve MessageTemplateSender error handling and partial success hand…

### DIFF
--- a/web/src/features/community-roi/components/MessageTemplateSender.tsx
+++ b/web/src/features/community-roi/components/MessageTemplateSender.tsx
@@ -120,11 +120,27 @@ const MessageTemplateSender: React.FC<MessageTemplateSenderProps> = ({
           recommendations,
         });
 
-        if (result.success) {
+        const innerData = (result as any)?.data ?? result;
+        const sentCount = innerData?.sentCount ?? 0;
+        const failedCount = innerData?.failedCount ?? 0;
+        const errMsg = (result as any)?.error
+          ?? innerData?.failedMembers?.[0]?.error
+          ?? null;
+
+        if (sentCount > 0 && failedCount === 0) {
           onSuccess(result);
           onClose();
+        } else if (sentCount > 0 && failedCount > 0) {
+          // Partial success — still close but inform
+          onSuccess(result);
+          onClose();
+          alert(`Sent ${sentCount} message(s). ${failedCount} failed.`);
         } else {
-          alert(`Error: ${result.error}`);
+          // All failed
+          alert(errMsg
+            ? `Send failed: ${errMsg}`
+            : `All ${failedCount || 'messages'} failed to send. Check WABA credentials and template approval in Meta.`
+          );
         }
       } else {
         // Schedule mode
@@ -140,16 +156,18 @@ const MessageTemplateSender: React.FC<MessageTemplateSenderProps> = ({
           templateIds: selectedTemplateIds,
         });
 
-        if (result.success) {
+        if ((result as any)?.success || (result as any)?.id) {
           onSuccess(result);
           onClose();
         } else {
-          alert(`Error: ${result.error}`);
+          const errMsg = (result as any)?.error ?? 'Failed to schedule messages';
+          alert(`Schedule failed: ${errMsg}`);
         }
       }
-    } catch (error) {
+    } catch (error: any) {
       console.error('Error sending messages:', error);
-      alert('Failed to send messages');
+      const msg = error?.response?.data?.error ?? error?.message ?? 'Unknown error';
+      alert(`Failed to send messages: ${msg}`);
     }
   };
 


### PR DESCRIPTION
…ling

- Extract actual error message from nested response structure
- Handle partial send success (some messages sent, some failed)
- Show sentCount/failedCount in alerts for transparency
- Better error messages for failed schedule operations
- Include WABA credential/template approval hints in error text