### PR TITLE
fix(deploy): point stage WABA URL to asia-south1 service

### DIFF
--- a/cloudbuild-stage.yaml
+++ b/cloudbuild-stage.yaml
@@ -119,7 +119,12 @@ substitutions:
   _API_URL: 'https://lad-backend-stage-344049867257.us-central1.run.app'
   _NEXT_PUBLIC_SOCKET_URL: 'https://lad-backend-stage-344049867257.us-central1.run.app'
   _CONVERSATION_SERVICE_URL: 'https://bni-conversation-service-stage-344049867257.us-central1.run.app'
-  _WABA_SERVICE_URL: 'https://lad-waba-comms-stage-344049867257.us-central1.run.app'
+  # NOTE: lad-waba-comms-stage runs in asia-south1 (not us-central1). The
+  # us-central1 service (lad-waba-comms-stage) is stale — last revision was
+  # deployed 2026-05-12 and lacks newer endpoints like /api/broadcasts/*,
+  # which causes 404s in the deployed frontend's WhatsApp proxy. The
+  # asia-south1 service (lad-waba-comms-stage-asia) is the live deployment.
+  _WABA_SERVICE_URL: 'https://lad-waba-comms-stage-asia-344049867257.asia-south1.run.app'
   # Voice playground worker (Vapi/voice-agent — currently using dev environment)
   _PLAYGROUND_WORKER_URL: 'https://voag-dev-playground-worker-160078175457.asia-south1.run.app'
   _PLAYGROUND_TENANT_ID: '926070b5-189b-4682-9279-ea10ca090b84'


### PR DESCRIPTION
## Summary
- Updates `_WABA_SERVICE_URL` in `cloudbuild-stage.yaml` from the stale `lad-waba-comms-stage-344049867257.us-central1.run.app` (revision deployed 2026-05-12, missing newer endpoints) to `lad-waba-comms-stage-asia-344049867257.asia-south1.run.app` (the live stage WABA service, deployed today).
- Identical fix pattern to PR #431 which fixed the same issue on develop. Both environments had been running stale us-central1 WABA services since 2026-05-12 while their actual live deployments were silently migrated to asia-south1.

## Symptoms before fix
- Deployed `lad-frontend-stage` returns 404 from `/api/whatsapp-conversations/broadcasts/template-stats` (and every other endpoint added to the Python WABA service after May 12).
- The Broadcast Performance widget on `/overview` cannot load data on the staged develop env.

## Why it works after fix
After merge, Cloud Build bakes the asia-south1 URL into all six WABA-related env vars on `lad-frontend-stage`:
- `NEXT_PUBLIC_WHATSAPP_API_URL`
- `NEXT_PUBLIC_COMMS_SERVICE_URL`
- `BNI_SERVICE_URL` (note: stage uses `_CONVERSATION_SERVICE_URL` for this one — separate)
- `WABA_SERVICE_URL`
- `WHATSAPP_SERVICE_URL`

## Test plan
- [ ] Merge PR → Cloud Build trigger fires on `stage`
- [ ] New `lad-frontend-stage` revision rolls out (~5-7 min)
- [ ] Verify env vars: `gcloud run services describe lad-frontend-stage --project lad-stage-484806 --region us-central1 --format="value(spec.template.spec.containers[0].env)" | tr ';' '\n' | grep WABA` shows `…-asia-344049867257.asia-south1.run.app`
- [ ] Refresh deployed stage `/overview` — Broadcast Performance widget should populate
- [ ] Existing WhatsApp Conversations page should still load normally (regression check)

## Follow-up worth doing separately
The us-central1 services `lad-waba-comms-stage` (and likewise `lad-waba-comms-develop`) appear to be abandoned — never updated since May 12. Suggest auditing whether they should be deleted to prevent future confusion, plus checking `cloudbuild.yaml` (production) for the same stale-URL pattern before it bites prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)