### PR TITLE
feat(broadcast): schedule group broadcasts for a later time

### DIFF
--- a/web/src/app/api/whatsapp-conversations/chat-groups/schedule-template-broadcast/route.ts
+++ b/web/src/app/api/whatsapp-conversations/chat-groups/schedule-template-broadcast/route.ts
@@ -1,0 +1,14 @@
+/**
+ * Schedule Template Broadcast Proxy
+ * POST /api/whatsapp-conversations/chat-groups/schedule-template-broadcast
+ *   → WAPA /chat-groups/schedule-template-broadcast (personal WhatsApp only)
+ *
+ * Schedules a template broadcast (one template → N groups) to fire at a chosen
+ * time via a GCP Cloud Task.
+ */
+import { NextRequest } from 'next/server';
+import { proxyToPythonService, getWABAServiceUrl } from '../../utils/python-proxy';
+
+export async function POST(req: NextRequest) {
+  return proxyToPythonService(req, getWABAServiceUrl(), '/api/chat-groups/schedule-template-broadcast');
+}

--- a/web/src/app/api/whatsapp-conversations/chat-groups/scheduled-broadcasts/[id]/route.ts
+++ b/web/src/app/api/whatsapp-conversations/chat-groups/scheduled-broadcasts/[id]/route.ts
@@ -1,0 +1,17 @@
+/**
+ * Scheduled Broadcast (cancel) Proxy
+ * DELETE /api/whatsapp-conversations/chat-groups/scheduled-broadcasts/:id
+ *   → WAPA /chat-groups/scheduled-broadcasts/:id (personal WhatsApp only)
+ *
+ * Cancels a still-scheduled group broadcast and deletes its Cloud Task.
+ */
+import { NextRequest } from 'next/server';
+import { proxyToPythonService, getWABAServiceUrl } from '../../../utils/python-proxy';
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params;
+  return proxyToPythonService(req, getWABAServiceUrl(), `/api/chat-groups/scheduled-broadcasts/${id}`);
+}

--- a/web/src/app/api/whatsapp-conversations/chat-groups/scheduled-broadcasts/route.ts
+++ b/web/src/app/api/whatsapp-conversations/chat-groups/scheduled-broadcasts/route.ts
@@ -1,0 +1,13 @@
+/**
+ * Scheduled Broadcasts (list) Proxy
+ * GET /api/whatsapp-conversations/chat-groups/scheduled-broadcasts
+ *   → WAPA /chat-groups/scheduled-broadcasts (personal WhatsApp only)
+ *
+ * Lists upcoming/in-flight scheduled group broadcasts for the tenant.
+ */
+import { NextRequest } from 'next/server';
+import { proxyToPythonService, getWABAServiceUrl } from '../../utils/python-proxy';
+
+export async function GET(req: NextRequest) {
+  return proxyToPythonService(req, getWABAServiceUrl(), '/api/chat-groups/scheduled-broadcasts');
+}

