### PR TITLE
fix(templates): stop nulling body_html on save (images vanishing)

### DIFF
--- a/web/src/components/templates/EmailTemplateEditor.tsx
+++ b/web/src/components/templates/EmailTemplateEditor.tsx
@@ -292,7 +292,13 @@ export default function EmailTemplateEditor({ mode, initialTemplate }: EmailTemp
     try {
       const url    = mode === 'create' ? '/api/campaigns/email-templates' : `/api/campaigns/email-templates/${template.id}`;
       const method = mode === 'create' ? 'POST' : 'PUT';
-      const isHtmlMode = editorMode === 'html' || editorMode === 'dragdrop';
+      // Preserve rich HTML whenever it exists — do NOT null body_html just
+      // because the "Simple editor" tab happens to be active at save time.
+      // Nulling it here silently destroyed the whole designed template
+      // (header banner, uploaded images, signature), which is why images kept
+      // "disappearing" and had to be re-uploaded for every broadcast. Only
+      // save as plain_text when there is genuinely no HTML body.
+      const hasRichHtml = (template.body_html || '').trim().length > 0;
 
       const res = await fetch(url, {
         method,
@@ -301,11 +307,11 @@ export default function EmailTemplateEditor({ mode, initialTemplate }: EmailTemp
         body: JSON.stringify({
           name:           template.name,
           subject:        template.subject,
-          body:           isHtmlMode
+          body:           hasRichHtml
                             ? (template.body || (template.body_html || '').replace(/<[^>]*>/g, '').trim())
                             : template.body,
-          body_html:      isHtmlMode ? (template.body_html || null) : null,
-          content_format: isHtmlMode ? 'html' : 'plain_text',
+          body_html:      hasRichHtml ? template.body_html : null,
+          content_format: hasRichHtml ? 'html' : 'plain_text',
           category:       template.category,
           description:    template.description,
           is_active:      template.is_active,


### PR DESCRIPTION
Saving a template while the "Simple editor" tab was active sent body_html: null + content_format: plain_text, silently wiping the entire designed template — header banner, uploaded images, signature — because the save keyed off the currently-active tab rather than whether HTML content exists. Users saw their images "deleted" and had to re-upload for every broadcast (the GCS objects were fine and permanent; the template just lost the <img> references).

Base the saved format on whether body_html actually has content (hasRichHtml), not on editorMode. Only persist plain_text when there is genuinely no HTML body, so a stray click on the Simple tab can no longer destroy a designed template.