### PR TITLE
fix(deploy): point develop WABA URL to asia-south1 service

### DIFF
--- a/cloudbuild-develop.yaml
+++ b/cloudbuild-develop.yaml
@@ -111,7 +111,12 @@ substitutions:
   _ENV: 'development'
   _API_URL: 'https://lad-backend-develop-160078175457.us-central1.run.app'
   _NEXT_PUBLIC_SOCKET_URL: 'https://lad-backend-develop-160078175457.us-central1.run.app'
-  _WABA_SERVICE_URL: 'https://lad-waba-comms-develop-160078175457.us-central1.run.app'
+  # NOTE: lad-waba-comms-develop runs in asia-south1 (not us-central1). The
+  # previous us-central1 URL pointed to a stale, abandoned revision (May 12)
+  # that lacks newer endpoints like /api/broadcasts/template-stats — the
+  # frontend's WhatsApp proxy was 404-ing because of it. The asia-south1
+  # service is the live develop deployment.
+  _WABA_SERVICE_URL: 'https://lad-waba-comms-develop-asia-160078175457.asia-south1.run.app'
   # Voice playground worker (Vapi/voice-agent dev environment)
   _PLAYGROUND_WORKER_URL: 'https://voag-dev-playground-worker-160078175457.asia-south1.run.app'
   _PLAYGROUND_TENANT_ID: '926070b5-189b-4682-9279-ea10ca090b84'


### PR DESCRIPTION
## Summary
- Updates `_WABA_SERVICE_URL` substitution in `cloudbuild-develop.yaml` to point at the live `lad-waba-comms-develop-asia` service in `asia-south1`, replacing the stale `lad-waba-comms-develop-160078175457.us-central1.run.app` URL.
- The us-central1 URL pointed to a revision deployed 2026-05-12 — 6 days before `api/broadcast_stats.py` was added to the WABA repo — so it has zero broadcast endpoints registered. The deployed frontend's WhatsApp proxy was 404-ing on `/api/whatsapp-conversations/broadcasts/template-stats` (Broadcast Performance widget on `/overview`) and likely other newer WABA endpoints.
- The asia-south1 service (deployed today, has 84+ endpoints including `/api/broadcasts/*`) is verified healthy via direct curl with a tenant header.

## Why
After merge, the next Cloud Build run will bake the correct URL into all six WABA-related env vars (`NEXT_PUBLIC_WHATSAPP_API_URL`, `NEXT_PUBLIC_BNI_SERVICE_URL`, `NEXT_PUBLIC_COMMS_SERVICE_URL`, `BNI_SERVICE_URL`, `WABA_SERVICE_URL`, `WHATSAPP_SERVICE_URL`) on `lad-frontend-develop`.

## Test plan
- [ ] Merge PR → Cloud Build trigger fires on `develop`
- [ ] New `lad-frontend-develop` revision rolls out (~5-7 min)
- [ ] Verify `gcloud run services describe lad-frontend-develop --project lad-develop --region us-central1 --format="value(spec.template.spec.containers[0].env)" | tr ';' '\n' | grep WABA` shows the asia-south1 URL
- [ ] Refresh deployed develop `/overview` page — Broadcast Performance widget should populate (no 404 in browser network tab)
- [ ] WhatsApp Conversations page should still load broadcasts/templates normally (sanity check that no existing WABA flow regresses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)