### PR TITLE
fix(build): raise Node heap to 6 GB for Next.js production build (Clo…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,13 @@ RUN if [ -d "prisma" ]; then npx --yes prisma@6 generate; fi
 RUN node -e "console.log('RQ:', require.resolve('@tanstack/react-query'))" \
  && node -e "console.log('QC:', require.resolve('@tanstack/query-core'))"
 
+# Next.js 15 production builds of this app exceed Node's default ~2 GB V8 heap
+# and OOM ("Reached heap limit Allocation failed"). The Cloud Build machine
+# (E2_HIGHCPU_8) has 8 GB RAM, so lift the old-space cap to 6 GB for the build.
+# Scoped to the builder stage — the runner stage starts FROM base, so this does
+# not affect the runtime server process.
+ENV NODE_OPTIONS="--max-old-space-size=6144"
+
 RUN npm run build
 
 # Verify standalone output was generated (fails build if next.config.mjs output:standalone didn't work)


### PR DESCRIPTION
…ud Build OOM)

`next build --webpack` was hitting V8's default ~2 GB heap cap and dying with "FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory" in Cloud Build. The build machine (E2_HIGHCPU_8) has 8 GB RAM, so the fix is to let Node use it: NODE_OPTIONS=--max-old-space-size=6144 in the Dockerfile builder stage (scoped to builder; the runner stage is unaffected).

The frontend grew substantially this cycle (CRM, prospects, ai-icp-assistant, lad-monitor, onboarding wizard), which pushed the production build past the 2 GB default.