### PR TITLE
chore(frontend): promote develop → stage (conv-sort fix + recent develop work)

### DIFF
--- a/sdk/features/billing/api.ts
+++ b/sdk/features/billing/api.ts
@@ -158,6 +158,53 @@ export async function rechargeWallet(params: {
   return response.data;
 }
 /**
+ * Recurring billing — monthly subscription + low-balance auto-recharge
+ */
+export interface RecurringPlan {
+  kind: 'monthly' | 'auto_recharge';
+  packageId: string;
+  priceUsd: number;
+  credits: number;
+  status: 'incomplete' | 'active' | 'past_due' | 'canceled';
+  thresholdCredits?: number | null;
+  currentPeriodEnd?: string | null;
+  lastChargedAt?: string | null;
+  lastError?: string | null;
+}
+export interface RecurringStatus {
+  monthly: RecurringPlan | null;
+  autoRecharge: RecurringPlan | null;
+}
+/** Start a hosted Checkout for a fixed MONTHLY subscription. */
+export async function subscribeMonthly(params: {
+  packageId: string;
+  successUrl: string;
+  cancelUrl: string;
+}): Promise<{ sessionUrl: string }> {
+  const response = await apiClient.post('/api/stripe/subscribe', params);
+  return response.data;
+}
+/** Start a hosted Checkout (setup mode) to save a card for low-balance auto-recharge. */
+export async function setupAutoRecharge(params: {
+  packageId: string;
+  thresholdCredits?: number;
+  successUrl: string;
+  cancelUrl: string;
+}): Promise<{ sessionUrl: string }> {
+  const response = await apiClient.post('/api/stripe/auto-recharge', params);
+  return response.data;
+}
+/** Current recurring arrangements (monthly + auto-recharge). */
+export async function getRecurring(): Promise<RecurringStatus> {
+  const response = await apiClient.get('/api/stripe/recurring');
+  return { monthly: response.data.monthly, autoRecharge: response.data.autoRecharge };
+}
+/** Cancel the monthly subscription (at period end) or disable auto-recharge. */
+export async function cancelRecurring(kind: 'monthly' | 'auto_recharge'): Promise<{ cancelled: boolean }> {
+  const response = await apiClient.post('/api/stripe/recurring/cancel', { kind });
+  return response.data;
+}
+/**
  * Get usage aggregation summary
  */
 export async function getUsageAggregation(params?: {

--- a/sdk/features/conversations/api.ts
+++ b/sdk/features/conversations/api.ts
@@ -147,6 +147,20 @@ function mapMessageFromApi(raw: any): Message {
   };
 }
 
+// A conversation's "last activity" can live in either column: updated_at is
+// bumped on every message, but last_message_at historically was NOT (so it could
+// be stale). Use whichever is NEWER for both display and sort, so a freshly-active
+// chat is never ranked/shown as old (real bug 2026-06-20: a chat active "2 min"
+// ago sorted among 2-month chats because the sort keyed off the stale
+// last_message_at). Backend now keeps the two in lock-step; this is belt-and-
+// braces and self-heals before the backfill runs.
+function latestActivityDate(...candidates: Array<string | null | undefined>): Date {
+  const times = candidates
+    .map((c) => (c ? new Date(c).getTime() : NaN))
+    .filter((t) => !Number.isNaN(t));
+  return new Date(times.length ? Math.max(...times) : Date.now());
+}
+
 function mapConversationFromApi(raw: any): Conversation {
   return {
     id: raw.id,
@@ -166,7 +180,7 @@ function mapConversationFromApi(raw: any): Conversation {
           id: `last-${raw.id}`,
           conversationId: raw.id,
           content: raw.last_message_content,
-          timestamp: new Date(raw.last_message_at || raw.updated_at),
+          timestamp: latestActivityDate(raw.last_message_at, raw.updated_at),
           isOutgoing: raw.last_message_role !== 'user',
           status: 'sent',
           sender: {
@@ -183,7 +197,7 @@ function mapConversationFromApi(raw: any): Conversation {
     is_favorite: Boolean(raw.is_favorite),
     isFavorite: Boolean(raw.is_favorite),
     createdAt: new Date(raw.started_at || raw.created_at),
-    updatedAt: new Date(raw.updated_at || raw.last_message_at || raw.started_at),
+    updatedAt: latestActivityDate(raw.updated_at, raw.last_message_at, raw.started_at),
   };
 }
 

--- a/web/src/components/WalletBalance.tsx
+++ b/web/src/components/WalletBalance.tsx
@@ -1,9 +1,9 @@
 'use client';
 import React, { useState, useEffect } from 'react';
-import { Wallet, Plus, ArrowUpRight, Clock, CheckCircle2 } from 'lucide-react';
+import { Wallet, Plus, ArrowUpRight, Clock, CheckCircle2, Repeat, RefreshCw, AlertCircle } from 'lucide-react';
 import { getApiBaseUrl } from '@/lib/api-utils';
 import { getCreditPackages, getWalletBalance, getWalletBalanceLegacy } from '@lad/frontend-features/billing';
-import { rechargeWallet } from '../../../sdk/features/billing/api';
+import { rechargeWallet, subscribeMonthly, setupAutoRecharge, getRecurring, cancelRecurring, type RecurringStatus } from '../../../sdk/features/billing/api';
 interface WalletData {
   balance: number;
   currency: string;
@@ -38,9 +38,14 @@ export const WalletBalance: React.FC = () => {
   const [selectedPackage, setSelectedPackage] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [processing, setProcessing] = useState(false);
+  const [purchaseMode, setPurchaseMode] = useState<'one_time' | 'monthly' | 'auto_recharge'>('one_time');
+  const [threshold, setThreshold] = useState<number>(250);
+  const [recurring, setRecurring] = useState<RecurringStatus | null>(null);
+  const [cancellingKind, setCancellingKind] = useState<'monthly' | 'auto_recharge' | null>(null);
   useEffect(() => {
     fetchWalletData();
     fetchCreditPackages();
+    fetchRecurring();
   }, []);
   const fetchWalletData = async () => {
     try {
@@ -98,6 +103,66 @@ export const WalletBalance: React.FC = () => {
       setShowRechargeModal(false);
     }
   };
+  const fetchRecurring = async () => {
+    try {
+      setRecurring(await getRecurring());
+    } catch (error) {
+      console.error('Error fetching recurring billing:', error);
+      setRecurring(null);
+    }
+  };
+  const handleSubscribe = async (packageId: string) => {
+    setProcessing(true);
+    try {
+      const { sessionUrl } = await subscribeMonthly({
+        packageId,
+        successUrl: `${window.location.origin}/wallet/success`,
+        cancelUrl: `${window.location.origin}/wallet/cancel`,
+      });
+      window.location.href = sessionUrl;
+    } catch (error: any) {
+      console.error('Error starting subscription:', error);
+      alert(error?.message || 'Failed to start subscription. Please try again.');
+    } finally {
+      setProcessing(false);
+      setShowRechargeModal(false);
+    }
+  };
+  const handleAutoRecharge = async (packageId: string) => {
+    setProcessing(true);
+    try {
+      const { sessionUrl } = await setupAutoRecharge({
+        packageId,
+        thresholdCredits: threshold,
+        successUrl: `${window.location.origin}/wallet/success`,
+        cancelUrl: `${window.location.origin}/wallet/cancel`,
+      });
+      window.location.href = sessionUrl;
+    } catch (error: any) {
+      console.error('Error enabling auto-recharge:', error);
+      alert(error?.message || 'Failed to enable auto-recharge. Please try again.');
+    } finally {
+      setProcessing(false);
+      setShowRechargeModal(false);
+    }
+  };
+  const handleConfirmPurchase = (packageId: string) => {
+    if (purchaseMode === 'monthly') return handleSubscribe(packageId);
+    if (purchaseMode === 'auto_recharge') return handleAutoRecharge(packageId);
+    return handleRecharge(packageId);
+  };
+  const handleCancelRecurring = async (kind: 'monthly' | 'auto_recharge') => {
+    setCancellingKind(kind);
+    try {
+      await cancelRecurring(kind);
+      await fetchRecurring();
+    } catch (error) {
+      console.error('Error cancelling recurring:', error);
+      alert('Failed to cancel. Please try again.');
+    } finally {
+      setCancellingKind(null);
+    }
+  };
   const formatDate = (timestamp: string) => {
     return new Date(timestamp).toLocaleDateString('en-US', {
       month: 'short',
@@ -139,6 +204,67 @@ export const WalletBalance: React.FC = () => {
           Available credits for voice calls, data scraping, and AI queries
         </p>
       </div>
+      {/* Recurring billing status */}
+      {(recurring?.monthly || recurring?.autoRecharge) && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+          {recurring?.monthly && recurring.monthly.status !== 'canceled' && (
+            <div className="bg-card border border-border rounded-xl p-5">
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-2">
+                  <Repeat className="h-5 w-5 text-primary" />
+                  <h4 className="font-semibold text-foreground">Monthly subscription</h4>
+                </div>
+                <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${recurring.monthly.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}`}>
+                  {recurring.monthly.status}
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground mt-2">
+                {recurring.monthly.credits.toLocaleString()} credits / month · ${recurring.monthly.priceUsd}
+              </p>
+              {recurring.monthly.currentPeriodEnd && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  Next charge: {formatDate(recurring.monthly.currentPeriodEnd)}
+                </p>
+              )}
+              <button
+                onClick={() => handleCancelRecurring('monthly')}
+                disabled={cancellingKind === 'monthly'}
+                className="mt-3 text-xs font-medium text-red-600 hover:text-red-700 disabled:opacity-50"
+              >
+                {cancellingKind === 'monthly' ? 'Cancelling…' : 'Cancel subscription'}
+              </button>
+            </div>
+          )}
+          {recurring?.autoRecharge && recurring.autoRecharge.status !== 'canceled' && (
+            <div className="bg-card border border-border rounded-xl p-5">
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-2">
+                  <RefreshCw className="h-5 w-5 text-primary" />
+                  <h4 className="font-semibold text-foreground">Auto-recharge</h4>
+                </div>
+                <span className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${recurring.autoRecharge.status === 'active' ? 'bg-green-100 text-green-700' : 'bg-orange-100 text-orange-700'}`}>
+                  {recurring.autoRecharge.status}
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground mt-2">
+                +{recurring.autoRecharge.credits.toLocaleString()} credits when balance &lt; {recurring.autoRecharge.thresholdCredits?.toLocaleString()} credits
+              </p>
+              {recurring.autoRecharge.lastError && (
+                <p className="text-xs text-orange-600 mt-1 flex items-center gap-1">
+                  <AlertCircle className="h-3.5 w-3.5" /> {recurring.autoRecharge.lastError}
+                </p>
+              )}
+              <button
+                onClick={() => handleCancelRecurring('auto_recharge')}
+                disabled={cancellingKind === 'auto_recharge'}
+                className="mt-3 text-xs font-medium text-red-600 hover:text-red-700 disabled:opacity-50"
+              >
+                {cancellingKind === 'auto_recharge' ? 'Disabling…' : 'Disable auto-recharge'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
       {/* Recharge Modal */}
       {showRechargeModal && (
         <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50 p-4" onClick={() => { setShowRechargeModal(false); setSelectedPackage(null); }}>
@@ -162,8 +288,42 @@ export const WalletBalance: React.FC = () => {
               </button>
             </div>
 
-            {/* Package Cards - 2x2 grid, compact */}
+            {/* Mode toggle + Package Cards */}
             <div className="p-4">
+              {/* Purchase mode */}
+              <div className="grid grid-cols-3 gap-2 mb-4 p-1 bg-muted rounded-xl">
+                {([
+                  { key: 'one_time', label: 'One-time' },
+                  { key: 'monthly', label: 'Monthly' },
+                  { key: 'auto_recharge', label: 'Auto-recharge' },
+                ] as const).map((m) => (
+                  <button
+                    key={m.key}
+                    onClick={() => setPurchaseMode(m.key)}
+                    className={`text-xs font-semibold py-2 rounded-lg transition-all ${purchaseMode === m.key ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground hover:text-foreground'}`}
+                  >
+                    {m.label}
+                  </button>
+                ))}
+              </div>
+              {purchaseMode === 'auto_recharge' && (
+                <div className="mb-4 rounded-xl border border-border bg-accent/30 p-3">
+                  <label className="text-xs font-medium text-foreground flex items-center gap-1.5">
+                    <RefreshCw className="h-3.5 w-3.5" />
+                    Recharge when my balance falls below
+                  </label>
+                  <div className="flex items-center gap-2 mt-2">
+                    <input
+                      type="number"
+                      min={1}
+                      value={threshold}
+                      onChange={(e) => setThreshold(Math.max(1, parseInt(e.target.value || '0', 10)))}
+                      className="w-28 rounded-lg border border-border bg-card px-3 py-1.5 text-sm text-foreground"
+                    />
+                    <span className="text-xs text-muted-foreground">credits</span>
+                  </div>
+                </div>
+              )}
               <div className="grid grid-cols-2 gap-3">
                 {packages.map((pkg) => (
                   <div
@@ -205,7 +365,7 @@ export const WalletBalance: React.FC = () => {
             {/* Footer */}
             <div className="px-5 py-3 border-t border-border space-y-2">
               <button
-                onClick={() => selectedPackage && handleRecharge(selectedPackage)}
+                onClick={() => selectedPackage && handleConfirmPurchase(selectedPackage)}
                 disabled={!selectedPackage || processing}
                 className="w-full bg-primary text-primary-foreground py-2.5 rounded-xl font-semibold text-sm hover:bg-primary/90 disabled:opacity-40 disabled:cursor-not-allowed transition-all flex items-center justify-center"
               >
@@ -216,7 +376,13 @@ export const WalletBalance: React.FC = () => {
                   </>
                 ) : selectedPackage ? (
                   <>
-                    Purchase {packages.find(p => p.id === selectedPackage)?.name} - ${packages.find(p => p.id === selectedPackage)?.price}
+                    {(() => {
+                      const pkg = packages.find(p => p.id === selectedPackage);
+                      if (!pkg) return 'Continue';
+                      if (purchaseMode === 'monthly') return `Subscribe ${pkg.name} — $${pkg.price}/mo`;
+                      if (purchaseMode === 'auto_recharge') return `Enable auto-recharge — $${pkg.price} per top-up`;
+                      return `Purchase ${pkg.name} - $${pkg.price}`;
+                    })()}
                     <ArrowUpRight className="h-4 w-4 ml-1.5" />
                   </>
                 ) : (
@@ -224,7 +390,11 @@ export const WalletBalance: React.FC = () => {
                 )}
               </button>
               <p className="text-[11px] text-muted-foreground text-center">
-                Secure payment powered by Stripe. Credits valid for 1 month.
+                {purchaseMode === 'monthly'
+                  ? 'Billed monthly via Stripe until you cancel. Credits added each cycle.'
+                  : purchaseMode === 'auto_recharge'
+                  ? 'We securely save your card and top up automatically when you run low.'
+                  : 'Secure payment powered by Stripe. Credits valid for 1 month.'}
               </p>
             </div>
           </div>

--- a/web/src/components/conversations/MessageComposer.tsx
+++ b/web/src/components/conversations/MessageComposer.tsx
@@ -814,11 +814,10 @@ export const MessageComposer = memo(function MessageComposer({
               <p className="text-[10px] font-semibold text-[#94A3B8] uppercase tracking-wide mb-2 px-1">Attach</p>
               <div className="grid grid-cols-3 gap-1">
                 {[
-                  // Broadcast mode drops Sticker (no broadcast payload) and adds Send Template,
-                  // keeping a clean 3×3 grid with the template in the 3rd row.
-                  ...(onSendTemplate && !conversationId
-                    ? ATTACH_ITEMS.filter(i => i.id !== 'sticker')
-                    : ATTACH_ITEMS),
+                  // Sticker is emoji-text (inserted into the message input), so it
+                  // broadcasts fine as text — keep it in every mode. Broadcast mode
+                  // additionally offers Send Template.
+                  ...ATTACH_ITEMS,
                   ...(onSendTemplate && !conversationId
                     ? [{ id: 'template', label: 'Send Template', icon: <LayoutTemplate className="w-6 h-6 text-white" />, bg: 'bg-[#0b1957]' } as AttachItem]
                     : []),

--- a/web/src/components/settings/CreditsSettings.tsx
+++ b/web/src/components/settings/CreditsSettings.tsx
@@ -18,7 +18,6 @@ export const CreditsSettings: React.FC = () => {
     { value: 99, credits: 1000, label: 'Starter' },
     { value: 199, credits: 3000, label: 'Professional' },
     { value: 499, credits: 12000, label: 'Business' },
-    { value: 999, credits: 12000, label: 'Enterprise' },
   ];
 
   // Extract balance from SDK response  


### PR DESCRIPTION
Promotes `develop` → `stage` to deploy on the stage frontend.

## Headline
- **fix(conversations): sort/display by latest of `last_message_at`/`updated_at`** ([#568](https://github.com/techiemaya-admin/LAD-Frontend/pull/568)) — fixes the Date-sort bug where a chat active "2 minutes" ago sorted among month-old chats. Pairs with backend [LAD-WABA-Comms #140](https://github.com/techiemaya-admin/LAD-WABA-Comms/pull/140).

## Also carried (already on develop)
- Stripe recurring payment setup
- Broadcast composer: expose Sticker ([#565](https://github.com/techiemaya-admin/LAD-Frontend/pull/565), [#567](https://github.com/techiemaya-admin/LAD-Frontend/pull/567))

5 files changed (+243 / −14).

## Notes
- Merging this updates the `stage` branch → triggers the stage frontend deploy.
- For the conv-sort fix to fully work on stage, also deploy the **WABA** side (#140) to stage and run the **043 backfill** on the stage conv schema.
- ⚠️ This also brings the **Stripe recurring** work to stage — confirm that's intended for this stage push.