### PR TITLE
feat(settings): AI Replies toggle on LinkedIn connected accounts

### DIFF
--- a/web/src/components/settings/LinkedInIntegration.tsx
+++ b/web/src/components/settings/LinkedInIntegration.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useState, useEffect } from 'react';
-import { CheckCircle2, AlertCircle, Loader2, ExternalLink, ChevronDown, ChevronUp, Eye, EyeOff, X } from 'lucide-react';
+import { CheckCircle2, AlertCircle, Loader2, ExternalLink, ChevronDown, ChevronUp, Eye, EyeOff, X, Power } from 'lucide-react';
 import { Dialog, DialogTitle, DialogContent, DialogActions, DialogHeader } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { getApiBaseUrl } from '@/lib/api-utils';
@@ -47,6 +47,15 @@ interface LinkedInStatusResponse {
   connections: LinkedInAccount[];
   totalConnections: number;
 }
+// Tenant-level LinkedIn automation config (one per tenant, derived from the
+// active social_linkedin_accounts metadata). Returned by
+// GET /api/social-integration/linkedin/automation-settings wrapped in { data }.
+interface LinkedInAutomationSettings {
+  auto_like_posts: boolean;
+  auto_comment_posts: boolean;
+  ai_agent_enabled: boolean;
+  ai_agent_reply_delay_seconds: number;
+}
 type AuthMethod = 'credentials' | 'cookies';
 export const LinkedInIntegration: React.FC = () => {
   const [linkedInConnections, setLinkedInConnections] = useState<LinkedInAccount[]>([]);
@@ -77,8 +86,26 @@ export const LinkedInIntegration: React.FC = () => {
   // Yes/No auto-polling states
   const [yesNoPolling, setYesNoPolling] = useState<NodeJS.Timeout | null>(null);
   const [autoResolving, setAutoResolving] = useState(false);
+  // ── AI Replies (tenant-level LinkedIn AI agent) ────────────────────────────
+  // ai_agent_enabled is stored once per tenant, so every connected account shares
+  // the same flag. We hold the full settings object (not just the boolean) so a
+  // PUT can resend auto_like_posts / auto_comment_posts / reply-delay unchanged —
+  // the backend rebuilds all four keys, so omitting them would clobber them.
+  const [automationSettings, setAutomationSettings] = useState<LinkedInAutomationSettings | null>(null);
+  const [aiRepliesSaving, setAiRepliesSaving] = useState(false);
+  const [aiToast, setAiToast] = useState<{ kind: 'ok' | 'err'; message: string } | null>(null);
+  // Auto-dismiss the AI Replies toast after a few seconds (mirrors Instagram).
+  useEffect(() => {
+    if (!aiToast) return;
+    const t = setTimeout(() => setAiToast(null), 4500);
+    return () => clearTimeout(t);
+  }, [aiToast]);
   useEffect(() => {
     checkLinkedInConnection();
+    // Fetch the tenant's AI-agent setting on mount and whenever the account
+    // count changes (connect/disconnect). Deliberately NOT in the 30s poll so
+    // an in-flight optimistic toggle isn't overwritten mid-flight.
+    void fetchAutomationSettings();
     // Start polling status every 30 seconds if any connection is active
     const pollInterval = setInterval(() => {
       if (linkedInConnections.some(conn => conn.connected)) {
@@ -305,6 +332,63 @@ export const LinkedInIntegration: React.FC = () => {
       setLinkedInConnections([]);
     } finally {
       setLoading(false);
+    }
+  };
+  // GET the tenant's LinkedIn automation settings. Response is { success, data }.
+  // Failure is non-fatal: we leave settings unloaded and keep the pill disabled
+  // (so a toggle can never PUT a partial/clobbering payload).
+  const fetchAutomationSettings = async () => {
+    try {
+      const res = await apiGet<{ success?: boolean; data?: LinkedInAutomationSettings }>(
+        '/api/social-integration/linkedin/automation-settings'
+      );
+      if (res?.data) {
+        setAutomationSettings(res.data);
+      }
+    } catch (error) {
+      // Non-fatal — see note above.
+    }
+  };
+  // Flip the tenant-level AI agent on/off. Optimistic UI, then PUT the FULL set
+  // (only ai_agent_enabled changed) so the backend's jsonb rebuild preserves
+  // auto_like_posts / auto_comment_posts / reply-delay. Reverts + toasts on
+  // failure (mirrors Instagram's per-account AI toggle).
+  const toggleAiReplies = async () => {
+    if (!automationSettings || aiRepliesSaving) return;
+    const previous = automationSettings;
+    const next = !previous.ai_agent_enabled;
+    // Optimistic — all cards read this one flag, so they flip together.
+    setAutomationSettings({ ...previous, ai_agent_enabled: next });
+    setAiRepliesSaving(true);
+    try {
+      const response = await fetch(
+        `${getApiBaseUrl()}/api/social-integration/linkedin/automation-settings`,
+        {
+          method: 'PUT',
+          headers: getAuthHeaders(),
+          body: JSON.stringify({
+            auto_like_posts: previous.auto_like_posts,
+            auto_comment_posts: previous.auto_comment_posts,
+            ai_agent_enabled: next,
+            ai_agent_reply_delay_seconds: previous.ai_agent_reply_delay_seconds,
+          }),
+        }
+      );
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.success) {
+        throw new Error(data?.error || data?.message || 'Failed to update AI Replies');
+      }
+      // Reconcile with the server's authoritative copy.
+      if (data.data) setAutomationSettings(data.data as LinkedInAutomationSettings);
+    } catch (error) {
+      // Roll back the optimistic flip and surface the error.
+      setAutomationSettings(previous);
+      setAiToast({
+        kind: 'err',
+        message: error instanceof Error ? error.message : 'Could not update AI Replies.',
+      });
+    } finally {
+      setAiRepliesSaving(false);
     }
   };
   const handleConnect = async () => {
@@ -670,12 +754,30 @@ export const LinkedInIntegration: React.FC = () => {
             })()}
           </div>
         </div>
+        {/* AI Replies toggle feedback — only surfaces on failure (mirrors Instagram). */}
+        {aiToast && (
+          <div
+            className={`mb-4 flex items-center gap-2 rounded-lg border p-3 text-sm ${
+              aiToast.kind === 'ok'
+                ? 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200'
+                : 'border-rose-300 bg-rose-50 text-rose-800 dark:border-rose-500/30 dark:bg-rose-500/10 dark:text-rose-200'
+            }`}
+          >
+            {aiToast.kind === 'ok' ? <CheckCircle2 className="h-4 w-4" /> : <AlertCircle className="h-4 w-4" />}
+            {aiToast.message}
+          </div>
+        )}
         {/* Display all connected LinkedIn accounts */}
         {linkedInConnections.length > 0 && (
           <div className="mb-6 space-y-3">
             <h4 className="font-medium text-gray-900 text-sm mb-2">
               Connected Accounts ({linkedInConnections.length})
             </h4>
+            {linkedInConnections.length > 1 && (
+              <p className="text-xs text-gray-500 -mt-1 mb-1">
+                AI Replies is account-wide — toggling it on any card applies to all your connected LinkedIn accounts.
+              </p>
+            )}
             {linkedInConnections.map((account, index) => {
               const accountStatusDisplay = getStatusDisplay(account.status, account.connected);
               const AccountStatusIcon = accountStatusDisplay.icon;
@@ -743,6 +845,17 @@ export const LinkedInIntegration: React.FC = () => {
                         {disconnecting[account.id || 'default'] ? 'Disconnecting...' : 'Disconnect'}
                       </button>
                     </div>
+                  </div>
+                  {/* AI Replies — tenant-level LinkedIn AI agent. Every connected
+                      account binds to the same flag; toggling persists via the
+                      automation-settings API and survives a refresh. */}
+                  <div className="mt-3 flex flex-wrap items-center gap-2">
+                    <AiToggleChip
+                      label="AI Replies"
+                      enabled={automationSettings?.ai_agent_enabled ?? true}
+                      disabled={!automationSettings || aiRepliesSaving}
+                      onToggle={toggleAiReplies}
+                    />
                   </div>
                 </div>
               );
@@ -1149,3 +1262,34 @@ export const LinkedInIntegration: React.FC = () => {
     </>
   );
 };
+
+// ── AI Replies chip ──────────────────────────────────────────────────────────
+// Green pill toggle mirroring Instagram's connected-account cards
+// (components/instagram/InstagramTenantOnboarding.tsx → AiToggleChip).
+function AiToggleChip({
+  label,
+  enabled,
+  onToggle,
+  disabled,
+}: {
+  label: string;
+  enabled: boolean;
+  onToggle: () => void;
+  disabled?: boolean;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={disabled}
+      className={`flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-[11px] font-medium transition disabled:cursor-not-allowed disabled:opacity-60 ${
+        enabled
+          ? 'border-emerald-200 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-200 dark:hover:bg-emerald-500/20'
+          : 'border-neutral-200 bg-white text-neutral-600 hover:bg-neutral-100 dark:border-white/10 dark:bg-white/5 dark:text-white/60 dark:hover:bg-white/10'
+      }`}
+    >
+      <Power className="h-3 w-3" />
+      {label}: {enabled ? 'on' : 'off'}
+    </button>
+  );
+}


### PR DESCRIPTION
## What

Adds a green **"AI Replies: on/off"** pill to each connected **LinkedIn** account card in `web/src/components/settings/LinkedInIntegration.tsx`, mirroring the `AiToggleChip` Instagram already shows on its connected-account cards. It's wired to the existing tenant-level automation-settings API — no backend changes.

## Why

LinkedIn had no UI to enable/disable the AI agent, unlike Instagram. This gives operators a one-click, explicit opt-out (and opt-in) that persists.

## How

- **Load:** GET `/api/social-integration/linkedin/automation-settings` on mount and whenever the connected-account count changes (deliberately **not** in the 30s status poll, so it can't overwrite an in-flight optimistic toggle). Reads the `{ success, data }` wrapper.
- **Toggle:** optimistic flip, then PUT the **full** settings set with only `ai_agent_enabled` changed. The controller's `jsonb_build_object` rebuilds all keys, so sending a partial body would clobber `auto_like_posts` / `auto_comment_posts` / `ai_agent_reply_delay_seconds` — we resend them unchanged. Reconciles with the server's `data` on success; reverts + shows an error toast on failure (mirrors Instagram).
- **UI:** the setting is tenant-level, so every connected card renders the same chip bound to the one flag (they flip together), defaulting to ON. A one-line "account-wide" note appears when there are 2+ accounts. Calls the backend directly via `getApiBaseUrl()` + the existing `getAuthHeaders()` Bearer auth — same convention the component already uses for `/api/campaigns/linkedin/*`; no Next.js proxy route needed.

## ⚠️ Reviewer note — default-ON depends on the backend

The frontend reflects whatever `ai_agent_enabled` the GET returns (it can't reconstruct "default ON" — the API collapses unset→false). The "freshly-connected account = ON" behavior relies on **LAD_backend PR #257**. Against a backend whose `getAutomationSettings` still uses `settings.ai_agent_enabled === true`, a new account will display OFF until that PR is deployed.

## Acceptance

- [x] Each connected LinkedIn card shows an "AI Replies: on/off" toggle, defaulting to ON (given PR #257 backend).
- [x] Toggling persists via PUT and survives refresh (GET reflects it).
- [x] OFF sets `ai_agent_enabled=false` (explicit opt-out); ON re-enables.
- [x] `auto_like_posts` / `auto_comment_posts` are not clobbered.
- [x] Visually consistent with the Instagram connected-account toggle.

## Test plan

- `NODE_OPTIONS=--max-old-space-size=6144 npm run build` (Node 20): ✅ compiled successfully, 107/107 pages.
- Backend route confirmed mounted (401 unauth) at `/api/social-integration/linkedin/automation-settings`.
- Manual: Settings → Integrations → LinkedIn → toggle the pill, refresh, verify it sticks and that auto-like/auto-comment are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)