### PR TITLE
fix: guard playground worker calls when URL not configured, add --no-…

### DIFF
--- a/web/cloudbuild-stage.yaml
+++ b/web/cloudbuild-stage.yaml
@@ -26,6 +26,7 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args: [
       'build',
+      '--no-cache',
       '-t', 'gcr.io/$PROJECT_ID/lad-frontend-stage:$COMMIT_SHA',
       '-t', 'gcr.io/$PROJECT_ID/lad-frontend-stage:$SHORT_SHA',
       '-t', 'gcr.io/$PROJECT_ID/lad-frontend-stage:$BRANCH_NAME',

--- a/web/src/hooks/voice-agent/useKnowledgeBase.ts
+++ b/web/src/hooks/voice-agent/useKnowledgeBase.ts
@@ -79,7 +79,7 @@ export function useKnowledgeBase(tenantId: string = "", userId: string = "") {
   }, []);
 
   const fetchStores = useCallback(async () => {
-    if (!tenantId) return;
+    if (!isWorkerConfigured || !tenantId) return;
     setLoadingStores(true);
     setError("");
     try {
@@ -100,6 +100,7 @@ export function useKnowledgeBase(tenantId: string = "", userId: string = "") {
 
   const createStore = async (displayName: string, description?: string) => {
     try {
+      if (!isWorkerConfigured) throw new Error("Voice playground is not available in this environment.");
       if (!tenantId) {
         throw new Error("You must select an active organization/tenant to create a knowledge base.");
       }
@@ -124,6 +125,7 @@ export function useKnowledgeBase(tenantId: string = "", userId: string = "") {
   };
 
   const deleteStore = async (storeName: string) => {
+    if (!isWorkerConfigured) throw new Error("Voice playground is not available in this environment.");
     if (!tenantId) throw new Error("Missing tenantId");
     try {
       const geminiId = storeName.replace("fileSearchStores/", "");
@@ -140,6 +142,7 @@ export function useKnowledgeBase(tenantId: string = "", userId: string = "") {
   };
 
   const updateStoreSettings = async (storeName: string, isDefault: boolean) => {
+    if (!isWorkerConfigured) throw new Error("Voice playground is not available in this environment.");
     if (!tenantId) throw new Error("Missing tenantId");
     try {
       const geminiId = storeName.replace("fileSearchStores/", "");
@@ -162,6 +165,7 @@ export function useKnowledgeBase(tenantId: string = "", userId: string = "") {
   };
 
   const uploadDocument = async (storeName: string, file: File, displayName?: string) => {
+    if (!isWorkerConfigured) throw new Error("Voice playground is not available in this environment.");
     if (!tenantId) throw new Error("Missing tenantId");
     try {
       const geminiId = storeName.replace("fileSearchStores/", "");
@@ -185,7 +189,7 @@ export function useKnowledgeBase(tenantId: string = "", userId: string = "") {
   };
 
   const fetchDocuments = async (storeName: string): Promise<PlaygroundDocument[]> => {
-    if (!tenantId) return [];
+    if (!isWorkerConfigured || !tenantId) return [];
     try {
       const geminiId = storeName.replace("fileSearchStores/", "");
       const res = await fetch(`${workerUrl}/playground-rag/stores/${geminiId}/documents?tenant_id=${tenantId}`);
@@ -198,6 +202,7 @@ export function useKnowledgeBase(tenantId: string = "", userId: string = "") {
   };
 
   const deleteDocument = async (storeName: string, documentId: string) => {
+    if (!isWorkerConfigured) throw new Error("Voice playground is not available in this environment.");
     if (!tenantId) throw new Error("Missing tenantId");
     try {
       const storeGeminiId = storeName.replace("fileSearchStores/", "");
@@ -215,6 +220,7 @@ export function useKnowledgeBase(tenantId: string = "", userId: string = "") {
   };
 
   const testChat = async (storeName: string, question: string) => {
+    if (!isWorkerConfigured) throw new Error("Voice playground is not available in this environment.");
     if (!tenantId) throw new Error("Missing tenantId");
     const storeGeminiId = storeName.replace("fileSearchStores/", "");
     const res = await fetch(`${workerUrl}/playground-rag/stores/${storeGeminiId}/chat`, {


### PR DESCRIPTION
…cache to stage build

- useKnowledgeBase: all 8 fetch functions now bail early when NEXT_PUBLIC_PLAYGROUND_WORKER_URL is not a real https:// URL, preventing 404s against the current origin (web.mrlads.com)
- cloudbuild-stage.yaml: add --no-cache to docker build so npm run build always runs fresh with the correct baked-in env vars