### PR TITLE
feat(lad-monitor): R4 Migrations tab — per-tenant drift matrix

### DIFF
--- a/sdk/features/lad-monitor/api.ts
+++ b/sdk/features/lad-monitor/api.ts
@@ -16,6 +16,7 @@ import type {
   SahCostData,
   TaskHealth,
   LlmCostData,
+  MigrationStatusData,
 } from './types';
 
 const BASE = '/api/admin/monitor';
@@ -105,4 +106,9 @@ export async function getLlmCost(params?: { days?: number }): Promise<LlmCostDat
     `${BASE}/llm-cost${qs({ days: params?.days })}`
   );
   return res.data.data;
+}
+
+export async function getMigrationStatus(): Promise<MigrationStatusData> {
+  const res = await apiGet<{ success: boolean; data: MigrationStatusData }>(`${BASE}/migrations`);
+  return res.data;
 }

--- a/sdk/features/lad-monitor/hooks/useMigrationStatus.ts
+++ b/sdk/features/lad-monitor/hooks/useMigrationStatus.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getMigrationStatus } from '../api';
+import type { MigrationStatusData } from '../types';
+
+/** R4 — read-only per-tenant migration drift matrix. */
+export function useMigrationStatus() {
+  const [data, setData] = useState<MigrationStatusData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const fetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setData(await getMigrationStatus());
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to load migration status'));
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetch();
+  }, [fetch]);
+
+  return { data, loading, error, refetch: fetch };
+}

--- a/sdk/features/lad-monitor/index.ts
+++ b/sdk/features/lad-monitor/index.ts
@@ -19,6 +19,7 @@ export {
   recomputeSah,
   getTaskHealth,
   getLlmCost,
+  getMigrationStatus,
 } from './api';
 
 // Hooks
@@ -30,3 +31,4 @@ export { useCronHealth } from './hooks/useCronHealth';
 export { useCostPerSah } from './hooks/useCostPerSah';
 export { useTaskHealth } from './hooks/useTaskHealth';
 export { useLlmCost } from './hooks/useLlmCost';
+export { useMigrationStatus } from './hooks/useMigrationStatus';

--- a/sdk/features/lad-monitor/types.ts
+++ b/sdk/features/lad-monitor/types.ts
@@ -358,3 +358,36 @@ export interface LlmCostData {
   range: { days: number };
   generatedAt: string;
 }
+
+// ── R4 migration status (per-tenant migration runner) ───────────────────────
+export interface MigrationManifestEntry {
+  id: string;
+  class: 'core' | 'tenant';
+  description: string;
+}
+
+export interface MigrationTargetStatus {
+  target: string; // 'core' or a tenant_id
+  name: string;
+  schema: string;
+  status: 'current' | 'behind' | 'schema_absent' | 'unreachable';
+  schemaExists: boolean | null;
+  applied: string[];
+  missing: string[];
+  ledgerPresent: boolean;
+  ledgerVersions: string[];
+}
+
+export interface MigrationStatusData {
+  env: { coreSchema: string; tenantSchema: string };
+  manifest: MigrationManifestEntry[];
+  core: MigrationTargetStatus;
+  tenants: MigrationTargetStatus[];
+  summary: {
+    tenantsChecked: number;
+    byStatus: Record<string, number>;
+    tenantsBehind: number;
+    coreStatus: string;
+    ledgerAdoption: number;
+  };
+}

--- a/web/src/app/admin/monitor/layout.tsx
+++ b/web/src/app/admin/monitor/layout.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { ShieldAlert, LayoutDashboard, Building2, ScrollText, Clock, Target, ListChecks, Sparkles } from 'lucide-react';
+import { ShieldAlert, LayoutDashboard, Building2, ScrollText, Clock, Target, ListChecks, Sparkles, Database } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 
 // Client-side gate for UX only — the real enforcement is server-side
@@ -18,6 +18,7 @@ const TABS = [
   { href: '/admin/monitor/llm-cost', label: 'LLM Spend', icon: Sparkles, exact: false },
   { href: '/admin/monitor/crons', label: 'Crons', icon: Clock, exact: false },
   { href: '/admin/monitor/tasks', label: 'Tasks', icon: ListChecks, exact: false },
+  { href: '/admin/monitor/migrations', label: 'Migrations', icon: Database, exact: false },
   { href: '/admin/monitor/logs', label: 'Cloud Logs', icon: ScrollText, exact: false },
 ];
 

