### PR TITLE
feat(overview): conversation analytics widgets — Enquiries & Bookings + Re-engage by Topic

### DIFF
--- a/web/src/app/api/analytics/overview/route.ts
+++ b/web/src/app/api/analytics/overview/route.ts
@@ -1,0 +1,17 @@
+/**
+ * GET /api/analytics/overview — tenant conversation analytics for the Overview page.
+ *
+ * Proxies to LAD-Master-Agent GET /analytics/overview (which derives the SAH
+ * funnel, daily-volume spike, and unconverted-topic segments from the tenant's
+ * conversation tables). The shared master-agent-proxy helper injects tenant_id
+ * (from the user's JWT) + the X-Service-Token; pass-through query: window_days.
+ */
+import { NextRequest } from 'next/server';
+
+import { proxyToMasterAgent } from '../../prospects/utils/master-agent-proxy';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest): Promise<Response> {
+  return proxyToMasterAgent(req, '/analytics/overview');
+}

--- a/web/src/components/overview/DashboardGrid.tsx
+++ b/web/src/components/overview/DashboardGrid.tsx
@@ -44,6 +44,8 @@ import { AIInsightsWidget } from './widgets/AIInsightsWidget';
 import { QuickActionsWidget } from './widgets/QuickActionsWidget';
 import { CalendarWidget } from './widgets/CalendarWidget';
 import { BroadcastPerformanceWidget } from './widgets/BroadcastPerformanceWidget';
