### PR TITLE
fix(waba): stop false 'template sent' + silent no-op in chat window

### DIFF
--- a/web/src/components/conversations/WABusinessView.tsx
+++ b/web/src/components/conversations/WABusinessView.tsx
@@ -1581,7 +1581,12 @@ const [voicePlayProgress, setVoicePlayProgress] = useState(0);
     headerParamCount: number, headerType: string, headerUrl: string,
   ) => {
     const convId = conversationId || conversation?.id;
-    if (!convId) return;
+    if (!convId) {
+      // Never fail silently — otherwise the picker can appear to "succeed"
+      // while no request is ever sent.
+      setTemplateSendResult({ success: false, message: 'Cannot send: this conversation has no ID. Reopen the chat and try again.' });
+      return;
+    }
     setTemplateSending(true);
     setTemplateSendResult(null);
     setTemplateSendProgress({ sent: 0, total: 1, running: true });
@@ -1604,11 +1609,23 @@ const [voicePlayProgress, setVoicePlayProgress] = useState(0);
         }
       );
       const data = await res.json();
-      setTemplateSendProgress({ sent: data.sent || 1, total: 1, running: false });
-      if (!data.success) throw new Error(data.error || 'Failed');
+      const sent = Number(data.sent) || 0;
+      const failed = Number(data.failed) || 0;
+      setTemplateSendProgress({ sent, total: 1, running: false });
+      // Gate success on ACTUAL delivery. A 2xx with sent:0 means WhatsApp/Meta
+      // rejected the send (e.g. template not yet approved, or a parameter
+      // mismatch) — surface the real reason instead of a misleading "✓ sent".
+      if (!res.ok || !data.success || sent < 1) {
+        throw new Error(
+          data.results?.[0]?.error || data.error ||
+          (failed > 0
+            ? 'WhatsApp rejected the template (often: not yet approved, or a parameter mismatch).'
+            : 'Template was not sent.')
+        );
+      }
       setTemplateSendResult({ success: true, message: `Template "${templateName}" sent` });
       setTimeout(() => setIsTemplatePickerOpen(false), 500);
-      setTimeout(() => setTemplateSendResult(null), 3000);
+      setTimeout(() => setTemplateSendResult(null), 4000);
     } catch (err: unknown) {
       setTemplateSendResult({ success: false, message: getErrorMessage(err, 'Failed to send template') });
       setTemplateSendProgress(null);


### PR DESCRIPTION
## Problem
Sending a template from the WhatsApp chat window showed a green **"✓ Template sent"** even though nothing was delivered (no real send / no `sent` count). Reported live: picker opens, templates load (`GET /templates` 200), select + send → success message, but the template never arrives.

## Root cause (`WABAChatWindow.handleTemplateSend`)
1. **False success on rejected delivery.** Success was gated on `data.success` (the *bulk op ran*), and progress used `data.sent || 1` (defaults to **1**). A `200` with `sent:0, failed:1` — WhatsApp/Meta rejecting the send (template not yet approved, parameter mismatch, etc.) — still rendered "✓ sent".
2. **Silent no-op.** `if (!convId) return` returned with no feedback, so a missing conversation id could look like success.

## Fix
- Gate success on **actual delivery**: `res.ok && data.success && sent >= 1`.
- Surface the real reason on failure (`results[0].error` / `data.error`, or a clear "rejected — often not yet approved / parameter mismatch").
- Use the real `sent` count (no `|| 1`).
- Replace the silent `return` with an explicit error message.

Net: the user now sees either a **real** success or the **exact reason** it failed — never a misleading acknowledgement. No backend change (the `/conversations/bulk` → `bulk/send-template` path is already 200).

## Note
Couldn't reproduce live (Claude-for-Chrome extension wasn't connected), but the false-success path is unambiguous in code and matches the reported symptom exactly. Scoped to the chat-window handler; the sidebar/bulk handler already uses `data.sent || 0` and isn't affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)