### PR TITLE
feat: implement ICP threshold filtering and custom message handling

### DIFF
--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -6463,7 +6463,7 @@ function CheckpointFormInline({
                 }
             }
             const t = targeting || { keywords: [], industries: [], locations: [], job_titles: [], profile_language: [] };
-            const icpMin = parseInt(cpIcpThreshold) || 0;
+            const icpMin = parseInt(icpThreshold) || 0;
             // Build lead feedback summary for campaign config
             const feedbackSummary = leads.reduce((acc, l) => {
                 const fb = leadFeedback[l.id];

--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -3965,7 +3965,7 @@ export default function AdvancedSearchAIPage() {
                             {/* LinkedIn search leads */}
                             {!inboundMode && (
                             <div className="adv-leads-list">
-                                {leads.filter(l => (l.icp_score ?? 0) >= (parseInt(cpIcpThreshold) || 0)).map((lead, i) => (
+                                {leads.map((lead, i) => (
                                     <div key={i} className={`adv-lead-card ${lead.locked ? 'adv-lead-locked' : ''}`}>
                                         {lead.profile_picture ? (
                                             <img src={lead.profile_picture} alt={lead.name} className="adv-lead-avatar-img" />

--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -3965,7 +3965,7 @@ export default function AdvancedSearchAIPage() {
                             {/* LinkedIn search leads */}
                             {!inboundMode && (
                             <div className="adv-leads-list">
-                                {leads.map((lead, i) => (
+                                {leads.filter(l => (l.icp_score ?? 0) >= (parseInt(cpIcpThreshold) || 0)).map((lead, i) => (
                                     <div key={i} className={`adv-lead-card ${lead.locked ? 'adv-lead-locked' : ''}`}>
                                         {lead.profile_picture ? (
                                             <img src={lead.profile_picture} alt={lead.name} className="adv-lead-avatar-img" />
@@ -6320,6 +6320,14 @@ function CheckpointFormInline({
         // Close whichever inline panel was open
         if (type === 'connect') setShowAiConnPanel(false);
         else setShowAiFollowPanel(false);
+
+        // Check if user already entered text - if so, don't generate
+        const existingMsg = type === 'connect' ? connMsg : followMsg;
+        if (existingMsg && existingMsg.trim()) {
+            // User has already entered a message, no need to generate
+            return;
+        }
+
         setLiFollowGenLoading(true);
         try {
             const sampleLead = leads && leads.length > 0 ? (leads[0] as any) : null;
@@ -6455,7 +6463,7 @@ function CheckpointFormInline({
                 }
             }
             const t = targeting || { keywords: [], industries: [], locations: [], job_titles: [], profile_language: [] };
-            const icpMin = parseInt(icpThreshold) || 0;
+            const icpMin = parseInt(cpIcpThreshold) || 0;
             // Build lead feedback summary for campaign config
             const feedbackSummary = leads.reduce((acc, l) => {
                 const fb = leadFeedback[l.id];
@@ -6526,8 +6534,10 @@ function CheckpointFormInline({
             // For LinkedIn search campaigns: include all leads except explicitly thumbs-down'd ones.
             // Previously required explicit thumbs-up (=== 'good') which meant zero leads if user
             // never clicked thumbs-up — leads were lost. Now we only exclude rejected leads.
+            // IMPORTANT: Filter by ICP threshold selected by user (only LinkedIn search leads, not direct/inbound)
             const goodMatchLeads = leads
                 .filter(l => leadFeedback[l.id] !== 'bad')
+                .filter(l => (l.icp_score ?? 0) >= icpMin)  // Apply ICP threshold filter
                 .map(l => mapLead(l, 'user_good_match'));
 
             const directContactLeads = isDirectContact


### PR DESCRIPTION
- Filter leads in campaign API by selected ICP threshold (85%, 75%, 50%, 25%, or all)
- Only send leads matching user-selected threshold to campaign backend
- Skip AI message generation if user has already entered custom text
- User can now manually enter LinkedIn activity messages without triggering auto-generation
- Pass user-provided messages directly to backend API

Changes:
1. Line 3968: Filter displayed leads by cpIcpThreshold
2. Lines 6323-6331: Check for existing user messages before calling generation API
3. Line 6466: Fix icpThreshold reference to cpIcpThreshold (bug fix)
4. Lines 6539-6540: Apply ICP threshold filter to goodMatchLeads sent to campaign API

This ensures that:
- When user selects "Above 85%", only high-match leads are included in campaign
- User can enter custom connection/follow-up messages without API interference
- Backend receives filtered leads with user's custom messages