### PR TITLE
Dark mode polish + Shareable Assets in WABA settings

### DIFF
--- a/web/src/components/settings/ChatSettings.tsx
+++ b/web/src/components/settings/ChatSettings.tsx
@@ -27,7 +27,15 @@ import {
   Sparkles,
 } from 'lucide-react';
 import KnowledgeBaseManager from './KnowledgeBaseManager';
-import { AIPlayground } from '../conversations/AIPlayground';
+import dynamic from 'next/dynamic';
+
+// AIPlayground is a heavy client-only component (framer-motion, refs, browser
+// APIs). Loading it dynamically with ssr:false keeps it out of the SSR bundle
+// and only fetches the chunk when the user clicks "Test in AI Playground".
+const AIPlayground = dynamic(
+  () => import('../conversations/AIPlayground').then((m) => m.AIPlayground),
+  { ssr: false },
+);
 
 // ── Types ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- **Dark mode improvements** — production-grade theme polish across the app (icon colours, contrast, button states)
- **Shareable Assets feature in WABA Chat Settings** — tenants can register files (price list, brochure, menu, etc.) with trigger keywords. When the AI's reply mentions a keyword the WABA pipeline downloads the file, uploads it to the WhatsApp Media API, and sends it as a real document attachment instead of a raw link
- **\"Test in AI Playground\" button** added to Chat Settings so admins can validate prompts + KB + asset matching without leaving the page
- **Build fix** — AIPlayground is now dynamically imported (`ssr: false`) so its framer-motion / browser-API deps stay out of the SSR bundle and don't break Cloud Build

## Notable UX details
- Saved assets render in a compact one-row card (icon, filename, triggers) and expand on click — matches the Knowledge Base pattern
- Newly-added assets are auto-expanded; saving collapses everything; validation errors auto-expand the offending row
- Trigger-keyword input is comma-separated; validates URL is `http(s)://` and at least one keyword is required
- Sticky violet "Test in AI Playground" button at the top-right of the Chat Settings page; opens a 480px slide-in panel with backdrop dismiss

## Backend wiring (lives in LAD-WABA-Comms — separate repo)
This PR is the frontend half. The backend exposes `GET/PUT /api/settings/shareable-assets` and the WABA pipeline auto-attaches matching files. UI talks to those endpoints via `/api/whatsapp-conversations/chat-settings/shareable-assets` proxy.

## Test plan
- [ ] Load Chat Settings page, dark mode visuals look correct
- [ ] Click "Add Asset", fill in URL + filename + trigger keywords, save → asset collapses to compact row
- [ ] Click compact row → expands editor; click again → collapses
- [ ] Click "Test in AI Playground" → side panel opens; type a message that should trigger an asset → playground shows the violet "would attach" pill
- [ ] Verify Cloud Build succeeds (was failing previously on synchronous AIPlayground import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)