### PR TITLE
fix(conversations): sort/display by latest of last_message_at and updated_at

### DIFF
--- a/sdk/features/conversations/api.ts
+++ b/sdk/features/conversations/api.ts
@@ -147,6 +147,20 @@ function mapMessageFromApi(raw: any): Message {
   };
 }
 
+// A conversation's "last activity" can live in either column: updated_at is
+// bumped on every message, but last_message_at historically was NOT (so it could
+// be stale). Use whichever is NEWER for both display and sort, so a freshly-active
+// chat is never ranked/shown as old (real bug 2026-06-20: a chat active "2 min"
+// ago sorted among 2-month chats because the sort keyed off the stale
+// last_message_at). Backend now keeps the two in lock-step; this is belt-and-
+// braces and self-heals before the backfill runs.
+function latestActivityDate(...candidates: Array<string | null | undefined>): Date {
+  const times = candidates
+    .map((c) => (c ? new Date(c).getTime() : NaN))
+    .filter((t) => !Number.isNaN(t));
+  return new Date(times.length ? Math.max(...times) : Date.now());
+}
+
 function mapConversationFromApi(raw: any): Conversation {
   return {
     id: raw.id,
@@ -166,7 +180,7 @@ function mapConversationFromApi(raw: any): Conversation {
           id: `last-${raw.id}`,
           conversationId: raw.id,
           content: raw.last_message_content,
-          timestamp: new Date(raw.last_message_at || raw.updated_at),
+          timestamp: latestActivityDate(raw.last_message_at, raw.updated_at),
           isOutgoing: raw.last_message_role !== 'user',
           status: 'sent',
           sender: {
@@ -183,7 +197,7 @@ function mapConversationFromApi(raw: any): Conversation {
     is_favorite: Boolean(raw.is_favorite),
     isFavorite: Boolean(raw.is_favorite),
     createdAt: new Date(raw.started_at || raw.created_at),
-    updatedAt: new Date(raw.updated_at || raw.last_message_at || raw.started_at),
+    updatedAt: latestActivityDate(raw.updated_at, raw.last_message_at, raw.started_at),
   };
 }
 


### PR DESCRIPTION
## Bug (prod)
A chat active **"2 minutes" ago** sat **among 2-month-old chats** under **Date** sort.

## Root cause
`mapConversationFromApi` set both the sort key and the displayed time to `last_message_at || updated_at` — **preferring `last_message_at`**. But the backend never bumped `last_message_at` on new messages (only `updated_at`), so a fresh chat kept a stale `last_message_at` and sorted/displayed as old. (The open chat showed "2 minutes" only because its display uses the live message.)

## Fix
`latestActivityDate(...)` returns the **newest** of the candidate timestamps. Used for both `lastMessage.timestamp` (sort key + list display) and `updatedAt`. Since `updated_at` is reliably bumped, the sort **self-heals immediately** — even before the backend `last_message_at` backfill ([LAD-WABA-Comms #140](https://github.com/techiemaya-admin/LAD-WABA-Comms/pull/140)) runs — and it tolerates any future desync between the two columns.

## Companion
- Backend: [LAD-WABA-Comms #140](https://github.com/techiemaya-admin/LAD-WABA-Comms/pull/140) makes `save_message` bump `last_message_at` and backfills existing rows (so the value is also semantically correct, not just worked-around here).
- This is **production** (`web.mrlads.com`) — promote develop → main to deploy.