+import { ConversationFunnelWidget } from './widgets/ConversationFunnelWidget';
+import { ReengageTopicsWidget } from './widgets/ReengageTopicsWidget';
 // Utilities
 import { cn } from '@/lib/utils';
 import {
@@ -477,6 +479,10 @@ export const DashboardGrid: React.FC<DashboardGridProps> = ({ className, onLoadi
         return <CalendarWidget id={widgetId} />;
       case 'broadcast-performance':
         return <BroadcastPerformanceWidget id={widgetId} />;
+      case 'conversation-funnel':
+        return <ConversationFunnelWidget id={widgetId} />;
+      case 'reengage-topics':
+        return <ReengageTopicsWidget id={widgetId} />;
       default:
         return <div className="widget-card h-full flex items-center justify-center text-muted-foreground">Unknown widget</div>;
     }

--- a/web/src/components/overview/useConversationAnalytics.ts
+++ b/web/src/components/overview/useConversationAnalytics.ts
@@ -1,0 +1,143 @@
+'use client';
+
+/**
+ * useConversationAnalytics — shared client hook for the tenant Overview's
+ * conversation analytics (funnel + daily-volume spike + unconverted-topic
+ * segments), served by LAD-Master-Agent via /api/analytics/overview.
+ *
+ * Two widgets (ConversationFunnel + ReengageTopics) read the SAME payload, so
+ * this dedupes them onto ONE in-flight request and one cache entry per window,
+ * with a tiny pub/sub so a refresh in one widget updates the other.
+ */
+import { useCallback, useEffect, useState } from 'react';
+
+import { fetchWithTenant } from '@/lib/fetch-with-tenant';
+
+export interface FunnelStep {
+  key: string;
+  label: string;
+  count: number;
+  pct_of_prev: number;
+}
+export interface Funnel {
+  steps: FunnelStep[];
+  conversion_rate: number;
+  cancelled: number;
+  escalated_to_human: number;
+  total: number;
+  converted: number;
+}
+export interface VolumePoint {
+  day: string;
+  count: number;
+}
+export interface VolumeSpike {
+  latest: number;
+  latest_day?: string;
+  trailing_avg: number;
+  pct_change: number;
+  is_spike: boolean;
+}
+export interface TopicContact {
+  conversation_id: string;
+  wa_contact_id: string | null;
+  contact_name: string | null;
+  phone: string | null;
+}
+export interface TopicSegment {
+  topic: string;
+  count: number;
+  contacts: TopicContact[];
+}
+export interface OverviewAnalytics {
+  tenant_id: string;
+  window_days: number;
+  funnel: Funnel;
+  daily_volume: VolumePoint[];
+  volume_spike: VolumeSpike;
+  unconverted_topics: TopicSegment[];
+  unconverted_total: number;
+}
+
+interface State {
+  data: OverviewAnalytics | null;
+  loading: boolean;
+  error: string | null;
+}
+
+interface Entry {
+  state: State;
+  listeners: Set<(s: State) => void>;
+  promise: Promise<void> | null;
+}
+
+const entries = new Map<number, Entry>();
+
+function getEntry(windowDays: number): Entry {
+  let e = entries.get(windowDays);
+  if (!e) {
+    e = { state: { data: null, loading: false, error: null }, listeners: new Set(), promise: null };
+    entries.set(windowDays, e);
+  }
+  return e;
+}
+
+function setState(e: Entry, next: State) {
+  e.state = next;
+  e.listeners.forEach((l) => l(next));
+}
+
+function load(windowDays: number, force: boolean): Promise<void> {
+  const e = getEntry(windowDays);
+  if (e.promise && !force) return e.promise;
+  if (e.state.data && !force) return Promise.resolve();
+
+  setState(e, { ...e.state, loading: true, error: null });
+
+  const p = fetchWithTenant(`/api/analytics/overview?window_days=${windowDays}`, {
+    method: 'GET',
+    cache: 'no-store',
+  })
+    .then(async (r) => {
+      const body = await r.json().catch(() => ({}));
+      if (!r.ok) {
+        throw new Error(body?.detail || body?.error || `Request failed (${r.status})`);
+      }
+      return body as OverviewAnalytics;
+    })
+    .then((data) => {
+      setState(e, { data, loading: false, error: null });
+    })
+    .catch((err: unknown) => {
+      setState(e, {
+        data: e.state.data,
+        loading: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    })
+    .finally(() => {
+      e.promise = null;
+    });
+
+  e.promise = p;
+  return p;
+}
+
+export function useConversationAnalytics(windowDays = 30) {
+  const [state, setLocal] = useState<State>(() => getEntry(windowDays).state);
+
+  useEffect(() => {
+    const e = getEntry(windowDays);
+    setLocal(e.state);
+    const listener = (s: State) => setLocal(s);
+    e.listeners.add(listener);
+    void load(windowDays, false);
+    return () => {
+      e.listeners.delete(listener);
+    };
+  }, [windowDays]);
+
+  const refresh = useCallback(() => load(windowDays, true), [windowDays]);
+
+  return { ...state, refresh };
+}

--- a/web/src/components/overview/useConversationAnalytics.ts
+++ b/web/src/components/overview/useConversationAnalytics.ts
@@ -5,9 +5,11 @@
  * conversation analytics (funnel + daily-volume spike + unconverted-topic
  * segments), served by LAD-Master-Agent via /api/analytics/overview.
  *
- * Two widgets (ConversationFunnel + ReengageTopics) read the SAME payload, so
- * this dedupes them onto ONE in-flight request and one cache entry per window,
- * with a tiny pub/sub so a refresh in one widget updates the other.
+ * The funnel + spike are fast SQL; topic extraction adds an LLM round-trip. So
+ * the funnel widget fetches with includeTopics=false (instant, and still renders
+ * if the LLM is down) while the Re-engage widget fetches topics separately. Each
+ * (window, includeTopics) pair is its own cache entry, deduped onto one in-flight
+ * request with a tiny pub/sub so a refresh updates every subscriber.
  */
 import { useCallback, useEffect, useState } from 'react';
 
@@ -71,13 +73,16 @@ interface Entry {
   promise: Promise<void> | null;
 }
 
-const entries = new Map<number, Entry>();
+const entries = new Map<string, Entry>();
 
-function getEntry(windowDays: number): Entry {
-  let e = entries.get(windowDays);
+const keyOf = (windowDays: number, includeTopics: boolean) =>
+  `${windowDays}:${includeTopics ? 1 : 0}`;
+
+function getEntry(key: string): Entry {
+  let e = entries.get(key);
   if (!e) {
     e = { state: { data: null, loading: false, error: null }, listeners: new Set(), promise: null };
-    entries.set(windowDays, e);
+    entries.set(key, e);
   }
   return e;
 }
@@ -87,17 +92,15 @@ function setState(e: Entry, next: State) {
   e.listeners.forEach((l) => l(next));
 }
 
-function load(windowDays: number, force: boolean): Promise<void> {
-  const e = getEntry(windowDays);
+function load(windowDays: number, includeTopics: boolean, force: boolean): Promise<void> {
+  const e = getEntry(keyOf(windowDays, includeTopics));
   if (e.promise && !force) return e.promise;
   if (e.state.data && !force) return Promise.resolve();
 
   setState(e, { ...e.state, loading: true, error: null });
 
-  const p = fetchWithTenant(`/api/analytics/overview?window_days=${windowDays}`, {
-    method: 'GET',
-    cache: 'no-store',
-  })
+  const url = `/api/analytics/overview?window_days=${windowDays}&include_topics=${includeTopics ? 1 : 0}`;
+  const p = fetchWithTenant(url, { method: 'GET', cache: 'no-store' })
     .then(async (r) => {
       const body = await r.json().catch(() => ({}));
       if (!r.ok) {
@@ -123,21 +126,22 @@ function load(windowDays: number, force: boolean): Promise<void> {
   return p;
 }
 
-export function useConversationAnalytics(windowDays = 30) {
-  const [state, setLocal] = useState<State>(() => getEntry(windowDays).state);
+export function useConversationAnalytics(windowDays = 30, includeTopics = true) {
+  const key = keyOf(windowDays, includeTopics);
+  const [state, setLocal] = useState<State>(() => getEntry(key).state);
 
   useEffect(() => {
-    const e = getEntry(windowDays);
+    const e = getEntry(key);
     setLocal(e.state);
     const listener = (s: State) => setLocal(s);
     e.listeners.add(listener);
-    void load(windowDays, false);
+    void load(windowDays, includeTopics, false);
     return () => {
       e.listeners.delete(listener);
     };
-  }, [windowDays]);
+  }, [key, windowDays, includeTopics]);
 
-  const refresh = useCallback(() => load(windowDays, true), [windowDays]);
+  const refresh = useCallback(() => load(windowDays, includeTopics, true), [windowDays, includeTopics]);
 
   return { ...state, refresh };
 }

--- a/web/src/components/overview/widgets/ConversationFunnelWidget.tsx
+++ b/web/src/components/overview/widgets/ConversationFunnelWidget.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+/**
+ * ConversationFunnelWidget — "Enquiries & Bookings".
+ *
+ * Shows the conversation funnel (New enquiries → Engaged → In booking → Booked)
+ * with drop-off at each step and the overall conversion rate, plus a daily
+ * new-conversation volume headline with a spike indicator + mini sparkline.
+ * Data: LAD-Master-Agent via useConversationAnalytics (shared with the
+ * Re-engage widget — one fetch).
+ */
+import React from 'react';
+import { TrendingUp, TrendingDown, ArrowRight, RefreshCw, Users } from 'lucide-react';
+
+import { WidgetWrapper } from '../WidgetWrapper';
+import { useConversationAnalytics } from '../useConversationAnalytics';
+
+const WINDOW_DAYS = 30;
+
+const fmtDay = (iso?: string) => {
+  if (!iso) return '';
+  const d = new Date(iso + (iso.length === 10 ? 'T00:00:00Z' : ''));
+  if (isNaN(d.getTime())) return '';
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', timeZone: 'UTC' });
+};
+
+const STEP_COLORS = ['bg-blue-500', 'bg-indigo-500', 'bg-violet-500', 'bg-emerald-500'];
+
+export const ConversationFunnelWidget: React.FC<{ id: string }> = ({ id }) => {
+  const { data, loading, error, refresh } = useConversationAnalytics(WINDOW_DAYS);
+
+  const header = (
+    <button
+      onClick={refresh}
+      title="Refresh"
+      className="p-1 rounded hover:bg-black/5 dark:hover:bg-white/10 text-muted-foreground dark:text-[#E0E0E0]"
+    >
+      <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+    </button>
+  );
+
+  return (
+    <WidgetWrapper
+      id={id}
+      title="Enquiries & Bookings"
+      icon={<Users className="h-4 w-4" />}
+      headerActions={header}
+    >
+      {error && !data ? (
+        <div className="h-full flex flex-col items-center justify-center text-center gap-1 py-6">
+          <p className="text-sm text-muted-foreground">Couldn’t load insights</p>
+          <p className="text-[11px] text-muted-foreground/70 max-w-[240px]">{error}</p>
+          <button onClick={refresh} className="mt-2 text-xs text-blue-600 hover:underline">Try again</button>
+        </div>
+      ) : loading && !data ? (
+        <FunnelSkeleton />
+      ) : !data || data.funnel.total === 0 ? (
+        <div className="h-full flex flex-col items-center justify-center text-center gap-1 py-6">
+          <p className="text-sm font-medium dark:text-[#E0E0E0]">No conversations yet</p>
+          <p className="text-[11px] text-muted-foreground max-w-[240px]">
+            Enquiries from your channels will show up here as a funnel from first message to booking.
+          </p>
+        </div>
+      ) : (
+        <FunnelBody data={data} />
+      )}
+    </WidgetWrapper>
+  );
+};
+
+const FunnelBody: React.FC<{ data: NonNullable<ReturnType<typeof useConversationAnalytics>['data']> }> = ({ data }) => {
+  const { funnel, volume_spike, daily_volume } = data;
+  const total = funnel.total || 1;
+  const spikeUp = volume_spike.pct_change >= 0;
+
+  // sparkline — last 14 days
+  const spark = daily_volume.slice(-14);
+  const sparkMax = Math.max(1, ...spark.map((p) => p.count));
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Daily volume + spike headline */}
+      <div className="flex items-end justify-between gap-3">
+        <div>
+          <p className="text-[11px] uppercase tracking-wide text-muted-foreground">New conversations</p>
+          <div className="flex items-baseline gap-2 mt-0.5">
+            <span className="text-2xl font-bold font-display dark:text-[#E0E0E0]">{volume_spike.latest}</span>
+            <span className="text-[11px] text-muted-foreground">{fmtDay(volume_spike.latest_day)}</span>
+          </div>
+        </div>
+        <div className="flex flex-col items-end gap-1">
+          <span
+            className={[
+              'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold',
+              volume_spike.is_spike
+                ? 'bg-amber-100 text-amber-700 dark:bg-amber-500/15 dark:text-amber-300'
+                : spikeUp
+                ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-300'
+                : 'bg-slate-100 text-slate-500 dark:bg-slate-500/15 dark:text-slate-300',
+            ].join(' ')}
+          >
+            {spikeUp ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+            {volume_spike.is_spike ? 'Spike' : `${spikeUp ? '+' : ''}${volume_spike.pct_change}%`}
+          </span>
+          <span className="text-[10px] text-muted-foreground">vs {volume_spike.trailing_avg}/day avg</span>
+        </div>
+      </div>
+
+      {/* Sparkline */}
+      {spark.length > 1 && (
+        <div className="flex items-end gap-[3px] h-8" aria-hidden>
+          {spark.map((p, i) => (
+            <div
+              key={i}
+              title={`${fmtDay(p.day)}: ${p.count}`}
+              className="flex-1 rounded-sm bg-blue-400/70 dark:bg-blue-500/50 min-h-[2px]"
+              style={{ height: `${Math.max(6, (p.count / sparkMax) * 100)}%` }}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Funnel */}
+      <div className="flex flex-col gap-2 pt-1 border-t border-gray-100 dark:border-white/5">
+        {funnel.steps.map((step, i) => {
+          const widthPct = Math.max(6, Math.round((step.count / total) * 100));
+          return (
+            <div key={step.key}>
+              <div className="flex items-center justify-between text-xs mb-1">
+                <span className="text-muted-foreground dark:text-[#E0E0E0]/80">{step.label}</span>
+                <span className="font-semibold dark:text-[#E0E0E0]">
+                  {step.count}
+                  {i > 0 && (
+                    <span className="ml-1 text-[10px] font-normal text-muted-foreground">{step.pct_of_prev}%</span>
+                  )}
+                </span>
+              </div>
+              <div className="h-2 rounded-full bg-gray-100 dark:bg-white/5 overflow-hidden">
+                <div className={`h-full rounded-full ${STEP_COLORS[i % STEP_COLORS.length]}`} style={{ width: `${widthPct}%` }} />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Footer */}
+      <div className="flex items-center justify-between pt-2 border-t border-gray-100 dark:border-white/5 text-xs">
+        <span className="inline-flex items-center gap-1 text-muted-foreground">
+          <ArrowRight className="h-3 w-3" />
+          Conversion
+          <span className="font-bold text-emerald-600 dark:text-emerald-400">{funnel.conversion_rate}%</span>
+        </span>
+        {funnel.escalated_to_human > 0 && (
+          <span className="text-muted-foreground">{funnel.escalated_to_human} to human</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const FunnelSkeleton: React.FC = () => (
+  <div className="flex flex-col gap-4 animate-pulse">
+    <div className="flex justify-between">
+      <div className="h-8 w-24 rounded bg-gray-200 dark:bg-white/10" />
+      <div className="h-6 w-16 rounded-full bg-gray-200 dark:bg-white/10" />
+    </div>
+    <div className="h-8 w-full rounded bg-gray-200 dark:bg-white/10" />
+    <div className="space-y-3 pt-1">
+      {[0, 1, 2, 3].map((i) => (
+        <div key={i} className="h-2 w-full rounded-full bg-gray-200 dark:bg-white/10" />
+      ))}
+    </div>
+  </div>
+);

--- a/web/src/components/overview/widgets/ConversationFunnelWidget.tsx
+++ b/web/src/components/overview/widgets/ConversationFunnelWidget.tsx
@@ -27,7 +27,9 @@ const fmtDay = (iso?: string) => {
 const STEP_COLORS = ['bg-blue-500', 'bg-indigo-500', 'bg-violet-500', 'bg-emerald-500'];
 
 export const ConversationFunnelWidget: React.FC<{ id: string }> = ({ id }) => {
-  const { data, loading, error, refresh } = useConversationAnalytics(WINDOW_DAYS);
+  // Funnel + spike are fast SQL — fetch WITHOUT topics so this renders instantly
+  // (and still works if topic extraction / the LLM is unavailable).
+  const { data, loading, error, refresh } = useConversationAnalytics(WINDOW_DAYS, false);
 
   const header = (
     <button

--- a/web/src/components/overview/widgets/ReengageTopicsWidget.tsx
+++ b/web/src/components/overview/widgets/ReengageTopicsWidget.tsx
@@ -35,7 +35,9 @@ function toMembers(topic: TopicSegment) {
 }
 
 export const ReengageTopicsWidget: React.FC<{ id: string }> = ({ id }) => {
-  const { data, loading, error, refresh } = useConversationAnalytics(WINDOW_DAYS);
+  // Topics need the LLM round-trip — fetched separately from the funnel so the
+  // funnel stays instant; this widget shows its own skeleton while labels resolve.
+  const { data, loading, error, refresh } = useConversationAnalytics(WINDOW_DAYS, true);
   const [active, setActive] = useState<TopicSegment | null>(null);
   const [sent, setSent] = useState<{ topic: string; total: number } | null>(null);
 

--- a/web/src/components/overview/widgets/ReengageTopicsWidget.tsx
+++ b/web/src/components/overview/widgets/ReengageTopicsWidget.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+/**
+ * ReengageTopicsWidget — "Re-engage by Topic".
+ *
+ * Surfaces the segments of customers who ASKED ABOUT a topic (e.g. Pilates,
+ * Pricing) but did NOT convert, and lets the tenant fire a WhatsApp broadcast
+ * to exactly that segment in one click. Each topic's contacts are handed to the
+ * existing MessageTemplateSender (template picker + send) as `allMembers`, so
+ * "Send to all" targets precisely that segment.
+ *
+ * Data: LAD-Master-Agent via useConversationAnalytics (shared with the funnel
+ * widget — one fetch).
+ */
+import React, { useMemo, useState } from 'react';
+import { Megaphone, RefreshCw, Sparkles, CheckCircle2 } from 'lucide-react';
+
+import MessageTemplateSender from '@/features/community-roi/components/MessageTemplateSender';
+import { WidgetWrapper } from '../WidgetWrapper';
+import { useConversationAnalytics, TopicSegment } from '../useConversationAnalytics';
+
+const WINDOW_DAYS = 30;
+
+// Map a topic's contacts → the member shape MessageTemplateSender expects.
+// We pass ONLY this segment as `allMembers`, so its "Send to all" = this segment.
+function toMembers(topic: TopicSegment) {
+  return topic.contacts
+    .filter((c) => (c.phone || '').trim())
+    .map((c) => ({
+      id: c.wa_contact_id || c.conversation_id,
+      name: c.contact_name || c.phone || 'Customer',
+      phone: c.phone,
+      whatsapp_phone: c.phone,
+    }));
+}
+
+export const ReengageTopicsWidget: React.FC<{ id: string }> = ({ id }) => {
+  const { data, loading, error, refresh } = useConversationAnalytics(WINDOW_DAYS);
+  const [active, setActive] = useState<TopicSegment | null>(null);
+  const [sent, setSent] = useState<{ topic: string; total: number } | null>(null);
+
+  const activeMembers = useMemo(() => (active ? toMembers(active) : []), [active]);
+
+  const header = (
+    <button
+      onClick={refresh}
+      title="Refresh"
+      className="p-1 rounded hover:bg-black/5 dark:hover:bg-white/10 text-muted-foreground dark:text-[#E0E0E0]"
+    >
+      <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+    </button>
+  );
+
+  const topics = data?.unconverted_topics ?? [];
+
+  return (
+    <WidgetWrapper
+      id={id}
+      title="Re-engage by Topic"
+      icon={<Megaphone className="h-4 w-4" />}
+      headerActions={header}
+    >
+      {sent && (
+        <div className="mb-3 flex items-center gap-2 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-700 dark:border-emerald-500/30 dark:bg-emerald-500/10 dark:text-emerald-300">
+          <CheckCircle2 className="h-4 w-4 shrink-0" />
+          <span>Broadcasting to {sent.total} {sent.topic} contact{sent.total === 1 ? '' : 's'}…</span>
+        </div>
+      )}
+
+      {error && !data ? (
+        <div className="h-full flex flex-col items-center justify-center text-center gap-1 py-6">
+          <p className="text-sm text-muted-foreground">Couldn’t load segments</p>
+          <p className="text-[11px] text-muted-foreground/70 max-w-[240px]">{error}</p>
+          <button onClick={refresh} className="mt-2 text-xs text-blue-600 hover:underline">Try again</button>
+        </div>
+      ) : loading && !data ? (
+        <TopicsSkeleton />
+      ) : topics.length === 0 ? (
+        <div className="h-full flex flex-col items-center justify-center text-center gap-1 py-6">
+          <Sparkles className="h-5 w-5 text-muted-foreground/60" />
+          <p className="text-sm font-medium dark:text-[#E0E0E0]">No re-engagement segments</p>
+          <p className="text-[11px] text-muted-foreground max-w-[250px]">
+            When customers ask about something specific but don’t book, they’ll be grouped here so you can win them back.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <p className="text-[11px] text-muted-foreground">
+            Asked but didn’t book — message them a tailored offer.
+          </p>
+          {topics.map((t) => {
+            const reachable = toMembers(t).length;
+            return (
+              <div
+                key={t.topic}
+                className="flex items-center justify-between gap-2 rounded-lg border border-gray-100 dark:border-white/5 bg-white/60 dark:bg-white/[0.03] px-3 py-2"
+              >
+                <div className="min-w-0">
+                  <p className="text-sm font-medium truncate dark:text-[#E0E0E0]">{t.topic}</p>
+                  <p className="text-[11px] text-muted-foreground">
+                    {t.count} didn’t book
+                    {reachable < t.count && <span> · {reachable} on WhatsApp</span>}
+                  </p>
+                </div>
+                <button
+                  onClick={() => setActive(t)}
+                  disabled={reachable === 0}
+                  className="shrink-0 inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-blue-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                  <Megaphone className="h-3.5 w-3.5" />
+                  Broadcast
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {active && (
+        <MessageTemplateSender
+          memberName=""
+          noInteractionCount={0}
+          recommendations={[]}
+          allMembers={activeMembers}
+          onClose={() => setActive(null)}
+          onSuccess={(result: { broadcasting?: boolean; total?: number }) => {
+            if (result?.broadcasting) {
+              setSent({ topic: active.topic, total: result.total ?? activeMembers.length });
+              setTimeout(() => setSent(null), 8000);
+            }
+          }}
+        />
+      )}
+    </WidgetWrapper>
+  );
+};
+
+const TopicsSkeleton: React.FC = () => (
+  <div className="flex flex-col gap-2 animate-pulse">
+    {[0, 1, 2, 3].map((i) => (
+      <div key={i} className="h-12 w-full rounded-lg bg-gray-200 dark:bg-white/10" />
+    ))}
+  </div>
+);

--- a/web/src/store/dashboardStore.ts
+++ b/web/src/store/dashboardStore.ts
@@ -196,7 +196,10 @@ export const useDashboardStore = create<DashboardState>()(
       //     the stat cards) rather than buried at the bottom from the v1
       //     append. Custom widget reorderings are lost — acceptable trade
       //     while the dashboard layout is still settling.
-      version: 2,
+      // v3: hard-reset to DEFAULT_LAYOUT so existing users get the new
+      //     conversation-analytics widgets (Enquiries & Bookings funnel +
+      //     Re-engage by Topic) at their intended slot under the stat cards.
+      version: 3,
       migrate: (persistedState: any, _version: number) => {
         if (!persistedState) return persistedState;
         return { ...persistedState, layout: DEFAULT_LAYOUT };

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -10,7 +10,9 @@ export type WidgetType =
   | 'ai-insights'
   | 'voice-agents'
   | 'quick-actions'
-  | 'broadcast-performance';
+  | 'broadcast-performance'
+  | 'conversation-funnel'
+  | 'reengage-topics';
 export type WidgetCategory =
   | 'analytics'
   | 'voice-agent'
@@ -178,6 +180,28 @@ export const WIDGET_CATALOG: Record<WidgetType, WidgetConfig> = {
     minSize: { w: 6, h: 3 },
     maxSize: { w: 12, h: 5 },
   },
+  'conversation-funnel': {
+    id: 'conversation-funnel',
+    type: 'conversation-funnel',
+    title: 'Enquiries & Bookings',
+    description: 'Conversation funnel from first enquiry to booking — drop-off, conversion rate and daily volume',
+    category: 'analytics',
+    icon: 'Users',
+    defaultSize: { w: 6, h: 4 },
+    minSize: { w: 4, h: 3 },
+    maxSize: { w: 12, h: 6 },
+  },
+  'reengage-topics': {
+    id: 'reengage-topics',
+    type: 'reengage-topics',
+    title: 'Re-engage by Topic',
+    description: 'Customers who asked about a topic but didn’t book — broadcast a tailored offer to win them back',
+    category: 'whatsapp',
+    icon: 'Megaphone',
+    defaultSize: { w: 6, h: 4 },
+    minSize: { w: 4, h: 3 },
+    maxSize: { w: 12, h: 6 },
+  },
 };
 // Widget categories for the library
 export const WIDGET_CATEGORIES: { id: WidgetCategory; label: string; icon: string }[] = [
@@ -193,7 +217,9 @@ export const DEFAULT_LAYOUT: WidgetLayoutItem[] = [
   { i: 'calls-today-1', x: 0, y: 0, w: 4, h: 2, minW: 3, minH: 2 },
   { i: 'answer-rate-1', x: 4, y: 0, w: 4, h: 2, minW: 3, minH: 2 },
   { i: 'calls-monthly-1', x: 8, y: 0, w: 4, h: 2, minW: 3, minH: 2 },
-  { i: 'broadcast-performance-1', x: 0, y: 2, w: 12, h: 3, minW: 6, minH: 3 },
+  { i: 'conversation-funnel-1', x: 0, y: 2, w: 6, h: 4, minW: 4, minH: 3 },
+  { i: 'reengage-topics-1', x: 6, y: 2, w: 6, h: 4, minW: 4, minH: 3 },
+  { i: 'broadcast-performance-1', x: 0, y: 6, w: 12, h: 3, minW: 6, minH: 3 },
   { i: 'calls-chart-1', x: 0, y: 5, w: 6, h: 4, minW: 4, minH: 3 },
   { i: 'voice-agents-1', x: 6, y: 5, w: 6, h: 4, minW: 4, minH: 3 },
   { i: 'credits-overview-1', x: 0, y: 9, w: 6, h: 4, minW: 4, minH: 3 },


### PR DESCRIPTION
## What

Two Overview dashboard widgets fed by LAD-Master-Agent `/analytics/overview` (proxied via `/api/analytics/overview`, tenant-scoped through the shared master-agent-proxy):

- **Enquiries & Bookings** — the conversation funnel (New enquiries → Engaged → In booking → Booked) with per-step drop-off + conversion rate, plus a daily new-conversation volume headline, spike badge, and sparkline. Fetches **without** topics so it renders instantly (and survives the LLM being down).
- **Re-engage by Topic** — segments of customers who asked about a topic (e.g. Pilates, Pricing) but didn't book. Each has a one-click **Broadcast** that opens the existing `MessageTemplateSender` pre-loaded with exactly that contact segment ("Send to all" = the segment), reusing the trusted WhatsApp send path.

Both share `useConversationAnalytics` (module-cached, keyed per window + includeTopics, cross-widget refresh). Registered in the widget catalog + default layout (store persist **v3** so existing users pick them up). Graceful loading / error / empty states. No backend provider names in tenant-facing copy.

## Files
- `app/api/analytics/overview/route.ts` — proxy → MA
- `components/overview/useConversationAnalytics.ts` — shared hook + types
- `components/overview/widgets/ConversationFunnelWidget.tsx`, `ReengageTopicsWidget.tsx`
- `components/overview/DashboardGrid.tsx`, `types/dashboard.ts`, `store/dashboardStore.ts` — registration

## Verified
`tsc --noEmit` clean (0 errors in touched files), eslint clean. Backend verified live against TPF dev (Pilates/Pricing/Dance segments).

## Depends on
`techiemaya-admin/LAD-Master-Agent#feat/overview-analytics` (the `/analytics/overview` endpoint). Widgets show a friendly error/empty state until the MA endpoint is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)