### PR TITLE
fix(community-roi): proxy falls back to main backend URL

### DIFF
--- a/web/src/app/api/community-roi/[...slug]/route.ts
+++ b/web/src/app/api/community-roi/[...slug]/route.ts
@@ -8,14 +8,25 @@ import { logger } from '@/lib/logger';
  */
 
 const getCommunityROIBackend = () => {
-  // Try environment variable first
+  // Explicit override — used when community-roi runs on its own service.
   const envUrl = process.env.NEXT_PUBLIC_COMMUNITY_API_URL;
   if (envUrl) {
     return envUrl;
   }
 
-  // Fallback to alternate Cloud Run service
-  return '';
+  // Fallback: community-roi is served by the main LAD backend in every
+  // environment today (see LAD_backend/features/community-roi/routes/).
+  // Mirror the URL resolution used by python-proxy.ts so the proxy still
+  // works even when the explicit override isn't configured — which is
+  // exactly what was breaking the broadcast wizard's "Map Parameters"
+  // preview in deployed develop / stage. Returning '' here produced a
+  // relative URL that server-side fetch (undici) can't parse, and the
+  // client-side `.catch(() => {})` silently swallowed the failure.
+  return (
+    process.env.BACKEND_INTERNAL_URL ||
+    process.env.NEXT_PUBLIC_BACKEND_URL ||
+    'http://localhost:3004'
+  );
 };
 
 interface RouteParams {


### PR DESCRIPTION
## Summary
Same fix as develop PR #449 — backports to \`stage\` because the same env-var omission affects \`cloudbuild-stage.yaml\` and the deployed \`lad-frontend-stage\`.

## Symptom
Broadcast wizard's **Map Parameters** preview renders empty \`[—]\` for variables \`{{2}}\` – \`{{7}}\` (only \`{{1}}\`, the member's own name, resolves) because the community-roi proxy can't reach the backend without an explicit URL env var.

## Fix
\`getCommunityROIBackend()\` falls back to \`BACKEND_INTERNAL_URL\` / \`NEXT_PUBLIC_BACKEND_URL\` (already set in every env). See PR #449 for full root cause analysis.

## Test plan
- [ ] Merge → Cloud Build trigger fires on \`stage\`, new \`lad-frontend-stage\` revision rolls out
- [ ] \`/community-roi\` broadcast wizard → \"Map Parameters\" → \`{{2}}\` – \`{{7}}\` resolve to real names
- [ ] Network tab: \`GET /api/community-roi/recommendations/member-data\` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)