### PR TITLE
Fix conversation page crash + knowledge base worker guard

### DIFF
--- a/web/src/components/conversations/ConversationsPage.tsx
+++ b/web/src/components/conversations/ConversationsPage.tsx
@@ -593,6 +593,13 @@ export function ConversationsPage() {
     });
   }, []);
 
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 1024);
+    check();
+    window.addEventListener('resize', check);
+    return () => window.removeEventListener('resize', check);
+  }, []);
+
   // Show only tabs whose channel is actively connected.
   // While loading (null) render nothing so there's no flash of wrong tabs.
   const visibleTabs = channelStatus
@@ -654,8 +661,34 @@ export function ConversationsPage() {
 
       {/* Channel views — only the active tab is mounted */}
       <div className="flex-1 flex overflow-hidden">
-        {activeTab === 'personal'  && <ChannelConversationView channel="personal" onShowBroadcastModal={() => setShowBroadcastModal(true)} />}
-        {activeTab === 'waba'      && <ChannelConversationView channel="waba" onShowBroadcastModal={() => setShowBroadcastModal(true)} />}
+        {activeTab === 'personal' && (
+          <ChannelConversationView
+            channel="personal"
+            onShowBroadcastModal={() => setShowBroadcastModal(true)}
+            visibleTabs={visibleTabs}
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+            isPlaygroundOpen={isPlaygroundOpen}
+            setIsPlaygroundOpen={setIsPlaygroundOpen}
+            isSidebarCollapsed={isSidebarCollapsed}
+            setIsSidebarCollapsed={setIsSidebarCollapsed}
+            isMobile={isMobile}
+          />
+        )}
+        {activeTab === 'waba' && (
+          <ChannelConversationView
+            channel="waba"
+            onShowBroadcastModal={() => setShowBroadcastModal(true)}
+            visibleTabs={visibleTabs}
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+            isPlaygroundOpen={isPlaygroundOpen}
+            setIsPlaygroundOpen={setIsPlaygroundOpen}
+            isSidebarCollapsed={isSidebarCollapsed}
+            setIsSidebarCollapsed={setIsSidebarCollapsed}
+            isMobile={isMobile}
+          />
+        )}
         {activeTab === 'linkedin'  && <LinkedInConversationView />}
         {activeTab === 'gmail'     && <EmailChannelView provider="gmail"   connectedEmail={channelStatus?.gmailEmail   ?? undefined} />}
         {activeTab === 'outlook'   && <EmailChannelView provider="outlook" connectedEmail={channelStatus?.outlookEmail ?? undefined} />}

--- a/web/src/components/settings/KnowledgeBaseManager.tsx
+++ b/web/src/components/settings/KnowledgeBaseManager.tsx
@@ -195,6 +195,19 @@ export default function KnowledgeBaseManager({ tenantId, userId }: KnowledgeBase
   };
 
   const renderContent = () => {
+  // --- Worker not configured in this environment ---
+  if (!rag.isConfigured) {
+    return (
+      <div className="flex flex-col items-center justify-center w-full min-h-[300px] text-slate-400 border-2 border-dashed border-slate-200 rounded-2xl bg-slate-50/50 p-6">
+        <BookOpen className="size-10 mb-3 opacity-30" />
+        <p className="text-sm font-medium text-slate-500">Voice Playground not available</p>
+        <p className="text-xs mt-1 text-center max-w-[260px]">
+          Knowledge base management requires a configured playground worker URL.
+        </p>
+      </div>
+    );
+  }
+
   // --- Render Store List View ---
   if (!rag.isAwake && !rag.wakeError) {
     return (
@@ -592,7 +605,7 @@ export default function KnowledgeBaseManager({ tenantId, userId }: KnowledgeBase
             This content is injected into all AI conversations as context. Add company info, FAQs, product details, etc.
           </p>
         </div>
-        {!selectedStore && !showCreateStore && rag.isAwake && !rag.wakeError && (
+        {!selectedStore && !showCreateStore && rag.isConfigured && rag.isAwake && !rag.wakeError && (
           <Button
             variant="outline"
             size="sm"

--- a/web/src/hooks/voice-agent/useKnowledgeBase.ts
+++ b/web/src/hooks/voice-agent/useKnowledgeBase.ts
@@ -90,7 +90,7 @@ export function useKnowledgeBase(tenantId: string = "", userId: string = "") {
       });
       if (!res.ok) throw new Error("Failed to fetch stores");
       const data = await res.json();
-      setStores(data);
+      setStores(Array.isArray(data) ? data : (data?.stores ?? data?.items ?? []));
     } catch (err: any) {
       setError(err.message || "An error occurred fetching stores.");
     } finally {
@@ -245,6 +245,7 @@ export function useKnowledgeBase(tenantId: string = "", userId: string = "") {
     setError,
     isAwake,
     wakeError,
+    isConfigured: isWorkerConfigured,
     fetchStores,
     createStore,
     deleteStore,


### PR DESCRIPTION
- ConversationsPage: pass required props (visibleTabs, activeTab, isPlaygroundOpen, isSidebarCollapsed, isMobile) to ChannelConversationView — missing props caused visibleTabs.map() to throw TypeError and prevented the page from opening
- ConversationsPage: add resize effect to properly track isMobile state
- useKnowledgeBase: guard all API functions with isWorkerConfigured check to prevent relative-URL requests when NEXT_PUBLIC_PLAYGROUND_WORKER_URL is unset; add isConfigured to return value; fix setStores to always receive an array
- KnowledgeBaseManager: show "not configured" state instead of infinite spinner when worker URL is not set; guard "New Folder" button on isConfigured