### PR TITLE
fix(proxy): route personal-whatsapp/prompts to WAPA, not the legacy backend

### DIFF
--- a/web/src/app/api/whatsapp-conversations/prompts/route.ts
+++ b/web/src/app/api/whatsapp-conversations/prompts/route.ts
@@ -1,13 +1,22 @@
 /**
- * Prompts Proxy — Personal WhatsApp (Node.js backend)
- * GET  /api/whatsapp-conversations/prompts → Node.js /api/personal-whatsapp/prompts
- * POST /api/whatsapp-conversations/prompts → Node.js /api/personal-whatsapp/prompts
+ * Prompts Proxy — the System Prompts store (channel-agnostic).
  *
- * Uses channel=backend so the proxy routes directly to Node.js LAD_backend
- * without path transformation (unlike channel=personal which prepends /api/whatsapp-conversations).
+ * The System Prompts UI saves prompts for EVERY channel (WABA / LinkedIn /
+ * Gmail / Instagram / personal-whatsapp) through this one endpoint — the
+ * target channel is a field in the request body, not the URL.
+ *
+ * GET/POST /api/whatsapp-conversations/prompts → /api/personal-whatsapp/prompts,
+ * which since the Phase-5 split is owned by LAD-WAPA-Comms (NOT LAD_backend —
+ * the backend's copy is the legacy, pre-split feature). WAPA writes to the
+ * per-tenant `<TENANT_DB_SCHEMA>.prompts` table that every channel service
+ * (WABA/LinkedIn/Instagram) reads its active prompt back from.
+ *
+ * Uses channel=backend (no path transformation); the proxy's path rule sends
+ * /api/personal-whatsapp/* → WAPA. Requires WAPA_SERVICE_URL on the frontend
+ * service (else getWAPAServiceUrl() falls back to localhost → ECONNREFUSED → 502).
  */
 import { NextRequest } from 'next/server';
-import { proxyToPythonService, getBackendUrl } from '../utils/python-proxy';
+import { proxyToPythonService, getWAPAServiceUrl } from '../utils/python-proxy';
 
 function withBackendChannel(req: NextRequest): NextRequest {
   const url = new URL(req.url);
@@ -16,9 +25,9 @@ function withBackendChannel(req: NextRequest): NextRequest {
 }
 
 export async function GET(req: NextRequest) {
-  return proxyToPythonService(withBackendChannel(req), getBackendUrl(), '/api/personal-whatsapp/prompts');
+  return proxyToPythonService(withBackendChannel(req), getWAPAServiceUrl(), '/api/personal-whatsapp/prompts');
 }
 
 export async function POST(req: NextRequest) {
-  return proxyToPythonService(withBackendChannel(req), getBackendUrl(), '/api/personal-whatsapp/prompts');
+  return proxyToPythonService(withBackendChannel(req), getWAPAServiceUrl(), '/api/personal-whatsapp/prompts');
 }

--- a/web/src/app/api/whatsapp-conversations/utils/python-proxy.ts
+++ b/web/src/app/api/whatsapp-conversations/utils/python-proxy.ts
@@ -98,15 +98,9 @@ export async function proxyToPythonService(
     // Direct route — no path transformation. Path-aware destination:
     //   /api/personal-whatsapp/*  → LAD-WAPA-Comms  (Phase 5+)
     //   anything else             → LAD_backend     (LinkedIn, billing, etc.)
-    // EXCEPTION: the System Prompts store (/api/personal-whatsapp/prompts*) is
-    // channel-agnostic config — the UI saves WABA / LinkedIn / Gmail / Instagram
-    // prompts through this same endpoint (channel is in the body) — and it lives
-    // in LAD_backend, so it must NOT follow the personal-whatsapp → WAPA rule.
-    const isPromptsStore = path.startsWith('/api/personal-whatsapp/prompts');
-    resolvedBaseUrl =
-      path.startsWith('/api/personal-whatsapp/') && !isPromptsStore
-        ? getWAPAServiceUrl()
-        : getBackendUrl();
+    resolvedBaseUrl = path.startsWith('/api/personal-whatsapp/')
+      ? getWAPAServiceUrl()
+      : getBackendUrl();
     resolvedPath = path;
   } else {
     // Fallback: use the passed-in baseUrl (backwards compat)


### PR DESCRIPTION
Follow-up to #514. Drops the prompts **carve-out** so `/api/personal-whatsapp/prompts` goes to **LAD-WAPA-Comms** like every other personal-whatsapp endpoint.

## Why the carve-out was the wrong layer
The WABA prompt-save 502 was caused by **`WAPA_SERVICE_URL` being unset** on the frontend (→ `localhost:18080` → ECONNREFUSED) — **not** by routing. #514 already wired that URL. So the carve-out (prompts → backend) only worked *incidentally* — it dodged the missing-URL by hitting the backend's still-mounted legacy copy.

## Why WAPA is correct
Personal WhatsApp — **including the prompts store** — moved to WAPA in the Phase-5 split (`server.js`: *"the move from LAD_backend's dual mount is fully covered"*, listing prompts/chat-settings/accounts/contacts). Verified end-to-end:

| Check | Result |
|---|---|
| Owner of `/api/personal-whatsapp/prompts` | LAD-WAPA-Comms |
| Reachable by frontend `fetch` | ✅ public (`allUsers`) |
| Auths the user JWT | ✅ same `jwt-secret` as backend |
| Writes where WABA reads | ✅ both `lad_conv_dev.prompts` (`TENANT_DB_SCHEMA=lad_conv_dev`) |

So WAPA's `createPrompt` lands in the exact per-tenant table `prompts_repo.get_active_prompt_by_channel` reads — for WABA **and** LinkedIn/Instagram.

## Changes
- `python-proxy.ts`: revert the carve-out → `/api/personal-whatsapp/*` (prompts included) → WAPA.
- `prompts/route.ts`: fix the stale header that claimed "LAD_backend" (the exact comment that misled the original diagnosis); pass `getWAPAServiceUrl()`.

## Note
Current develop **already works** (prompts → backend via the carve-out). This is a **consistency / correctness** cleanup, not an outage fix — safe to merge once the #514 redeploy (which sets `WAPA_SERVICE_URL`) has landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)