### PR TITLE
feat(personal-whatsapp): route channel=personal traffic to LAD-WAPA-Comms

### DIFF
--- a/web/src/app/api/[feature]/[...path]/route.ts
+++ b/web/src/app/api/[feature]/[...path]/route.ts
@@ -24,6 +24,35 @@
  */
 import { NextRequest, NextResponse } from 'next/server';
 import { getBackendUrl } from '../../utils/backend';
+import { getWAPAServiceUrl } from '../../whatsapp-conversations/utils/python-proxy';
+
+/**
+ * Per-feature backend resolver (Phase 5+ — Personal WhatsApp lives in
+ * LAD-WAPA-Comms now, NOT LAD_backend).
+ *   personal-whatsapp                          → LAD-WAPA-Comms
+ *   whatsapp-conversations  + channel=personal → LAD-WAPA-Comms
+ *   whatsapp-conversations  + other channels   → LAD_backend (legacy fallthrough)
+ *   everything else                            → LAD_backend
+ *
+ * The whatsapp-conversations case exists because some frontend calls hit
+ * `/api/whatsapp-conversations/<sub>/<path>` (e.g. /conversations/bulk/send-template)
+ * that have NO dedicated route.ts file — they fall through to this catch-all.
+ * For channel=personal those need to go to WAPA, not LAD_backend (whose explicit
+ * mount is now disabled by PERSONAL_WHATSAPP_LOCAL=false).
+ *
+ * Add more entries here when other features get extracted into their own
+ * Cloud Run services.
+ */
+function getServiceUrlForFeature(feature: string, req: NextRequest): string {
+  if (feature === 'personal-whatsapp') return getWAPAServiceUrl();
+  if (feature === 'whatsapp-conversations') {
+    const channel =
+      req.nextUrl.searchParams.get('channel') ||
+      req.headers.get('x-whatsapp-channel');
+    if (channel === 'personal') return getWAPAServiceUrl();
+  }
+  return getBackendUrl();
+}
 function isMultipart(contentType: string | null | undefined): boolean {
   return Boolean(contentType && contentType.toLowerCase().includes('multipart/form-data'));
 }
