### PR TITLE
fix: close Shareable Assets section JSX so Turbopack can parse the file

### DIFF
--- a/web/src/components/settings/ChatSettings.tsx
+++ b/web/src/components/settings/ChatSettings.tsx
@@ -1181,6 +1181,10 @@ export function ChatSettings() {
                 </button>
               </div>
             </>
+          )}
+        </div>
+      </div>
+
       {/* ── Section 2.5: Company Website Context ─────────────────── */}
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
         <div className="p-6 border-b border-gray-100">


### PR DESCRIPTION
The Shareable Assets block was missing the ternary close `)` `}` and the two wrapper `</div>` tags after `</>`. Turbopack failed at line 1184 because the next sibling section started inside an unclosed JSX expression.