### PR TITLE
fix(community-roi): proxy falls back to main backend URL

### DIFF
--- a/web/src/app/api/community-roi/[...slug]/route.ts
+++ b/web/src/app/api/community-roi/[...slug]/route.ts
@@ -8,14 +8,25 @@ import { logger } from '@/lib/logger';
  */
 
 const getCommunityROIBackend = () => {
-  // Try environment variable first
+  // Explicit override — used when community-roi runs on its own service.
   const envUrl = process.env.NEXT_PUBLIC_COMMUNITY_API_URL;
   if (envUrl) {
     return envUrl;
   }
 
-  // Fallback to alternate Cloud Run service
-  return '';
+  // Fallback: community-roi is served by the main LAD backend in every
+  // environment today (see LAD_backend/features/community-roi/routes/).
+  // Mirror the URL resolution used by python-proxy.ts so the proxy still
+  // works even when the explicit override isn't configured — which is
+  // exactly what was breaking the broadcast wizard's "Map Parameters"
+  // preview in deployed develop / stage. Returning '' here produced a
+  // relative URL that server-side fetch (undici) can't parse, and the
+  // client-side `.catch(() => {})` silently swallowed the failure.
+  return (
+    process.env.BACKEND_INTERNAL_URL ||
+    process.env.NEXT_PUBLIC_BACKEND_URL ||
+    'http://localhost:3004'
+  );
 };
 
 interface RouteParams {


### PR DESCRIPTION
## Summary
The broadcast wizard's **Map Parameters** preview was rendering empty placeholders (\`[—]\`) for \`{{2}}\` – \`{{7}}\` in deployed develop / stage, while working fine on localhost. Root cause was a misconfigured proxy that returned an empty base URL whenever \`NEXT_PUBLIC_COMMUNITY_API_URL\` wasn't set — which it wasn't in either \`cloudbuild-develop.yaml\` or \`cloudbuild-stage.yaml\`.

## Bug chain
1. \`web/src/app/api/community-roi/[...slug]/route.ts\` reads \`NEXT_PUBLIC_COMMUNITY_API_URL\`.
2. Develop/stage builds had it unset → \`getCommunityROIBackend()\` returned \`''\`.
3. \`fullUrl = '' + '/api/community-roi/recommendations/member-data'\` → a relative URL.
4. Server-side \`fetch()\` (Node/undici) throws \`Failed to parse URL\` on relative paths.
5. Proxy returned 500; the client \`.catch(() => {})\` silently swallowed it (literal code comment: \"silent — recs just won't be available in preview\").
6. \`memberRecData\` stayed \`{}\`, so the preview's recommendation variables (\`{{2}}\` – \`{{7}}\`) couldn't be resolved.
7. \`{{1}}\` (the member's own name) worked because it comes from the broadcast recipient list — a different code path.

## Fix
Community-roi is served by the main LAD backend in every environment today (see \`LAD_backend/features/community-roi/routes/\`), so the proxy now falls back to \`BACKEND_INTERNAL_URL\` / \`NEXT_PUBLIC_BACKEND_URL\` — already configured in every env — before giving up.

The explicit \`NEXT_PUBLIC_COMMUNITY_API_URL\` override is still honoured for the future case of splitting community-roi onto its own Cloud Run service. Pattern mirrors \`python-proxy.ts\`.

## Why this is the right fix (vs. just adding the env var)
- **Self-healing**: works in every env without a config flag, so future env additions (preview deploys, new tenants) don't repeat this trap.
- **Less moving parts**: no new substitution to maintain in three cloudbuild files.
- **Matches existing convention**: \`python-proxy.ts\` uses the same fallback chain.

## Test plan
- [ ] Merge → Cloud Build trigger fires on \`develop\`, new \`lad-frontend-develop\` revision rolls out (~5-7 min).
- [ ] Open \`/community-roi\` → click into the broadcast wizard → select \"Member Friday Followup\" template → reach \"Map Parameters\" step.
- [ ] Confirm \`{{2}}\` – \`{{7}}\` resolve to real member names (e.g. \"Akshay Rane, Esther Ikpeka, Deepika Vachhani\" for Afshad Mistry), not \`[—]\`.
- [ ] Browser network tab: \`GET /api/community-roi/recommendations/member-data\` returns 200 with \`{ success: true, data: {…} }\`.
- [ ] Same on stage after the equivalent merge there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)