### PR TITLE
fix(conversations): resolve WABusinessView TypeScript errors

### DIFF
--- a/web/src/components/conversations/WABusinessView.tsx
+++ b/web/src/components/conversations/WABusinessView.tsx
@@ -1124,7 +1124,7 @@ const [voicePlayProgress, setVoicePlayProgress] = useState(0);
 
   const [olderMessages, setOlderMessages] = useState<Message[]>([]);
   const [loadingOlder, setLoadingOlder] = useState(false);
-  const [olderOffset, setOlderOffset] = useState(CONFIG.INITIAL_MESSAGE_LIMIT);
+  const [olderOffset, setOlderOffset] = useState<number>(CONFIG.INITIAL_MESSAGE_LIMIT);
 
   const prevConvId = useRef<string | null>(null);
 
@@ -1251,7 +1251,7 @@ const [voicePlayProgress, setVoicePlayProgress] = useState(0);
     status: normalizeStatus(
       (m as Message & { message_status?: string }).status ||
       (m as Message & { message_status?: string }).message_status
-    ),
+    ) as Message['status'],
   }));
 
   const baseMessages = dedupeById([...olderMessages, ...normalizedPolledMessages]);
@@ -1355,8 +1355,8 @@ const [voicePlayProgress, setVoicePlayProgress] = useState(0);
         } as Message;
       });
 
-      setOlderMessages((prev) => dedupeById([...mapped, ...prev]).slice(-MAX_OLDER_MESSAGES));
-      const nextOffsetIncrement = raw.length > 0 ? raw.length : LOAD_MORE_LIMIT;
+      setOlderMessages((prev) => dedupeById([...mapped, ...prev]).slice(-CONFIG.MAX_OLDER_MESSAGES));
+      const nextOffsetIncrement = raw.length > 0 ? raw.length : CONFIG.LOAD_MORE_LIMIT;
       setOlderOffset((prev) => prev + nextOffsetIncrement);
     } catch (err: unknown) {
       setSendError(getErrorMessage(err, 'Failed to load older messages'));
@@ -3315,7 +3315,7 @@ function WABASidebar({
               lastMsg = activeLastMsg;
             }
             const time = lastMsg
-              ? formatDistanceToNow(new Date(lastMsg.timestamp || lastMsg.created_at || new Date()), { addSuffix: false })
+              ? formatDistanceToNow(new Date(lastMsg.timestamp || (lastMsg as Message & { created_at?: string }).created_at || new Date()), { addSuffix: false })
               : '';
 
             return (
@@ -3369,7 +3369,7 @@ function WABASidebar({
                   <div className="flex justify-between items-center">
                     <div className="flex items-center gap-1 min-w-0 overflow-hidden">
                       {(lastMsg?.isOutgoing || lastMsg?.role === 'assistant' || lastMsg?.role === 'human_agent') && !conv.unreadCount && (
-                        <MessageTicks status={lastMsg?.status || lastMsg?.message_status} />
+                        <MessageTicks status={lastMsg?.status || (lastMsg as (Message & { message_status?: string }) | undefined)?.message_status} />
                       )}
                       <span className="text-[14px] text-muted-foreground dark:text-[#a2a2a2] truncate max-w-[80%]">
                         {lastMsg?.content || 'Started conversation'}


### PR DESCRIPTION
Six TS errors: MAX_OLDER_MESSAGES & LOAD_MORE_LIMIT referenced without the CONFIG. prefix; normalizeStatus()'s string result not narrowed to MessageStatus; raw-API fields created_at/message_status read off the typed Message; and olderOffset inferred as the literal 50 (CONFIG is `as const`) so its arithmetic setter (prev => prev + n) failed — widened to useState<number>. Verified with a clean full tsc: 0 WABusinessView errors.