--- a/web/src/app/admin/monitor/migrations/page.tsx
+++ b/web/src/app/admin/monitor/migrations/page.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import React from 'react';
+import { Database, RefreshCw, CheckCircle2, AlertTriangle, HelpCircle, XCircle } from 'lucide-react';
+import { useMigrationStatus } from '@lad/frontend-features/lad-monitor';
+import { StatCard } from '../components/StatCard';
+
+const STATUS_STYLE: Record<string, { cls: string; Icon: typeof CheckCircle2; label: string }> = {
+  current: { cls: 'text-emerald-600 bg-emerald-50 dark:bg-emerald-950/30 dark:text-emerald-400', Icon: CheckCircle2, label: 'Current' },
+  behind: { cls: 'text-amber-600 bg-amber-50 dark:bg-amber-950/30 dark:text-amber-400', Icon: AlertTriangle, label: 'Behind' },
+  schema_absent: { cls: 'text-gray-500 bg-gray-100 dark:bg-gray-800 dark:text-gray-400', Icon: HelpCircle, label: 'No schema' },
+  unreachable: { cls: 'text-red-600 bg-red-50 dark:bg-red-950/30 dark:text-red-400', Icon: XCircle, label: 'Unreachable' },
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const s = STATUS_STYLE[status] || STATUS_STYLE.unreachable;
+  const { Icon } = s;
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${s.cls}`}>
+      <Icon className="h-3 w-3" />
+      {s.label}
+    </span>
+  );
+}
+
+export default function MonitorMigrationsPage() {
+  const { data, loading, error, refetch } = useMigrationStatus();
+  const s = data?.summary;
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Database className="h-4 w-4 text-gray-400" />
+          <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">Per-tenant migration status</h2>
+        </div>
+        <button
+          onClick={() => refetch()}
+          className="flex items-center gap-1.5 rounded-lg border border-gray-200 px-3 py-1.5 text-xs font-medium text-gray-600 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      {error ? (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/30 dark:text-red-300">
+          Failed to load migration status: {error.message}
+        </div>
+      ) : null}
+
+      {loading && !data ? (
+        <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-24 animate-pulse rounded-xl bg-gray-100 dark:bg-gray-800" />
+          ))}
+        </div>
+      ) : data && s ? (
+        <>
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            <StatCard title="Tenants checked" value={s.tenantsChecked} icon={Database} accent="text-blue-500" />
+            <StatCard title="Behind" value={s.tenantsBehind} icon={AlertTriangle} accent={s.tenantsBehind ? 'text-amber-500' : 'text-emerald-500'} />
+            <StatCard title="Ledger adoption" value={`${s.ledgerAdoption}/${s.tenantsChecked}`} icon={CheckCircle2} accent="text-indigo-500" />
+            <StatCard title="Core schema" value={s.coreStatus} icon={s.coreStatus === 'current' ? CheckCircle2 : AlertTriangle} accent={s.coreStatus === 'current' ? 'text-emerald-500' : 'text-amber-500'} />
+          </div>
+
+          <p className="mt-3 text-xs text-gray-500 dark:text-gray-400">
+            Env: core <code>{data.env.coreSchema}</code>, tenant <code>{data.env.tenantSchema}</code>. Applying migrations is an
+            API-only super-admin action (<code>POST /api/admin/monitor/migrations/run</code>, dry-run by default).
+          </p>
+
+          <div className="mt-4 overflow-x-auto rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900">
+            <table className="w-full min-w-[560px]">
+              <thead>
+                <tr className="border-b border-gray-200 text-left text-xs font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400">
+                  <th className="px-4 py-2">Target</th>
+                  <th className="px-4 py-2">Status</th>
+                  <th className="px-4 py-2">Missing</th>
+                  <th className="px-4 py-2">Ledger</th>
+                </tr>
+              </thead>
+              <tbody className="px-4">
+                <tr className="border-b border-gray-100 bg-gray-50/50 dark:border-gray-800 dark:bg-gray-800/30">
+                  <td className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200">{data.core.name}</td>
+                  <td className="px-4 py-2"><StatusBadge status={data.core.status} /></td>
+                  <td className="px-4 py-2 text-xs text-gray-500 dark:text-gray-400">{data.core.missing.join(', ') || '—'}</td>
+                  <td className="px-4 py-2 text-xs text-gray-500 dark:text-gray-400">{data.core.ledgerPresent ? `${data.core.ledgerVersions.length} recorded` : 'no ledger'}</td>
+                </tr>
+                {[...data.tenants].sort((a, b) => (a.status === b.status ? 0 : a.status === 'behind' ? -1 : 1)).map((t) => (
+                  <tr key={t.target} className="border-b border-gray-100 last:border-0 dark:border-gray-800">
+                    <td className="px-4 py-2 text-sm text-gray-900 dark:text-gray-100">{t.name}</td>
+                    <td className="px-4 py-2"><StatusBadge status={t.status} /></td>
+                    <td className="px-4 py-2 text-xs text-gray-500 dark:text-gray-400">{t.missing.length ? t.missing.join(', ') : <span className="text-emerald-500">—</span>}</td>
+                    <td className="px-4 py-2 text-xs">{t.ledgerPresent ? <span className="text-gray-500 dark:text-gray-400">{t.ledgerVersions.length} recorded</span> : <span className="text-amber-500">no ledger</span>}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
Frontend for **R4** (per-tenant migration runner; backend = LAD-Backend PR #305). Adds a super-admin **Migrations** tab to the lad-monitor console.

## What
- **SDK** (`sdk/features/lad-monitor`): `MigrationStatusData` types, `getMigrationStatus()` api fn, `useMigrationStatus` hook (read + refetch — copies the existing hook shape).
- **Web** (`/admin/monitor/migrations`): summary cards (tenants checked / behind / ledger adoption / core status) + a per-target table — status badge (current / behind / no-schema / unreachable), the missing-migration list, and ledger state. Core row pinned on top; behind tenants sorted first. Adds one `TABS` entry in `layout.tsx`.

## Read-only by design
Applying migrations stays an **API-only** super-admin action (`POST /api/admin/monitor/migrations/run`, dry-run by default) — deliberately not a one-click "migrate all tenants" web button. The tab inherits the console's super-admin gate + nav automatically.

## Verified
Typechecks clean (the only `tsc` errors are in a pre-existing `store.backup/` folder, unrelated). Backend live-verified: 31 tenants, currently all `current`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)