--- a/web/src/components/conversations/ScheduleBroadcastModal.tsx
+++ b/web/src/components/conversations/ScheduleBroadcastModal.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import { useEffect, useState, useMemo } from 'react';
+import { CalendarClock, Loader2 } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { fetchWithTenant } from '@/lib/fetch-with-tenant';
+
+interface TemplateOpt {
+  name: string;
+  language: string;
+  parameters: string[];
+}
+
+interface ScheduleBroadcastModalProps {
+  open: boolean;
+  onClose: () => void;
+  groupIds: string[];
+  channel: 'personal' | 'waba';
+  onScheduled?: () => void;
+}
+
+/**
+ * Schedule a group broadcast for a future time (Cloud-Task triggered).
+ * Two modes: a free-text Message (→ broadcast-to-groups) or a Template
+ * (→ schedule-template-broadcast). Both carry a `scheduled_at` ISO timestamp.
+ */
+export function ScheduleBroadcastModal({ open, onClose, groupIds, channel, onScheduled }: ScheduleBroadcastModalProps) {
+  const [mode, setMode] = useState<'message' | 'template'>('message');
+  const [message, setMessage] = useState('');
+  const [templates, setTemplates] = useState<TemplateOpt[]>([]);
+  const [templateName, setTemplateName] = useState('');
+  const [params, setParams] = useState<string[]>([]);
+  const [scheduledAt, setScheduledAt] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [loadingTemplates, setLoadingTemplates] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setMode('message'); setMessage(''); setTemplateName(''); setParams([]);
+      setScheduledAt(''); setError(null); setSubmitting(false);
+    }
+  }, [open]);
+
+  // Lazy-load templates the first time the user switches to template mode.
+  useEffect(() => {
+    if (!open || mode !== 'template' || templates.length) return;
+    setLoadingTemplates(true);
+    fetchWithTenant(`/api/whatsapp-conversations/conversations/templates?channel=${channel}`)
+      .then((r) => r.json())
+      .then((data) => {
+        if (!data?.success) return;
+        const raw: any[] = data.data || data.templates || [];
+        setTemplates(
+          raw
+            .filter((t: any) => t.status !== 'REJECTED' && t.status !== 'DELETED')
+            .map((t: any) => {
+              const body = t.body || t.content || '';
+              const bodyParams = [...new Set(
+                (body.match(/\{\{([^}]+)\}\}/g) || []).map((p: string) => p.replace(/^\{\{|\}\}$/g, '').trim())
+              )] as string[];
+              return {
+                name: t.name || '',
+                language: t.language || t.language_code || 'en',
+                parameters: (t.parameters && t.parameters.length ? t.parameters : bodyParams) as string[],
+              };
+            })
+        );
+      })
+      .catch(() => {})
+      .finally(() => setLoadingTemplates(false));
+  }, [open, mode, channel, templates.length]);
+
+  const selectedTemplate = useMemo(
+    () => templates.find((t) => t.name === templateName),
+    [templates, templateName]
+  );
+
+  // datetime-local min: ~2 minutes from now, in the browser's local time.
+  const minDateTime = useMemo(() => {
+    const d = new Date(Date.now() + 2 * 60 * 1000);
+    const pad = (n: number) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  }, [open]);
+
+  const submit = async () => {
+    setError(null);
+    if (!scheduledAt) { setError('Pick a date and time'); return; }
+    const whenIso = new Date(scheduledAt).toISOString();
+    if (new Date(whenIso).getTime() <= Date.now() + 30 * 1000) { setError('Pick a time at least a minute from now'); return; }
+    if (mode === 'message' && !message.trim()) { setError('Enter a message'); return; }
+    if (mode === 'template' && !templateName) { setError('Pick a template'); return; }
+
+    setSubmitting(true);
+    try {
+      const res = mode === 'message'
+        ? await fetchWithTenant(`/api/whatsapp-conversations/chat-groups/broadcast-to-groups?channel=${channel}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ group_ids: groupIds, message: message.trim(), scheduled_at: whenIso }),
+          })
+        : await fetchWithTenant(`/api/whatsapp-conversations/chat-groups/schedule-template-broadcast?channel=${channel}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              group_ids: groupIds,
+              template_name: templateName,
+              language_code: selectedTemplate?.language || 'en',
+              parameters: params,
+              scheduled_at: whenIso,
+            }),
+          });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok || data?.scheduled === false) {
+        throw new Error(data?.error || `Failed to schedule (HTTP ${res.status})`);
+      }
+      onScheduled?.();
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to schedule broadcast');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <CalendarClock className="h-5 w-5 text-emerald-600" />
+            Schedule broadcast · {groupIds.length} group{groupIds.length === 1 ? '' : 's'}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-1">
+          <div className="flex gap-2">
+            {(['message', 'template'] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMode(m)}
+                className={`flex-1 text-sm py-1.5 rounded-md border transition-colors ${
+                  mode === m ? 'bg-emerald-500 text-white border-emerald-500' : 'border-border hover:bg-muted'
+                }`}
+              >
+                {m === 'message' ? 'Message' : 'Template'}
+              </button>
+            ))}
+          </div>
+
+          {mode === 'message' ? (
+            <textarea
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              rows={4}
+              placeholder="Type the message to post into each group…"
+              className="w-full text-sm rounded-md border border-border bg-background px-3 py-2 resize-none focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+            />
+          ) : (
+            <div className="space-y-2">
+              {loadingTemplates ? (
+                <div className="flex items-center gap-2 text-sm text-muted-foreground py-2">
+                  <Loader2 className="h-4 w-4 animate-spin" /> Loading templates…
+                </div>
+              ) : (
+                <select
+                  value={templateName}
+                  onChange={(e) => { setTemplateName(e.target.value); setParams([]); }}
+                  className="w-full text-sm rounded-md border border-border bg-background px-3 py-2"
+                >
+                  <option value="">Select a template…</option>
+                  {templates.map((t) => (
+                    <option key={t.name} value={t.name}>{t.name} ({t.language})</option>
+                  ))}
+                </select>
+              )}
+              {selectedTemplate && selectedTemplate.parameters.length > 0 && (
+                <div className="space-y-1.5">
+                  {selectedTemplate.parameters.map((p, i) => (
+                    <input
+                      key={i}
+                      value={params[i] || ''}
+                      onChange={(e) => setParams((prev) => { const n = [...prev]; n[i] = e.target.value; return n; })}
+                      placeholder={`Value for {{${p}}}`}
+                      className="w-full text-sm rounded-md border border-border bg-background px-3 py-1.5"
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          <div>
+            <label className="text-xs font-medium text-muted-foreground">Send at</label>
+            <input
+              type="datetime-local"
+              value={scheduledAt}
+              min={minDateTime}
+              onChange={(e) => setScheduledAt(e.target.value)}
+              className="mt-1 w-full text-sm rounded-md border border-border bg-background px-3 py-2"
+            />
+          </div>
+
+          {error && <p className="text-sm text-red-500">{error}</p>}
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button type="button" onClick={onClose} className="text-sm px-3 py-1.5 rounded-md border border-border hover:bg-muted">
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={submit}
+            disabled={submitting}
+            className="text-sm px-4 py-1.5 rounded-md bg-emerald-500 hover:bg-emerald-600 text-white font-medium disabled:opacity-60 flex items-center gap-2"
+          >
+            {submitting && <Loader2 className="h-4 w-4 animate-spin" />} Schedule
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/conversations/ScheduledBroadcastsModal.tsx
+++ b/web/src/components/conversations/ScheduledBroadcastsModal.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+import { CalendarClock, Loader2, Trash2 } from 'lucide-react';
+import { format } from 'date-fns';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { fetchWithTenant } from '@/lib/fetch-with-tenant';
+
+interface ScheduledRow {
+  id: number | string;
+  scheduled_at: string;
+  status: string;
+  group_count: number;
+  message_preview: string;
+}
+
+interface ScheduledBroadcastsModalProps {
+  open: boolean;
+  onClose: () => void;
+  channel: 'personal' | 'waba';
+}
+
+/** Lists upcoming/in-flight scheduled broadcasts with a cancel action. */
+export function ScheduledBroadcastsModal({ open, onClose, channel }: ScheduledBroadcastsModalProps) {
+  const [rows, setRows] = useState<ScheduledRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [cancelingId, setCancelingId] = useState<string | number | null>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    fetchWithTenant(`/api/whatsapp-conversations/chat-groups/scheduled-broadcasts?channel=${channel}`)
+      .then((r) => r.json())
+      .then((data) => setRows(Array.isArray(data?.data) ? data.data : []))
+      .catch(() => setError('Could not load scheduled broadcasts'))
+      .finally(() => setLoading(false));
+  }, [channel]);
+
+  useEffect(() => { if (open) load(); }, [open, load]);
+
+  const cancel = useCallback(async (id: string | number) => {
+    setCancelingId(id);
+    try {
+      const res = await fetchWithTenant(
+        `/api/whatsapp-conversations/chat-groups/scheduled-broadcasts/${id}?channel=${channel}`,
+        { method: 'DELETE' }
+      );
+      if (res.ok) setRows((prev) => prev.filter((r) => r.id !== id));
+    } catch {
+      /* ignore — leave the row; the user can retry */
+    } finally {
+      setCancelingId(null);
+    }
+  }, [channel]);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent className="max-w-lg p-0 overflow-hidden">
+        <DialogHeader className="px-5 py-4 border-b border-border">
+          <DialogTitle className="flex items-center gap-2">
+            <CalendarClock className="h-5 w-5 text-emerald-600" /> Scheduled broadcasts
+          </DialogTitle>
+        </DialogHeader>
+        <div className="max-h-[60vh] overflow-y-auto">
+          {loading ? (
+            <div className="flex items-center justify-center py-16 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin mr-2" /> Loading…
+            </div>
+          ) : error ? (
+            <div className="py-16 text-center text-sm text-muted-foreground">{error}</div>
+          ) : rows.length === 0 ? (
+            <div className="py-16 text-center text-sm text-muted-foreground px-6">
+              No upcoming scheduled broadcasts.
+            </div>
+          ) : (
+            <ul className="divide-y divide-border">
+              {rows.map((r) => (
+                <li key={r.id} className="flex items-start gap-3 px-5 py-3">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-[13px] font-semibold">
+                        {(() => { try { return format(new Date(r.scheduled_at), 'MMM d, h:mm a'); } catch { return r.scheduled_at; } })()}
+                      </span>
+                      <span className="text-[11px] text-muted-foreground">
+                        · {r.group_count} group{r.group_count === 1 ? '' : 's'}
+                      </span>
+                      {r.status === 'sending' && <span className="text-[10px] text-amber-600">sending…</span>}
+                    </div>
+                    <p className="text-[13px] text-muted-foreground truncate mt-0.5">{r.message_preview || '—'}</p>
+                  </div>
+                  {r.status === 'scheduled' && (
+                    <button
+                      type="button"
+                      onClick={() => cancel(r.id)}
+                      disabled={cancelingId === r.id}
+                      title="Cancel"
+                      aria-label="Cancel scheduled broadcast"
+                      className="shrink-0 mt-0.5 text-muted-foreground hover:text-red-500 disabled:opacity-50"
+                    >
+                      {cancelingId === r.id ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/web/src/components/conversations/WABusinessView.tsx
+++ b/web/src/components/conversations/WABusinessView.tsx
@@ -75,6 +75,8 @@ import { MessageComposer } from './MessageComposer';
 import type { Channel } from '@/types/conversation';
 import type { RichMessagePayload as ComposerRichPayload } from '@lad/frontend-features/conversations';
 import { CreateBroadcastGroupModal } from './CreateBroadcastGroupModal';
+import { ScheduleBroadcastModal } from './ScheduleBroadcastModal';
+import { ScheduledBroadcastsModal } from './ScheduledBroadcastsModal';
 import { MessageSettings } from './MessageSettings';
 import { MrLadAvatar } from './MrLadAvatar';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -2494,6 +2496,9 @@ function WABASidebar({
   // group (or taps "Select"), which turns on multi-select mode. A single click
   // outside selection mode opens that group's chat instead.
   const [panelSelectionMode, setPanelSelectionMode] = useState(false);
+  // Scheduled broadcasts (Cloud-Task triggered): groups to schedule for + list-viewer toggle.
+  const [scheduleGroupIds, setScheduleGroupIds] = useState<string[] | null>(null);
+  const [isScheduledListOpen, setIsScheduledListOpen] = useState(false);
   const [createGroupIds, setCreateGroupIds] = useState<string[]>([]);
 
   // ── Group-chat broadcast: post one message into each selected WhatsApp group
@@ -4048,6 +4053,17 @@ function WABASidebar({
             {backendChannel === 'personal' && (
               <button
                 type="button"
+                onClick={() => setIsScheduledListOpen(true)}
+                title="View scheduled broadcasts"
+                className="flex items-center gap-1 text-xs font-medium text-emerald-600 hover:text-emerald-700"
+              >
+                <Clock className="h-3.5 w-3.5" />
+                Scheduled
+              </button>
+            )}
+            {backendChannel === 'personal' && (
+              <button
+                type="button"
                 onClick={handleSyncWaGroups}
                 disabled={isSyncingWaGroups}
                 title="Import your WhatsApp groups from the connected number"
@@ -4346,6 +4362,14 @@ function WABASidebar({
                 </label>
                 <button
                   type="button"
+                  className="flex items-center gap-1 border border-emerald-500 text-emerald-600 text-[11px] h-7 px-2 rounded-md hover:bg-emerald-50 dark:hover:bg-emerald-950/30 transition-colors"
+                  onClick={() => setScheduleGroupIds(Array.from(selectedGroupsPanelIds))}
+                  title="Schedule this broadcast for a later time"
+                >
+                  <Clock className="h-3 w-3" /> Schedule
+                </button>
+                <button
+                  type="button"
                   className="border border-border text-[11px] h-7 px-2 rounded-md hover:bg-muted transition-colors"
                   onClick={() => setSelectedGroupsPanelIds(new Set())}
                 >
@@ -4373,6 +4397,21 @@ function WABASidebar({
           )}
         </div>
       )}
+
+      {/* Schedule a broadcast (message or template) for the selected groups */}
+      {scheduleGroupIds && (
+        <ScheduleBroadcastModal
+          open={!!scheduleGroupIds}
+          onClose={() => setScheduleGroupIds(null)}
+          groupIds={scheduleGroupIds}
+          channel={(backendChannel as 'personal' | 'waba') || 'personal'}
+        />
+      )}
+      <ScheduledBroadcastsModal
+        open={isScheduledListOpen}
+        onClose={() => setIsScheduledListOpen(false)}
+        channel={(backendChannel as 'personal' | 'waba') || 'personal'}
+      />
 
       {/* ── Chat Group Manager Dialog ───────────────────────────────────── */}
       <ChatGroupManager


### PR DESCRIPTION
Adds a Schedule action to the Broadcast Groups panel (message or template) + a Scheduled-broadcasts viewer with cancel, backed by Cloud-Task-triggered WAPA endpoints. New: ScheduleBroadcastModal, ScheduledBroadcastsModal, and the scheduled-broadcasts / schedule-template-broadcast proxy routes; wired into WABusinessView.