### PR TITLE
feat(community-roi): attach per-member report PDF for cohesion_report_with_sheet

### DIFF
--- a/web/src/features/community-roi/components/MessageTemplateSender.tsx
+++ b/web/src/features/community-roi/components/MessageTemplateSender.tsx
@@ -484,6 +484,14 @@ const MessageTemplateSender: React.FC<MessageTemplateSenderProps> = ({
         }))
         .filter(m => m.phone); // skip members with no phone — WABA will reject them anyway
 
+      // Templates that attach each member's OWN cohesion-report PDF as the
+      // document header (resolved per-recipient by the WABA service) instead
+      // of a single shared document.
+      const MEMBER_REPORT_TEMPLATES = new Set(['cohesion_report_with_sheet']);
+      const attachMemberReport =
+        selectedTemplate.header_type === 'document' &&
+        MEMBER_REPORT_TEMPLATES.has(selectedTemplate.name);
+
       fetchWithTenant('/api/whatsapp-conversations/conversations/send-template-to-members', {
         method:  'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -492,7 +500,10 @@ const MessageTemplateSender: React.FC<MessageTemplateSenderProps> = ({
           template_name: selectedTemplate.name,
           language_code: selectedTemplate.language_code || 'en',
           header_type:   selectedTemplate.header_type || '',
-          header_url:    headerMediaUrl,
+          // In per-member mode the WABA service supplies each member's document,
+          // so the shared header_url is irrelevant (omit to avoid confusion).
+          header_url:    attachMemberReport ? '' : headerMediaUrl,
+          attach_member_report: attachMemberReport,
         }),
       })
         .then(r => r.json())


### PR DESCRIPTION
Final wiring for the per-member report attachment. When the broadcast sender sends the **approved** `cohesion_report_with_sheet` template (document header), it now passes `attach_member_report: true` so the WABA service attaches **each recipient's own** cohesion-report PDF as the document header.

Completes the feature alongside:
- LAD-Backend #266 — generates + stores per-member PDFs
- LAD-WABA-Comms #103 — uploads to Meta + per-member document header in the send loop

## Change
`MessageTemplateSender` send payload:
- `attach_member_report: true` only for `cohesion_report_with_sheet` (document header). All other templates unaffected.
- Omits the shared `header_url` in that mode (the per-member document supersedes it).

Body params are unchanged — they come from the per-member mapping (`{{1}}` = member name, `{{2}}` = no-interaction count, which now reads each member's own sheet value).

## Test plan (post-merge, all 3 PRs deployed)
- [ ] In the broadcast sender, pick `cohesion_report_with_sheet`, map `{{1}}`→Member Name, `{{2}}`→No-Interaction Count.
- [ ] Send to a single test member first.
- [ ] Confirm that member receives a PDF document header that is THEIR report (filename = their name), with the body counts correct.
- [ ] Confirm a different member receives a DIFFERENT PDF.
- [ ] A member with no stored report is skipped (reported in the results), not sent a broken message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)