### PR TITLE
Fix Mobile sidebar is too wide and occupies excessive screen space — …

### DIFF
--- a/web/src/components/sidebar.tsx
+++ b/web/src/components/sidebar.tsx
@@ -321,7 +321,7 @@ export function Sidebar() {
       {/* Mobile Drawer */}
       <div
         className={cn(
-          "md:hidden fixed inset-y-0 left-0 w-[70%] bg-sidebar/95 backdrop-blur-2xl border-r border-sidebar-border shadow-2xl z-[70] flex flex-col",
+          "md:hidden fixed inset-y-0 left-0 w-[50%] bg-sidebar/95 backdrop-blur-2xl border-r border-sidebar-border shadow-2xl z-[70] flex flex-col",
           "transition-transform duration-300 ease-out",
           isMobileMenuOpen ? "translate-x-0" : "-translate-x-full",
         )}
@@ -464,7 +464,7 @@ export function Sidebar() {
             </div>
           </div>
 
-          <div className="flex items-center gap-3 px-3 py-2 border-t border-sidebar-border/30">
+          <div className="flex items-center gap-3 px-2 py-2 border-t border-sidebar-border/30">
             {isHydrated && user?.avatar ? (
               <img
                 src={user.avatar}


### PR DESCRIPTION
…it should be reduced to a smaller width for better usability and content visibility