@@ -37,7 +66,7 @@ async function handler(
   const resolvedParams = await params;
   const { feature, path } = resolvedParams;
   try {
-    const backend = getBackendUrl();
+    const backend = getServiceUrlForFeature(feature, req);
     // Build backend URL
     const pathSegments = path || [];
     const fullPath = pathSegments.join('/');

--- a/web/src/app/api/whatsapp-conversations/utils/python-proxy.ts
+++ b/web/src/app/api/whatsapp-conversations/utils/python-proxy.ts
@@ -1,8 +1,10 @@
 /**
  * Proxy utility for forwarding Next.js API requests to the appropriate backend:
- *   - channel=personal  → LAD_backend (Node.js) for personal WhatsApp (Baileys)
+ *   - channel=personal  → LAD-WAPA-Comms (Node.js, Baileys; was LAD_backend pre-Phase 5)
  *   - channel=waba      → LAD-WABA-Comms (Python FastAPI) for WhatsApp Business API
  *   - channel=linkedin  → LAD_backend (Node.js) for LinkedIn via Unipile
+ *   - channel=backend   → LAD_backend OR LAD-WAPA-Comms (path-aware: any path
+ *                         starting with /api/personal-whatsapp/ goes to WAPA)
  *
  * The channel is determined by the `channel` query param or `X-WhatsApp-Channel` header.
  */
@@ -10,12 +12,22 @@ import { NextRequest, NextResponse } from 'next/server';
 
 // ── Service URL resolvers ───────────────────────────────────────────
 
-/** LAD_backend (Node.js) – personal WhatsApp via Baileys */
+/** LAD_backend (Node.js) – everything except personal WhatsApp post-Phase 5 */
 export function getBackendUrl(): string {
   return (
     process.env.BACKEND_INTERNAL_URL ||
     process.env.NEXT_PUBLIC_BACKEND_URL ||
     'http://localhost:3004'
+  );
+}
+
+/** LAD-WAPA-Comms (Node.js) – personal WhatsApp via Baileys (Phase 5+) */
+export function getWAPAServiceUrl(): string {
+  return (
+    process.env.NEXT_PUBLIC_WAPA_SERVICE_URL ||
+    process.env.WAPA_SERVICE_URL ||
+    process.env.WAPA_SERVICE_INTERNAL_URL ||
+    'http://localhost:18080'
   );
 }
 
@@ -69,9 +81,9 @@ export async function proxyToPythonService(
   let resolvedPath: string;
 
   if (channel === 'personal') {
-    // Personal WhatsApp → LAD_backend
+    // Personal WhatsApp → LAD-WAPA-Comms (was LAD_backend pre-Phase 5)
     // Transform: /api/conversations → /api/whatsapp-conversations/conversations
-    resolvedBaseUrl = getBackendUrl();
+    resolvedBaseUrl = getWAPAServiceUrl();
     resolvedPath = '/api/whatsapp-conversations' + path.replace(/^\/api/, '');
   } else if (channel === 'waba') {
     // WhatsApp Business API → LAD-WABA-Comms
@@ -83,9 +95,12 @@ export async function proxyToPythonService(
     resolvedBaseUrl = getBackendUrl();
     resolvedPath = '/api/linkedin-conversations' + path.replace(/^\/api/, '');
   } else if (channel === 'backend') {
-    // Direct Node.js backend route — no path transformation
-    // Use when the full API path is already specified (e.g. /api/personal-whatsapp/prompts)
-    resolvedBaseUrl = getBackendUrl();
+    // Direct route — no path transformation. Path-aware destination:
+    //   /api/personal-whatsapp/*  → LAD-WAPA-Comms  (Phase 5+)
+    //   anything else             → LAD_backend     (LinkedIn, billing, etc.)
+    resolvedBaseUrl = path.startsWith('/api/personal-whatsapp/')
+      ? getWAPAServiceUrl()
+      : getBackendUrl();
     resolvedPath = path;
   } else {
     // Fallback: use the passed-in baseUrl (backwards compat)
@@ -122,6 +137,20 @@ export async function proxyToPythonService(
     const tenantId = extractTenantIdFromJwt(token);
     if (tenantId) {
       headers['X-Tenant-ID'] = tenantId;
+    }
+  } else {
+    // Phase 5: WAPA (Node.js) actually verifies the JWT, unlike the Python WABA
+    // service which trusts X-Tenant-ID. If the browser only sent a cookie, lift
+    // it into the Authorization header so WAPA's JWT middleware accepts it.
+    const cookieToken =
+      req.cookies.get('access_token')?.value ||
+      req.cookies.get('token')?.value;
+    if (cookieToken) {
+      headers['Authorization'] = `Bearer ${cookieToken}`;
+      const tenantId = extractTenantIdFromJwt(cookieToken);
+      if (tenantId) {
+        headers['X-Tenant-ID'] = tenantId;
+      }
     }
   }
 

--- a/web/src/components/conversations/TemplatePicker.tsx
+++ b/web/src/components/conversations/TemplatePicker.tsx
@@ -249,8 +249,15 @@ export function TemplatePicker({
     // WABA handles rate-limiting server-side — pass zeroes so the backend sends
     // without artificial throttling. Personal WA uses the user-configured schedule
     // to avoid account restrictions from rapid bulk sends.
+    // Guard against NaN values (a cleared number input puts NaN into state).
+    // Fall back to the same defaults the useState hooks use above.
     const scheduleParams = channel === 'personal'
-      ? { batchSize, delayMin, delayRandom, dailyLimit }
+      ? {
+          batchSize:   Number.isFinite(batchSize)   ? batchSize   : 5,
+          delayMin:    Number.isFinite(delayMin)    ? delayMin    : 120,
+          delayRandom: Number.isFinite(delayRandom) ? delayRandom : 30,
+          dailyLimit:  Number.isFinite(dailyLimit)  ? dailyLimit  : 250,
+        }
       : { batchSize: 0, delayMin: 0, delayRandom: 0, dailyLimit: 0 };
     onSend(
       selectedTemplate.name,
@@ -554,8 +561,12 @@ export function TemplatePicker({
                           <label className="text-[10px] font-bold text-amber-700 uppercase tracking-wider">Batch Size</label>
                           <Input
                             type="number"
-                            value={batchSize}
-                            onChange={e => setBatchSize(parseInt(e.target.value))}
+                            value={Number.isFinite(batchSize) ? batchSize : ''}
+                            onChange={e => {
+                              const raw = e.target.value;
+                              const n = parseInt(raw, 10);
+                              setBatchSize(raw === '' || Number.isNaN(n) ? NaN : n);
+                            }}
                             className="h-10 rounded-lg border-amber-200 bg-white"
                           />
                         </div>
@@ -563,8 +574,12 @@ export function TemplatePicker({
                           <label className="text-[10px] font-bold text-amber-700 uppercase tracking-wider">Delay (s)</label>
                           <Input
                             type="number"
-                            value={delayMin}
-                            onChange={e => setDelayMin(parseInt(e.target.value))}
+                            value={Number.isFinite(delayMin) ? delayMin : ''}
+                            onChange={e => {
+                              const raw = e.target.value;
+                              const n = parseInt(raw, 10);
+                              setDelayMin(raw === '' || Number.isNaN(n) ? NaN : n);
+                            }}
                             className="h-10 rounded-lg border-amber-200 bg-white"
                           />
                         </div>
@@ -572,8 +587,12 @@ export function TemplatePicker({
                           <label className="text-[10px] font-bold text-amber-700 uppercase tracking-wider">Daily Cap</label>
                           <Input
                             type="number"
-                            value={dailyLimit}
-                            onChange={e => setDailyLimit(parseInt(e.target.value))}
+                            value={Number.isFinite(dailyLimit) ? dailyLimit : ''}
+                            onChange={e => {
+                              const raw = e.target.value;
+                              const n = parseInt(raw, 10);
+                              setDailyLimit(raw === '' || Number.isNaN(n) ? NaN : n);
+                            }}
                             className="h-10 rounded-lg border-amber-200 bg-white"
                           />
                         </div>


### PR DESCRIPTION
## Summary
- Route `channel=personal` (in `python-proxy.ts`) and the `/api/personal-whatsapp/*` catch-all (in `[feature]/[...path]/route.ts`) to **LAD-WAPA-Comms** instead of LAD_backend. Phase 5 of the personal-WhatsApp extraction.
- Lift cookie JWT into `Authorization: Bearer` for the upstream because WAPA actually validates JWTs (the Python WABA service didn't).
- Fix a React `value=NaN` warning in `TemplatePicker.tsx` and harden the bulk-send payload against cleared number inputs.

## Test plan
- [ ] LAD-WAPA-Comms deployed (or running on `localhost:18080`)
- [ ] `NEXT_PUBLIC_WAPA_SERVICE_URL` + `WAPA_SERVICE_URL` set in the deploy env
- [ ] Hit `/api/whatsapp-conversations/conversations?channel=personal` — response header `X-WAPA-Service: lad-wapa-comms`
- [ ] Hit `/api/personal-whatsapp/contacts` — same header, real data returned
- [ ] Open the bulk template send dialog — clear the Batch Size input, see no React warning, submit and see the default (5) used
- [ ] Verify channel=waba still routes to LAD-WABA-Comms unchanged
- [ ] Verify channel=linkedin still routes to LAD_backend unchanged

## Related
- WAPA service: techiemaya-admin/LAD-WAPA-Comms#develop (commit `157a5f6`)
- LAD_backend gating + cron: techiemaya-admin/LAD-Backend#develop (commit `698c2ef0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)