### PR TITLE
fix(routing): default WhatsApp channel to 'waba' (was 'personal'), dr…

### DIFF
--- a/sdk/shared/proxyClient.ts
+++ b/sdk/shared/proxyClient.ts
@@ -46,9 +46,11 @@ class ProxyClient {
     }
 
     // Inject channel param so the proxy routes to the correct backend.
-    // Prefer the per-request override; fall back to localStorage for legacy callers.
+    // Prefer the per-request override; fall back to localStorage, then default to
+    // 'waba' — matching the Next proxy's default and the primary channel. Personal-WA
+    // callers always pass channel: 'personal' explicitly, so this default is safe.
     if (typeof window !== 'undefined' && !url.searchParams.has('channel')) {
-      const channel = options?.channel ?? safeStorage.getItem('whatsappChannel') ?? 'personal';
+      const channel = options?.channel ?? safeStorage.getItem('whatsappChannel') ?? 'waba';
       url.searchParams.set('channel', channel);
     }
 

--- a/web/src/components/settings/IntegrationsSettings.tsx
+++ b/web/src/components/settings/IntegrationsSettings.tsx
@@ -303,7 +303,9 @@ export const IntegrationsSettings: React.FC = () => {
           const accounts = Array.isArray(data?.accounts) ? data.accounts : [];
           const connected = accounts.some((a: any) => a.status === 'connected');
           setStatus('whatsapp-personal', connected ? 'connected' : 'disconnected');
-          if (connected) try { localStorage.setItem('whatsappChannel', 'personal'); } catch {}
+          // NOTE: do NOT write localStorage.whatsappChannel here — it globally biased
+          // proxyClient routing to 'personal' for every unspecified call (sending WABA
+          // requests to the personal/WAPA service). Channel is now per-request/explicit.
           // Load the WAPA "AI Replies" master switch for the connected-account pill.
           // WAPA returns { success, settings: { ai_enabled, ... } }. Default ON.
           if (connected) {


### PR DESCRIPTION
…op localStorage bias

proxyClient appended ?channel from localStorage.whatsappChannel and defaulted to 'personal' — inconsistent with the Next python-proxy default of 'waba'. So any SDK call without an explicit channel routed to the personal/WAPA service; in stage (where that service is down) this surfaced as 500/502 on WABA endpoints. Default to 'waba' (the primary channel; personal-WA flows pass channel: 'personal' explicitly) and stop IntegrationsSettings from globally writing localStorage.whatsappChannel='personal', which poisoned routing for every unspecified call.