### PR TITLE
fix(broadcast-modal): render via portal + add close button (Overview Re-engage widget)

### DIFF
--- a/web/src/features/community-roi/components/MessageTemplateSender.tsx
+++ b/web/src/features/community-roi/components/MessageTemplateSender.tsx
@@ -1,9 +1,40 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
-import { Send, Clock, Search, CheckCircle, AlertCircle, ChevronRight, ChevronLeft } from 'lucide-react';
+import { createPortal } from 'react-dom';
+import { Send, Clock, Search, CheckCircle, AlertCircle, ChevronRight, ChevronLeft, X } from 'lucide-react';
 import { useScheduleMessages } from '@lad/frontend-features/community-roi';
 import { fetchWithTenant } from '@/lib/fetch-with-tenant';
+
+// Render the modal at <body> via a portal so its `position: fixed` actually
+// pins to the viewport. Without this, any ancestor with a CSS transform / filter
+// / will-change becomes the fixed-positioning containing block — which happens
+// on the dashboard Overview because @dnd-kit applies a transform to widget
+// wrappers, clipping this modal inside the widget card (no visible footer,
+// broken scrolling). Falls through cleanly during SSR (document undefined).
+function ModalPortal({ children }: { children: React.ReactNode }) {
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => { setMounted(true); }, []);
+  if (!mounted || typeof document === 'undefined') return null;
+  return createPortal(children, document.body);
+}
+
+// Small × button shown in every step's header. The component originally lived
+// in a flow with a guaranteed Cancel/Back path, but once it's invoked from
+// elsewhere (e.g. the Overview Re-engage widget) callers expect a top-right
+// close affordance.
+function CloseButton({ onClose }: { onClose: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClose}
+      aria-label="Close"
+      className="absolute top-4 right-4 p-1.5 rounded-lg text-slate-400 hover:text-slate-700 hover:bg-slate-100 transition-colors"
+    >
+      <X className="w-5 h-5" />
+    </button>
+  );
+}
 
 interface MetaTemplate {
   name: string;
@@ -501,8 +532,10 @@ const MessageTemplateSender: React.FC<MessageTemplateSenderProps> = ({
   // ─── STEP 1: Template Selection ────────────────────────────────────────────
   if (step === 'template') {
     return (
-      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-        <div className="bg-white rounded-2xl p-8 max-w-2xl w-full mx-4 max-h-[90vh] flex flex-col">
+      <ModalPortal>
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
+        <div className="relative bg-white rounded-2xl p-8 max-w-2xl w-full mx-4 max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
+          <CloseButton onClose={onClose} />
           <h2 className="text-2xl font-bold text-slate-900 mb-1">Send Message</h2>
           <p className="text-sm text-slate-500 mb-5">Select a Meta-approved template to send</p>
 
@@ -614,6 +647,7 @@ const MessageTemplateSender: React.FC<MessageTemplateSenderProps> = ({
           </div>
         </div>
       </div>
+      </ModalPortal>
     );
   }
 
@@ -622,8 +656,10 @@ const MessageTemplateSender: React.FC<MessageTemplateSenderProps> = ({
     const paramCount = selectedTemplate?.parameter_count ?? 0;
 
     return (
-      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-        <div className="bg-white rounded-2xl p-8 max-w-2xl w-full mx-4 max-h-[90vh] flex flex-col">
+      <ModalPortal>
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
+        <div className="relative bg-white rounded-2xl p-8 max-w-2xl w-full mx-4 max-h-[90vh] flex flex-col" onClick={e => e.stopPropagation()}>
+          <CloseButton onClose={onClose} />
           <h2 className="text-2xl font-bold text-slate-900 mb-1">Map Parameters</h2>
           <p className="text-sm text-slate-500 mb-5">
             Template: <span className="font-semibold text-indigo-600">{displayName(selectedTemplate?.name ?? '')}</span>
@@ -793,14 +829,17 @@ const MessageTemplateSender: React.FC<MessageTemplateSenderProps> = ({
           </div>
         </div>
       </div>
+      </ModalPortal>
     );
   }
 
   // ─── STEP 3: Member Selection ───────────────────────────────────────────────
   if (step === 'members') {
     return (
-      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-        <div className="bg-white rounded-2xl p-8 max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+      <ModalPortal>
+      <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
+        <div className="relative bg-white rounded-2xl p-8 max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+          <CloseButton onClose={onClose} />
           <h2 className="text-2xl font-bold text-slate-900 mb-1">Select Recipients</h2>
           <p className="text-sm text-slate-500 mb-5">
             Template: <span className="font-semibold text-indigo-600">{displayName(selectedTemplate?.name ?? '')}</span>
@@ -891,13 +930,16 @@ const MessageTemplateSender: React.FC<MessageTemplateSenderProps> = ({
           </div>
         </div>
       </div>
+      </ModalPortal>
     );
   }
 
   // ─── STEP 4: Confirm / Schedule ────────────────────────────────────────────
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-2xl p-8 max-w-2xl w-full mx-4">
+    <ModalPortal>
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
+      <div className="relative bg-white rounded-2xl p-8 max-w-2xl w-full mx-4 max-h-[90vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+        <CloseButton onClose={onClose} />
         <h2 className="text-2xl font-bold text-slate-900 mb-5">
           {sendMode === 'instant' ? 'Confirm Send' : 'Schedule Message'}
         </h2>
@@ -971,6 +1013,7 @@ const MessageTemplateSender: React.FC<MessageTemplateSenderProps> = ({
         </div>
       </div>
     </div>
+    </ModalPortal>
   );
 };
 


### PR DESCRIPTION
## Reported by user

> Broadcast in overview page is not rendering properly, no close option when clicked on broadcast button, no send button once template message is selected. scroll down & up is not working properly

Screenshot showed a template card with a blue selection ring and no visible footer buttons or close affordance.

## Root cause

The `MessageTemplateSender` modal is reused by the new Overview **Re-engage by Topic** widget (PR #532). Dashboard widget cards are wrapped by `@dnd-kit`'s `useSortable`, which applies a CSS `transform` to the wrapper for drag animations. **A transformed ancestor becomes the containing block for `position: fixed` descendants** (W3C spec) — so the modal renders inside the widget card boundary instead of escaping to the viewport. Symptoms reported by the user line up exactly:

- "No send button" — Next/Send button is below the visible card area.
- "Scroll not working" — internal scroll competes with widget overflow.
- "No close option" — backdrop only covers the widget tile, and there was never an X button.

## Fix

1. **Portal each step to `document.body`** via a small `<ModalPortal>` wrapper (4 steps × 4 wraps). Defers mount with `useState`/`useEffect` so SSR cleanly returns `null` (no hydration mismatch on a `createPortal(_, document.body)`).
2. **Explicit × close button** in the top-right of every step (template / params / members / confirm). Backdrop click also closes, with `stopPropagation` on the modal box so clicks inside don't dismiss.
3. **Confirm step**: added `max-h-[90vh] overflow-y-auto` to match the other steps (it was the only one without scroll containment).

## Verified

- `<ModalPortal>` open/close tags balanced **4/4**.
- `tsc --noEmit` clean on the changed file.
- The 21 pre-existing eslint errors in this file are unchanged (lines 520/521/524/526/690/873 — all in untouched code).
- Community-ROI's existing usage is unaffected — portal renders at body, which is visually identical to in-place rendering when no transformed ancestor exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)