### PR TITLE
fix(import): robust Excel parser for email contacts (auto-hyperlink e…

### DIFF
--- a/web/src/components/conversations/ImportLeadsDialog.tsx
+++ b/web/src/components/conversations/ImportLeadsDialog.tsx
@@ -226,6 +226,8 @@ export function ImportLeadsDialog({ open, onOpenChange, onImportComplete, channe
   } | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const excelInputRef = useRef<HTMLInputElement>(null);
+  // Feedback for the Excel-upload parser (empty = no problem).
+  const [excelError, setExcelError] = useState<string>('');
   const [broadcastName, setBroadcastName] = useState('');
   const [showBroadcastPrompt, setShowBroadcastPrompt] = useState(false);
   const [showAddToGroupPrompt, setShowAddToGroupPrompt] = useState(false);
@@ -456,55 +458,95 @@ export function ImportLeadsDialog({ open, onOpenChange, onImportComplete, channe
         await workbook.xlsx.load(buffer);
         const worksheet = workbook.worksheets[0];
 
-        if (!worksheet || !worksheet.rowCount || worksheet.rowCount < 2) return;
+        setExcelError('');
+        if (!worksheet || !worksheet.rowCount || worksheet.rowCount < 2) {
+          setExcelError('That sheet has no data rows. Add contacts below the header row and re-upload.');
+          return;
+        }
 
-        // Parse header
-        const headerRow = worksheet.getRow(1);
-        const headers = headerRow.values
-          ?.map((h) => String(h || '').trim().toLowerCase().replace(/['"]/g, ''))
-          .filter((h) => h) || [];
+        // Normalise any cell value to a trimmed string. Excel auto-converts
+        // emails/URLs to hyperlinks, so exceljs returns objects like
+        // { text, hyperlink } (also richText / formula { result }) — a plain
+        // String() on those yields "[object Object]", which is why email
+        // uploads were silently dropped. Unwrap them here.
+        const cellText = (v: unknown): string => {
+          if (v == null) return '';
+          if (typeof v === 'object') {
+            const o = v as Record<string, unknown>;
+            const rt = Array.isArray(o.richText)
+              ? (o.richText as { text?: string }[]).map((r) => r.text ?? '').join('')
+              : undefined;
+            return String(o.text ?? rt ?? o.result ?? o.hyperlink ?? '').trim();
+          }
+          return String(v).trim();
+        };
+        const norm = (v: unknown) => cellText(v).toLowerCase().replace(/['"]/g, '');
 
-        const nameIdx = headers.findIndex((h) => h === 'name' || h === 'full name' || h === 'fullname');
-        const phoneIdx = headers.findIndex((h) => h === 'phone' || h === 'whatsapp' || h === 'mobile' || h === 'phone number');
-        const emailIdx = headers.findIndex((h) => h === 'email' || h === 'email address');
-        const companyIdx = headers.findIndex((h) => h === 'company' || h === 'organization' || h === 'org');
-        const linkedinIdx = headers.findIndex((h) => h === 'linkedin' || h === 'linkedin_url' || h === 'linkedin url');
-        const instagramIdx = headers.findIndex((h) => h === 'instagram' || h === 'instagram_url' || h === 'instagram url');
-        const sourceIdx = headers.findIndex((h) => h === 'source');
+        // Build header → 1-based column-number map (gap-safe; never compacted).
+        const col: Record<string, number> = {};
+        worksheet.getRow(1).eachCell({ includeEmpty: false }, (cell, colNumber) => {
+          const h = norm(cell.value);
+          if (h && !(h in col)) col[h] = colNumber;
+        });
+        const pick = (...names: string[]) => {
+          for (const n of names) if (col[n]) return col[n];
+          return 0;
+        };
+        const nameCol      = pick('name', 'full name', 'fullname', 'contact name');
+        const phoneCol     = pick('phone', 'whatsapp', 'mobile', 'phone number');
+        const emailCol     = pick('email', 'email address', 'e-mail');
+        const companyCol   = pick('company', 'organization', 'org');
+        const linkedinCol  = pick('linkedin', 'linkedin_url', 'linkedin url');
+        const instagramCol = pick('instagram', 'instagram_url', 'instagram url');
+        const sourceCol    = pick('source');
+
+        if (!nameCol) {
+          setExcelError('No "name" column found in the header row. Use Download Template to see the expected columns.');
+          return;
+        }
+
+        const readCell = (row: ReturnType<typeof worksheet.getRow>, c: number) =>
+          c ? cellText(row.getCell(c).value) : '';
 
         const parsedLeads: LeadEntry[] = [];
         for (let i = 2; i <= worksheet.rowCount; i++) {
           const row = worksheet.getRow(i);
-          const cells = row.values || [];
-          const name = nameIdx >= 0 ? String(cells[nameIdx + 1] || '').trim() : '';
+          const name = readCell(row, nameCol);
           if (!name) continue;
-
           parsedLeads.push({
             id: crypto.randomUUID(),
             name,
-            phone: phoneIdx >= 0 ? String(cells[phoneIdx + 1] || '').trim() : '',
-            email: emailIdx >= 0 ? String(cells[emailIdx + 1] || '').trim() : '',
-            company: companyIdx >= 0 ? String(cells[companyIdx + 1] || '').trim() : '',
-            linkedin_url: linkedinIdx >= 0 ? String(cells[linkedinIdx + 1] || '').trim() : '',
-            instagram_url: instagramIdx >= 0 ? String(cells[instagramIdx + 1] || '').trim() : '',
-            source: sourceIdx >= 0 ? String(cells[sourceIdx + 1] || '').trim() : 'excel_import',
+            phone: readCell(row, phoneCol),
+            email: readCell(row, emailCol),
+            company: readCell(row, companyCol),
+            linkedin_url: readCell(row, linkedinCol),
+            instagram_url: readCell(row, instagramCol),
+            source: readCell(row, sourceCol) || 'excel_import',
           });
         }
 
-        if (parsedLeads.length > 0) {
-          setLeads(parsedLeads);
-          setSelectedIds(new Set());
-          setActiveTab('single');
+        if (parsedLeads.length === 0) {
+          setExcelError('No rows with a name were found.');
+          return;
         }
+        // Email groups need an email per contact — surface it early rather
+        // than silently importing 0.
+        if (isEmailMode && !parsedLeads.some((l) => l.email.trim())) {
+          setExcelError('None of the rows have an email address — email groups need an "email" column.');
+        }
+        setLeads(parsedLeads);
+        setSelectedIds(new Set());
+        setActiveTab('single');
       } catch (err) {
         console.error('Failed to parse Excel file:', err);
+        setExcelError('Could not read that file. Make sure it is a valid .xlsx export.');
       }
     };
     reader.readAsArrayBuffer(file);
 
     // Reset input
     if (excelInputRef.current) excelInputRef.current.value = '';
-  }, []);
+  }, [isEmailMode]);
 
   // Download template
   const downloadTemplate = useCallback(async () => {
@@ -865,8 +907,17 @@ export function ImportLeadsDialog({ open, onOpenChange, onImportComplete, channe
               <Upload className="h-10 w-10 mx-auto mb-3 text-muted-foreground" />
               <p className="text-sm font-medium mb-1">Upload Excel file (.xlsx)</p>
               <p className="text-xs text-muted-foreground mb-4">
-                Required: <span className="font-medium">name</span>. Optional: phone, email, company, linkedin, instagram, source
+                {isEmailMode ? (
+                  <>Required: <span className="font-medium">name</span>, <span className="font-medium">email</span>. Optional: company, phone, source</>
+                ) : (
+                  <>Required: <span className="font-medium">name</span>. Optional: phone, email, company, linkedin, instagram, source</>
+                )}
               </p>
+              {excelError && (
+                <p className="text-xs text-red-600 bg-red-50 border border-red-200 rounded-lg p-2.5 mb-4 text-left">
+                  {excelError}
+                </p>
+              )}
               <div className="flex gap-2 justify-center">
                 <Button
                   variant="outline"


### PR DESCRIPTION
…mails)

Excel Upload silently imported 0 contacts. Three causes:
- Excel auto-converts email/URL cells to hyperlink objects, so exceljs returns { text, hyperlink } (or richText/formula) — the old String(cell) produced "[object Object]", so every email failed validation and email groups (which require an email) ended up with 0 valid contacts.
- The header array was compacted with .filter(), misaligning columns to cells whenever any header cell was blank.
- Parse failures were silent (no error), so it just looked broken.

Rewrite: unwrap hyperlink/richText/formula cell values; build a gap-safe header→column-number map via eachCell; surface a clear error when the sheet has no data rows, no name column, no named rows, or (email groups) no email. Also correct the hint — email groups require name + email, not just name.