### PR TITLE
fix(billing): render transaction history in credits, not dollars + fi…

### DIFF
--- a/sdk/features/billing/api.ts
+++ b/sdk/features/billing/api.ts
@@ -226,7 +226,13 @@ export async function listTransactions(params?: {
   limit?: number;
   offset?: number;
 }): Promise<any> {
-  const response = await apiClient.get('/api/billing/transactions', { params });
+  // The backend reads `fromDate`/`toDate` query params (not `from`/`to`), so map them —
+  // otherwise the date-range filter is silently ignored.
+  const { from, to, ...rest } = params || {};
+  const query: Record<string, any> = { ...rest };
+  if (from) query.fromDate = from;
+  if (to) query.toDate = to;
+  const response = await apiClient.get('/api/billing/transactions', { params: query });
   
   const creditsPerDollar: number = response.data.creditsPerDollar ?? (1000 / 99);
   const planTier: string = response.data.planTier ?? 'starter';
@@ -248,9 +254,10 @@ export async function listTransactions(params?: {
       balanceBefore: balanceBeforeUsd,
       balanceAfter: balanceAfterUsd,
       // Credits equivalents (converted using plan rate)
-      credits_amount: Math.round(Math.abs(amountUsd) * creditsPerDollar * 100) / 100,
-      credits_balance_after: balanceAfterUsd != null ? Math.round(balanceAfterUsd * creditsPerDollar * 100) / 100 : null,
-      credits_balance_before: balanceBeforeUsd != null ? Math.round(balanceBeforeUsd * creditsPerDollar * 100) / 100 : null,
+      // Ledger amounts are already CREDIT-denominated — do NOT multiply by creditsPerDollar.
+      credits_amount: Math.round(Math.abs(amountUsd) * 100) / 100,
+      credits_balance_after: balanceAfterUsd != null ? Math.round(balanceAfterUsd * 100) / 100 : null,
+      credits_balance_before: balanceBeforeUsd != null ? Math.round(balanceBeforeUsd * 100) / 100 : null,
       description: tx.description || '',
       reference_type: tx.reference_type,
       reference_id: tx.reference_id,

--- a/web/src/components/billing/TransactionDetailModal.tsx
+++ b/web/src/components/billing/TransactionDetailModal.tsx
@@ -35,13 +35,13 @@ export const TransactionDetailModal: React.FC<TransactionDetailModalProps> = ({
 }) => {
   if (!transaction) return null;
 
-  const formatCurrency = (amount: string | number) => {
+  // Ledger amounts are CREDIT-denominated — format as credits, not USD.
+  const formatCredits = (amount: string | number) => {
     const num = typeof amount === 'string' ? parseFloat(amount) : amount;
     return new Intl.NumberFormat('en-US', {
-      style: 'currency',
-      currency: 'USD',
-      minimumFractionDigits: 2,
-    }).format(num);
+      maximumFractionDigits: 2,
+      minimumFractionDigits: 0,
+    }).format(num) + ' cr';
   };
 
   const formatDate = (date: string) => {
@@ -131,7 +131,7 @@ export const TransactionDetailModal: React.FC<TransactionDetailModalProps> = ({
                 }
               >
                 {transaction.type === 'credit' ? '+' : '-'}
-                {formatCurrency(transaction.amount)}
+                {formatCredits(transaction.amount)}
               </span>
             </div>
           </div>
@@ -190,7 +190,7 @@ export const TransactionDetailModal: React.FC<TransactionDetailModalProps> = ({
                 Balance After Transaction
               </label>
               <div className="mt-1 text-lg font-semibold text-gray-900">
-                {formatCurrency(transaction.balance_after)}
+                {formatCredits(transaction.balance_after)}
               </div>
             </div>
           )}

--- a/web/src/components/billing/TransactionHistory.tsx
+++ b/web/src/components/billing/TransactionHistory.tsx
@@ -28,8 +28,8 @@ export const TransactionHistory: React.FC = () => {
   // Fetch transactions
   const { data: txData, isLoading } = useTransactions({
     type: transactionType !== 'all' ? transactionType : undefined,
-    startDate,
-    endDate,
+    from: startDate,
+    to: endDate,
     limit: 200,
   });
 
@@ -62,10 +62,10 @@ export const TransactionHistory: React.FC = () => {
     if (!filteredTransactions.length) return { credits: 0, debits: 0, net: 0 };
     const added = filteredTransactions
       .filter((tx: any) => tx.type === 'credit')
-      .reduce((sum: number, tx: any) => sum + (tx.credits_amount ?? Math.abs(parseFloat(tx.amount)) * creditsPerDollar), 0);
+      .reduce((sum: number, tx: any) => sum + (tx.credits_amount ?? Math.abs(parseFloat(tx.amount))), 0);
     const used = filteredTransactions
       .filter((tx: any) => tx.type === 'debit')
-      .reduce((sum: number, tx: any) => sum + (tx.credits_amount ?? Math.abs(parseFloat(tx.amount)) * creditsPerDollar), 0);
+      .reduce((sum: number, tx: any) => sum + (tx.credits_amount ?? Math.abs(parseFloat(tx.amount))), 0);
     return { credits: added, debits: used, net: added - used };
   }, [filteredTransactions, creditsPerDollar]);
 
@@ -88,10 +88,10 @@ export const TransactionHistory: React.FC = () => {
   const isLLMUsage = (tx: any) => tx.source === 'llm_usage' || tx.reference_type === 'llm_usage';
 
   const getCreditsAmount = (tx: any): number =>
-    tx.credits_amount ?? Math.abs(parseFloat(tx.amount || '0')) * creditsPerDollar;
+    tx.credits_amount ?? Math.abs(parseFloat(tx.amount || '0'));
 
   const getCreditsBalance = (tx: any): number | null =>
-    tx.credits_balance_after ?? (tx.balance_after != null ? parseFloat(tx.balance_after) * creditsPerDollar : null);
+    tx.credits_balance_after ?? (tx.balance_after != null ? parseFloat(tx.balance_after) : null);
 
   if (isLoading) return <LoadingSpinner size="md" message="Loading transaction history..." />;
 


### PR DESCRIPTION
…x date filter

Transaction history rendered the credit-denominated ledger as USD: the detail modal labeled credits with '$' and the list multiplied amounts by creditsPerDollar (~24x inflation). Both now show raw credits ('cr'), matching the wallet card and ledger.

Also fixes the time-range filter, which was silently ignored end-to-end: the component sent startDate/endDate, the SDK typed from/to, and the backend reads fromDate/toDate. Now aligned: component from/to -> SDK maps to fromDate/toDate.