### PR TITLE
feat: LinkedIn withdrawal UI + connection-aware, channel-scoped Chat Settings

### DIFF
--- a/sdk/features/campaigns/api.ts
+++ b/sdk/features/campaigns/api.ts
@@ -548,6 +548,40 @@ export async function retryConnection(
   return response.data;
 }
 
+/**
+ * Withdraw a still-PENDING LinkedIn connection request for a single lead.
+ * Used by the Live Activity Feed "Withdraw" button, alongside "Retry".
+ *
+ * `campaignLeadId` matches the id the feed already uses for a row (the core
+ * lead id from campaign_analytics.lead_id, which the backend also accepts as
+ * campaign_leads.id). `campaignId` is passed through for precise scoping.
+ *
+ * Backend guarantees it only ever retracts a pending sent invite — an accepted
+ * connection is never in the pending list, so it can't be touched. When nothing
+ * is pending it returns `{ withdrawn: false, reason: 'no_pending_invite' }`
+ * rather than erroring.
+ */
+export interface WithdrawConnectionResult {
+  success: boolean;
+  withdrawn: boolean;
+  reason?: string | null;
+  invitationId?: string | null;
+  alreadyGone?: boolean;
+  status?: string | null;
+  error?: string | null;
+}
+
+export async function withdrawConnection(
+  campaignLeadId: string,
+  campaignId?: string
+): Promise<WithdrawConnectionResult> {
+  const response = await apiClient.post<WithdrawConnectionResult>(
+    `/api/social-integration/linkedin/connection-request/${campaignLeadId}/withdraw`,
+    campaignId ? { campaignId } : {}
+  );
+  return response.data;
+}
+
 // ====================
 // Inbound Leads Functions
 // ====================

--- a/sdk/features/campaigns/index.ts
+++ b/sdk/features/campaigns/index.ts
@@ -42,10 +42,12 @@ export {
   revealLeadPhone,
   revealLeadLinkedIn,
   retryConnection,
+  withdrawConnection,
   saveInboundLeads,
   getInboundLeads,
   cancelLeadBookingsForReNurturing,
 } from './api';
+export type { WithdrawConnectionResult } from './api';
 
 // ============================================================================
 // HOOKS

--- a/web/src/components/campaigns/LiveActivityTable.tsx
+++ b/web/src/components/campaigns/LiveActivityTable.tsx
@@ -15,11 +15,12 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import {
   Download, Filter, Loader2, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight,
   ExternalLink, ChevronDown, ChevronUp, Sparkles, Globe, Newspaper, Mic, Award, FileText, Users, MessageSquare,
-  RotateCw, CheckCircle2, AlertCircle, ArrowUpDown,
+  RotateCw, CheckCircle2, AlertCircle, ArrowUpDown, XCircle, Ban,
 } from 'lucide-react';
 import Link from 'next/link';
 import { format } from 'date-fns';
-import { useCampaignActivityFeed, retryConnection } from '@lad/frontend-features/campaigns';
+import { useCampaignActivityFeed, retryConnection, withdrawConnection } from '@lad/frontend-features/campaigns';
+import { useToast } from '@/components/ui/use-toast';
 import { apiGet } from '@/lib/api';
 import { MiniStepper } from './MiniStepper';
 import { StatusStepper, type WorkflowStep } from './StatusStepper';
@@ -343,9 +344,18 @@ export const LiveActivityTable: React.FC<LiveActivityTableProps> = ({
   // Tracks which lead's "Agent Insights" panel is open (one at a time)
   const [expandedLeadId, setExpandedLeadId] = useState<string | null>(null);
 
+  const { toast } = useToast();
+
   // Retry-state per lead — leadId → { status, message? }
   // Drives the small status pill that appears next to the Retry button.
   const [retryState, setRetryState] = useState<Record<string, {
+    status: 'pending' | 'success' | 'failed';
+    message?: string;
+  }>>({});
+
+  // Withdraw-state per lead — leadId → { status, message? }
+  // Drives the small status pill next to the Withdraw button (mirrors retry).
+  const [withdrawState, setWithdrawState] = useState<Record<string, {
     status: 'pending' | 'success' | 'failed';
     message?: string;
   }>>({});
@@ -496,6 +506,59 @@ export const LiveActivityTable: React.FC<LiveActivityTableProps> = ({
     }
   };
 
+  /**
+   * Withdraw a still-pending LinkedIn connection request for a single lead.
+   * Confirms first, then calls the withdraw endpoint. A `no_pending_invite`
+   * response (nothing to retract — already accepted/withdrawn) is surfaced as a
+   * friendly toast rather than an error.
+   */
+  const handleWithdraw = async (leadId: string) => {
+    if (!leadId || withdrawState[leadId]?.status === 'pending') return;
+    if (typeof window !== 'undefined' &&
+        !window.confirm('Withdraw this connection request?')) {
+      return;
+    }
+    setWithdrawState((prev) => ({ ...prev, [leadId]: { status: 'pending' } }));
+    try {
+      const result = await withdrawConnection(leadId, campaignId);
+      if (result.success && result.withdrawn) {
+        setWithdrawState((prev) => ({
+          ...prev,
+          [leadId]: { status: 'success', message: 'Connection request withdrawn' },
+        }));
+        // Pull the freshly-inserted CONNECTION_WITHDRAWN row into the feed.
+        setTimeout(() => refresh(), 500);
+      } else if (result.reason === 'no_pending_invite') {
+        // Nothing to do — invite already accepted, withdrawn, or never pending.
+        setWithdrawState((prev) => {
+          const next = { ...prev };
+          delete next[leadId];
+          return next;
+        });
+        toast({
+          title: 'No pending request to withdraw',
+          description: 'This connection request is no longer pending.',
+        });
+      } else {
+        setWithdrawState((prev) => ({
+          ...prev,
+          [leadId]: {
+            status: 'failed',
+            message: result.error || 'Withdrawal failed',
+          },
+        }));
+      }
+    } catch (err: any) {
+      setWithdrawState((prev) => ({
+        ...prev,
+        [leadId]: {
+          status: 'failed',
+          message: err?.message || 'Withdrawal failed',
+        },
+      }));
+    }
+  };
+
   // Group activities by lead
   const groupedLeads = useMemo(() => {
     if (!activities || activities.length === 0) return [];
@@ -518,6 +581,7 @@ export const LiveActivityTable: React.FC<LiveActivityTableProps> = ({
           connectionStatus: 'NOT_SENT' as const,
           connectionSentWithMessage: false,
           connectionAccepted: false,
+          connectionWithdrawn: false,   // tracks CONNECTION_WITHDRAWN
           contacted: false,
           contactedStatus: undefined,
           callMade: false,          // tracks VOICE_CALL_MADE / VOICE_CALL_INITIATED
@@ -577,7 +641,12 @@ export const LiveActivityTable: React.FC<LiveActivityTableProps> = ({
         }
       }
 
-      if (actionType.includes('CONNECTION')) {
+      if (actionType.includes('CONNECTION') && actionType.includes('WITHDRAW')) {
+        // A withdrawn request is terminal for the connect step — mark it and
+        // skip the SENT/ACCEPT handling below so the row reads "Withdrawn".
+        lead.connectionWithdrawn = true;
+        lead.connectionStatus = 'WITHDRAWN';
+      } else if (actionType.includes('CONNECTION')) {
         // Capture the personalization source — which post/article URL the agent
         // used as the hook. Only present on CONNECTION_SENT_WITH_MESSAGE rows.
         if (
@@ -1085,6 +1154,69 @@ export const LiveActivityTable: React.FC<LiveActivityTableProps> = ({
                                   </TooltipTrigger>
                                   <TooltipContent side="bottom" className="max-w-[260px]">
                                     {rs.message}
+                                  </TooltipContent>
+                                </Tooltip>
+                              </TooltipProvider>
+                            )}
+                          </div>
+                        );
+                      })()}
+                      {/* Withdraw button — appears when this lead has a still-pending
+                          sent connection request (SENT and not accepted/replied/
+                          already withdrawn). Retracts the LinkedIn invitation. */}
+                      {(() => {
+                        const ws = withdrawState[lead.leadId];
+                        const isPendingSent =
+                          lead.connectionStatus === 'SENT' &&
+                          !lead.connectionAccepted &&
+                          !lead.leadReplied &&
+                          !lead.connectionWithdrawn;
+                        // Keep showing once withdrawn (so the success pill lingers).
+                        if (!isPendingSent && ws?.status !== 'success') return null;
+
+                        const isPending = ws?.status === 'pending';
+                        const isSuccess = ws?.status === 'success';
+                        const isFailed  = ws?.status === 'failed';
+
+                        return (
+                          <div className="flex items-center gap-1.5">
+                            <button
+                              type="button"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleWithdraw(lead.leadId);
+                              }}
+                              disabled={isPending || isSuccess}
+                              title={
+                                isSuccess
+                                  ? 'Connection request withdrawn'
+                                  : isPending
+                                  ? 'Withdrawing…'
+                                  : 'Withdraw this pending connection request'
+                              }
+                              className={`inline-flex items-center gap-1 px-2 py-0.5 text-[11px] rounded border transition-colors ${
+                                isSuccess
+                                  ? 'bg-slate-100 text-slate-600 border-slate-200 cursor-default'
+                                  : isPending
+                                  ? 'bg-slate-100 text-slate-500 border-slate-200 cursor-wait'
+                                  : 'bg-amber-50 text-amber-700 border-amber-200 hover:bg-amber-100'
+                              }`}
+                            >
+                              {isPending && <Loader2 className="w-3 h-3 animate-spin" />}
+                              {isSuccess && <XCircle className="w-3 h-3" />}
+                              {!isPending && !isSuccess && <Ban className="w-3 h-3" />}
+                              {isSuccess ? 'Withdrawn' : isPending ? 'Withdrawing…' : 'Withdraw'}
+                            </button>
+                            {isFailed && ws?.message && (
+                              <TooltipProvider>
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <span className="text-red-500">
+                                      <AlertCircle className="w-3 h-3" />
+                                    </span>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="bottom" className="max-w-[260px]">
+                                    {ws.message}
                                   </TooltipContent>
                                 </Tooltip>
                               </TooltipProvider>

--- a/web/src/components/settings/ChatSettings.tsx
+++ b/web/src/components/settings/ChatSettings.tsx
@@ -25,6 +25,7 @@ import {
   X,
   Send,
   Sparkles,
+  UserMinus,
 } from 'lucide-react';
 import KnowledgeBaseManager from './KnowledgeBaseManager';
 import dynamic from 'next/dynamic';
@@ -444,10 +445,14 @@ export function ChatSettings() {
     auto_like_posts: boolean;
     auto_comment_posts: boolean;
     ai_agent_reply_delay_seconds: number;
+    auto_withdraw_pending_enabled: boolean;
+    auto_withdraw_pending_days: number;
   }>({
     auto_like_posts: false,
     auto_comment_posts: false,
     ai_agent_reply_delay_seconds: 0,
+    auto_withdraw_pending_enabled: false,
+    auto_withdraw_pending_days: 90,
   });
   const [savingLinkedinAutomation, setSavingLinkedinAutomation] = useState(false);
 
@@ -481,10 +486,13 @@ export function ChatSettings() {
         setFollowupConfig(f);
         if (liSettings?.success && liSettings.data) {
           const rawDelay = Number(liSettings.data.ai_agent_reply_delay_seconds);
+          const rawWithdrawDays = Number(liSettings.data.auto_withdraw_pending_days);
           setLinkedinAutomation({
             auto_like_posts:              !!liSettings.data.auto_like_posts,
             auto_comment_posts:           !!liSettings.data.auto_comment_posts,
             ai_agent_reply_delay_seconds: Number.isFinite(rawDelay) ? Math.max(0, Math.min(300, rawDelay)) : 0,
+            auto_withdraw_pending_enabled: !!liSettings.data.auto_withdraw_pending_enabled,
+            auto_withdraw_pending_days:   Number.isFinite(rawWithdrawDays) ? Math.max(30, rawWithdrawDays) : 90,
           });
         }
         if (liFollowup?.success && liFollowup.data) {
@@ -716,13 +724,26 @@ export function ChatSettings() {
 
   const handleSaveLinkedinAutomation = useCallback(async () => {
     setSavingLinkedinAutomation(true);
+    // Floor the withdraw window at 30 days (backend clamps too) so a stray small
+    // value can never retract fresh invitations. Reflect the clamp in the UI.
+    const cleanDays = Math.max(30, Math.floor(Number(linkedinAutomation.auto_withdraw_pending_days) || 90));
+    const payload = { ...linkedinAutomation, auto_withdraw_pending_days: cleanDays };
     try {
       const res = await fetch('/api/social-integration/linkedin/automation-settings', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(linkedinAutomation),
+        body: JSON.stringify(payload),
       });
       const data = await res.json();
+      if (data.success && data.data) {
+        setLinkedinAutomation((prev) => ({
+          ...prev,
+          auto_withdraw_pending_enabled: !!data.data.auto_withdraw_pending_enabled,
+          auto_withdraw_pending_days: Number.isFinite(Number(data.data.auto_withdraw_pending_days))
+            ? Math.max(30, Number(data.data.auto_withdraw_pending_days))
+            : cleanDays,
+        }));
+      }
       showToast(data.success ? 'LinkedIn automation settings saved' : 'Failed to save', data.success ? 'success' : 'error');
     } catch {
       showToast('Failed to save', 'error');
@@ -2211,6 +2232,58 @@ export function ChatSettings() {
                   className="w-20 px-2 py-1.5 border border-gray-200 rounded-md text-sm text-right focus:outline-none focus:ring-2 focus:ring-blue-200"
                 />
                 <span className="text-xs text-gray-500 w-8">sec</span>
+              </div>
+            </div>
+
+            {/* Auto-withdraw old pending connection requests */}
+            <div className="flex items-center justify-between px-4 py-3">
+              <div className="flex items-center gap-2.5">
+                <UserMinus className="h-4 w-4 text-blue-500 flex-shrink-0" />
+                <div>
+                  <p className="text-sm font-medium text-gray-800">Auto-withdraw old pending requests</p>
+                  <p className="text-xs text-gray-500">
+                    Withdraw connection requests that are still pending after the set number of days (minimum 30)
+                  </p>
+                </div>
+              </div>
+              <div className="flex items-center gap-3">
+                <div className={`flex items-center gap-1.5 ${linkedinAutomation.auto_withdraw_pending_enabled ? '' : 'opacity-40'}`}>
+                  <span className="text-xs text-gray-500">older than</span>
+                  <input
+                    type="number"
+                    min={30}
+                    step={1}
+                    value={linkedinAutomation.auto_withdraw_pending_days}
+                    disabled={!linkedinAutomation.auto_withdraw_pending_enabled}
+                    onChange={(e) => {
+                      const v = parseInt(e.target.value, 10);
+                      setLinkedinAutomation((prev) => ({
+                        ...prev,
+                        auto_withdraw_pending_days: Number.isFinite(v) ? v : 0,
+                      }));
+                    }}
+                    onBlur={() =>
+                      setLinkedinAutomation((prev) => ({
+                        ...prev,
+                        auto_withdraw_pending_days: Math.max(30, Math.floor(Number(prev.auto_withdraw_pending_days) || 90)),
+                      }))
+                    }
+                    className="w-16 px-2 py-1.5 border border-gray-200 rounded-md text-sm text-right focus:outline-none focus:ring-2 focus:ring-blue-200 disabled:bg-gray-100"
+                  />
+                  <span className="text-xs text-gray-500">days</span>
+                </div>
+                <button
+                  onClick={() =>
+                    setLinkedinAutomation((prev) => ({ ...prev, auto_withdraw_pending_enabled: !prev.auto_withdraw_pending_enabled }))
+                  }
+                  title={linkedinAutomation.auto_withdraw_pending_enabled ? 'On — click to disable' : 'Off — click to enable'}
+                >
+                  {linkedinAutomation.auto_withdraw_pending_enabled ? (
+                    <ToggleRight className="h-6 w-6 text-blue-500" />
+                  ) : (
+                    <ToggleLeft className="h-6 w-6 text-gray-300" />
+                  )}
+                </button>
               </div>
             </div>
           </div>

--- a/web/src/components/settings/ChatSettings.tsx
+++ b/web/src/components/settings/ChatSettings.tsx
@@ -26,7 +26,10 @@ import {
   Send,
   Sparkles,
   UserMinus,
+  EyeOff,
 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useConnectedChannels, type ChannelId } from '@/hooks/useConnectedChannels';
 import KnowledgeBaseManager from './KnowledgeBaseManager';
 import dynamic from 'next/dynamic';
 import { fetchWithTenant } from '@/lib/fetch-with-tenant';
@@ -387,6 +390,26 @@ export function ChatSettings() {
   const [loading, setLoading] = useState(true);
   const [activeChannel, setActiveChannel] = useState('waba');
   const [expandedPrompt, setExpandedPrompt] = useState<string | null>(null);
+
+  // ── Connection-aware visibility ─────────────────────────────────────────
+  // Only connected channels get their settings shown; a channel that is
+  // positively NOT connected is hidden (tabs, typing rows, LinkedIn cards).
+  // Nothing is deleted — reconnecting brings the settings back with their
+  // saved values, because visibility is derived from live status per mount.
+  // Fail-open: while probing (or if a probe errors) the channel stays visible.
+  const router = useRouter();
+  const { loaded: channelsLoaded, isVisible: isChannelVisible } = useConnectedChannels();
+  const visibleChannels = CHANNELS.filter((c) => isChannelVisible(c.id as ChannelId));
+  const hiddenChannels = CHANNELS.filter((c) => !isChannelVisible(c.id as ChannelId));
+  const visibleIds = visibleChannels.map((c) => c.id).join(',');
+  // If the active tab's channel just got hidden, snap to the first visible one.
+  useEffect(() => {
+    if (!channelsLoaded) return;
+    const ids = visibleIds ? visibleIds.split(',') : [];
+    if (ids.length > 0 && !ids.includes(activeChannel)) {
+      setActiveChannel(ids[0]);
+    }
+  }, [channelsLoaded, visibleIds, activeChannel]);
   const [editedTexts, setEditedTexts] = useState<Record<string, string>>({});
   const [savingPrompt, setSavingPrompt] = useState<string | null>(null);
   const [savingSettings, setSavingSettings] = useState(false);
@@ -933,10 +956,11 @@ export function ChatSettings() {
           </p>
         </div>
 
-        {/* Channel tabs */}
+        {/* Channel tabs — only connected channels; hidden ones collapse into
+            a "+N more" chip that jumps to the Integrations tab. */}
         <div className="border-b border-gray-100 overflow-x-auto hide-scrollbar">
-          <div className="flex gap-1 -mb-px px-6 min-w-max flex-nowrap">
-            {CHANNELS.map((ch) => (
+          <div className="flex items-center gap-1 -mb-px px-6 min-w-max flex-nowrap">
+            {visibleChannels.map((ch) => (
               <button
                 key={ch.id}
                 onClick={() => setActiveChannel(ch.id)}
@@ -950,10 +974,36 @@ export function ChatSettings() {
                 {ch.label}
               </button>
             ))}
+            {hiddenChannels.length > 0 && (
+              <button
+                onClick={() => router.push('/settings?tab=integrations')}
+                title={`Not connected: ${hiddenChannels.map((c) => c.label).join(', ')}. Connect to configure.`}
+                className="flex items-center gap-1 px-3 py-1 my-1.5 text-xs text-gray-400 border border-dashed border-gray-300 rounded-full hover:text-gray-600 hover:border-gray-400 transition-colors whitespace-nowrap"
+              >
+                <Plus className="h-3 w-3" />
+                {hiddenChannels.length} more
+              </button>
+            )}
           </div>
         </div>
 
-        {/* Prompts list */}
+        {/* No channels connected at all — invite to connect instead of blank tabs */}
+        {channelsLoaded && visibleChannels.length === 0 && (
+          <div className="px-6 py-12 text-center text-gray-400">
+            <EyeOff className="h-8 w-8 mx-auto mb-2 opacity-40" />
+            <p className="text-sm text-gray-500">No channels connected</p>
+            <p className="text-xs mt-1 mb-4">Connect WhatsApp, LinkedIn, Gmail or Instagram to configure AI prompts</p>
+            <button
+              onClick={() => router.push('/settings?tab=integrations')}
+              className="text-sm font-medium text-blue-600 hover:text-blue-700"
+            >
+              Connect a channel →
+            </button>
+          </div>
+        )}
+
+        {/* Prompts list — hidden entirely when no channel is connected */}
+        {(!channelsLoaded || visibleChannels.length > 0) && (
         <div className="divide-y divide-gray-100">
           {filteredPrompts.length === 0 ? (
             <div className="px-6 py-12 text-center text-gray-400">
@@ -1049,8 +1099,10 @@ export function ChatSettings() {
             })
           )}
         </div>
+        )}
 
-        {/* Add new prompt */}
+        {/* Add new prompt — needs at least one connected channel */}
+        {(!channelsLoaded || visibleChannels.length > 0) && (
         <div className="px-6 py-3 border-t border-gray-100">
           {!showNewPrompt ? (
             <button
@@ -1078,7 +1130,7 @@ export function ChatSettings() {
                   onChange={(e) => setActiveChannel(e.target.value)}
                   className="flex-1 px-3 py-1.5 text-xs border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400 bg-white"
                 >
-                  {CHANNELS.map((ch) => (
+                  {visibleChannels.map((ch) => (
                     <option key={ch.id} value={ch.id}>{ch.label}</option>
                   ))}
                 </select>
@@ -1102,6 +1154,7 @@ export function ChatSettings() {
             </div>
           )}
         </div>
+        )}
       </div>
 
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
@@ -1670,6 +1723,9 @@ export function ChatSettings() {
       </div>
 
       {/* ── Section 3: Chat Behaviour ────────────────────────────── */}
+      {/* Both rows are WhatsApp-channel settings — hide the whole card when
+          neither WhatsApp flavour is connected. */}
+      {(isChannelVisible('personal_whatsapp') || isChannelVisible('waba')) && (
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
         <div className="p-6 border-b border-gray-100">
           <div className="flex items-center gap-2 mb-1">
@@ -1691,6 +1747,7 @@ export function ChatSettings() {
 
             <div className="space-y-3 border border-gray-100 rounded-lg divide-y divide-gray-100 overflow-hidden">
               {/* Personal WhatsApp row */}
+              {isChannelVisible('personal_whatsapp') && (
               <div className="flex items-center justify-between px-4 py-3">
                 <div className="flex items-center gap-2.5">
                   <span className="h-2 w-2 rounded-full bg-emerald-400 flex-shrink-0" />
@@ -1712,8 +1769,10 @@ export function ChatSettings() {
                   )}
                 </button>
               </div>
+              )}
 
               {/* WABA row */}
+              {isChannelVisible('waba') && (
               <div className="flex items-center justify-between px-4 py-3">
                 <div className="flex items-center gap-2.5">
                   <span className="h-2 w-2 rounded-full bg-green-500 flex-shrink-0" />
@@ -1735,6 +1794,7 @@ export function ChatSettings() {
                   )}
                 </button>
               </div>
+              )}
             </div>
           </div>
 
@@ -1750,6 +1810,7 @@ export function ChatSettings() {
           </div>
         </div>
       </div>
+      )}
 
       {/* ── Section 5: Campaign Settings ──────────────────────────── */}
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
@@ -2141,6 +2202,11 @@ export function ChatSettings() {
       </div>
 
       {/* ── Section 7: LinkedIn Automation ──────────────────────── */}
+      {/* Both LinkedIn cards (Automation + Follow-up Sequence) hide together
+          when LinkedIn isn't connected; saved values persist and the cards
+          reappear on reconnect. */}
+      {isChannelVisible('linkedin') && (
+      <>
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
         <div className="p-6 border-b border-gray-100">
           <div className="flex items-center gap-2 mb-1">
@@ -2424,6 +2490,29 @@ export function ChatSettings() {
           </div>
         </div>
       </div>
+      </>
+      )}
+
+      {/* ── Hidden channels hint ─────────────────────────────────── */}
+      {/* One quiet strip so hidden settings are discoverable — the settings
+          themselves are kept and reappear once the channel is reconnected. */}
+      {channelsLoaded && hiddenChannels.length > 0 && (
+        <div className="bg-white rounded-lg border border-gray-200 shadow-sm px-5 py-4 flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2.5 min-w-0">
+            <EyeOff className="h-4 w-4 text-gray-400 flex-shrink-0" />
+            <p className="text-sm text-gray-500">
+              {hiddenChannels.map((c) => c.label).join(', ')} settings are hidden because
+              {hiddenChannels.length === 1 ? " it isn't" : " they aren't"} connected. Your saved settings are kept.
+            </p>
+          </div>
+          <button
+            onClick={() => router.push('/settings?tab=integrations')}
+            className="text-sm font-medium text-blue-600 hover:text-blue-700 whitespace-nowrap"
+          >
+            Connect channels →
+          </button>
+        </div>
+      )}
 
       {/* Toast */}
       {toast && <Toast message={toast.message} type={toast.type} onClose={() => setToast(null)} />}

--- a/web/src/components/settings/ChatSettings.tsx
+++ b/web/src/components/settings/ChatSettings.tsx
@@ -2051,9 +2051,7 @@ export function ChatSettings() {
                           ),
                         }))
                       }
-                      className={`w-full pl-3 pr-10 py-2 text-sm border rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400 transition-all appearance-none ${
-                        !reminder.template_name ? 'border-red-300' : 'border-gray-200'
-                      }`}
+                      className="w-full pl-3 pr-10 py-2 text-sm border border-gray-200 rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400 transition-all appearance-none"
                       style={{
                         backgroundImage: `url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e")`,
                         backgroundPosition: 'right 0.5rem center',
@@ -2061,10 +2059,13 @@ export function ChatSettings() {
                         backgroundSize: '1.5em 1.5em'
                       }}
                     >
+                      {/* Empty value = AI-generated: the WABA service composes the
+                          reminder at send time (free-form inside the 24h window,
+                          generic approved-template fallback outside it). */}
                       <option value="">
                         {loadingTemplates
                           ? 'Loading templates…'
-                          : '— Pick a template (required) —'}
+                          : '— AI-generated (default) —'}
                       </option>
                       {approvedTemplates.map((t) => (
                         <option key={`${t.name}-${t.language}`} value={t.name}>
@@ -2116,7 +2117,9 @@ export function ChatSettings() {
             </button>
 
             <p className="text-xs text-gray-500">
-              All reminders need an APPROVED WhatsApp template — Meta blocks free-text replies outside the 24-hour conversation window.
+              AI-generated reminders send as personalised free-text while the customer&apos;s 24-hour
+              conversation window is open, and fall back to your approved follow-up template when it
+              isn&apos;t. Pick an approved template instead for guaranteed delivery regardless of the window.
               {followupConfig.booking_reminders.length >= 10 && (
                 <span className="block mt-1 text-amber-600">Maximum 10 reminders per booking.</span>
               )}

--- a/web/src/components/settings/ChatSettings.tsx
+++ b/web/src/components/settings/ChatSettings.tsx
@@ -412,7 +412,6 @@ export function ChatSettings() {
   }, [channelsLoaded, visibleIds, activeChannel]);
   const [editedTexts, setEditedTexts] = useState<Record<string, string>>({});
   const [savingPrompt, setSavingPrompt] = useState<string | null>(null);
-  const [savingSettings, setSavingSettings] = useState(false);
   const [savingKb, setSavingKb] = useState(false);
   const [toast, setToast] = useState<{ message: string; type: 'success' | 'error' } | null>(null);
 
@@ -726,15 +725,6 @@ export function ChatSettings() {
     showToast(allOk ? 'Chat behaviour saved' : 'Partially saved — check console', allOk ? 'success' : 'error');
     setSavingBehaviour(false);
   }, [chatSettings.typing_indicator, chatSettings.waba_typing_indicator, showToast]);
-
-  // ── Campaign Settings save ───────────────────────────────────
-
-  const handleSaveCampaign = useCallback(async () => {
-    setSavingSettings(true);
-    const ok = await updateChatSettings({ campaign_frequency: chatSettings.campaign_frequency });
-    showToast(ok ? 'Campaign settings saved' : 'Failed to save', ok ? 'success' : 'error');
-    setSavingSettings(false);
-  }, [chatSettings.campaign_frequency, showToast]);
 
   // ── Follow-up Timing save ────────────────────────────────────
 
@@ -1812,103 +1802,10 @@ export function ChatSettings() {
       </div>
       )}
 
-      {/* ── Section 5: Campaign Settings ──────────────────────────── */}
-      <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
-        <div className="p-6 border-b border-gray-100">
-          <div className="flex items-center gap-2 mb-1">
-            <Clock className="h-5 w-5 text-blue-600" />
-            <h2 className="text-lg font-semibold text-gray-900">Campaign Settings</h2>
-          </div>
-          <p className="text-sm text-gray-500">
-            Configure automated campaign frequency and limits.
-          </p>
-        </div>
-        <div className="p-6 space-y-5">
-          {/* Enable toggle */}
-          <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-gray-800">Enable Automated Campaigns</p>
-              <p className="text-xs text-gray-500 mt-0.5">Send automated follow-up messages to leads</p>
-            </div>
-            <button
-              onClick={() =>
-                setChatSettings((prev) => ({
-                  ...prev,
-                  campaign_frequency: {
-                    ...prev.campaign_frequency,
-                    enabled: !prev.campaign_frequency.enabled,
-                  },
-                }))
-              }
-            >
-              {chatSettings.campaign_frequency.enabled ? (
-                <ToggleRight className="h-6 w-6 text-blue-500" />
-              ) : (
-                <ToggleLeft className="h-6 w-6 text-gray-300" />
-              )}
-            </button>
-          </div>
-
-          {/* Interval hours */}
-          <div>
-            <label className="block text-sm font-medium text-gray-800 mb-1">
-              Message Interval (hours)
-            </label>
-            <p className="text-xs text-gray-500 mb-2">Minimum time between automated messages to the same lead</p>
-            <input
-              type="number"
-              min={1}
-              max={168}
-              value={chatSettings.campaign_frequency.interval_hours}
-              onChange={(e) =>
-                setChatSettings((prev) => ({
-                  ...prev,
-                  campaign_frequency: {
-                    ...prev.campaign_frequency,
-                    interval_hours: parseInt(e.target.value) || 24,
-                  },
-                }))
-              }
-              className="w-32 px-3 py-2 text-sm border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400"
-            />
-          </div>
-
-          {/* Max daily messages */}
-          <div>
-            <label className="block text-sm font-medium text-gray-800 mb-1">
-              Max Daily Messages
-            </label>
-            <p className="text-xs text-gray-500 mb-2">Maximum number of automated messages sent per day across all leads</p>
-            <input
-              type="number"
-              min={1}
-              max={1000}
-              value={chatSettings.campaign_frequency.max_daily_messages}
-              onChange={(e) =>
-                setChatSettings((prev) => ({
-                  ...prev,
-                  campaign_frequency: {
-                    ...prev.campaign_frequency,
-                    max_daily_messages: parseInt(e.target.value) || 50,
-                  },
-                }))
-              }
-              className="w-32 px-3 py-2 text-sm border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400"
-            />
-          </div>
-
-          <div className="flex justify-end pt-2">
-            <button
-              onClick={handleSaveCampaign}
-              disabled={savingSettings}
-              className="flex items-center gap-1.5 px-5 py-2.5 text-sm font-semibold text-white bg-[#0B1957] rounded-xl hover:opacity-90 disabled:opacity-50 transition-all shadow-md active:scale-95"
-            >
-              {savingSettings ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
-              Save Campaign Settings
-            </button>
-          </div>
-        </div>
-      </div>
+      {/* NOTE: the old Section 5 "Campaign Settings" card (campaign_frequency:
+          enable/interval/max-daily) was removed 2026-07-05 — the values were
+          never consumed by any campaign path. The field remains in the
+          ChatSettings API type because the backend still stores/returns it. */}
 
       {/* ── Section 6: Post-Conversation Follow-up Timing ────────── */}
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm">

--- a/web/src/components/settings/ChatSettings.tsx
+++ b/web/src/components/settings/ChatSettings.tsx
@@ -1807,25 +1807,35 @@ export function ChatSettings() {
           never consumed by any campaign path. The field remains in the
           ChatSettings API type because the backend still stores/returns it. */}
 
-      {/* ── Section 6: Post-Conversation Follow-up Timing ────────── */}
+      {/* ── Section 6: WhatsApp Post-Conversation Follow-up Timing ── */}
+      {/* WhatsApp-only: the config lives in the whatsapp-conversations service
+          (FOLLOWUP_CONFIG_API) and the stages/booking reminders send via
+          WhatsApp templates. Titled + badged accordingly (users assumed it
+          applied to every channel) and hidden when no WhatsApp is connected.
+          LinkedIn has its own follow-up card below; other channels have none. */}
+      {(isChannelVisible('waba') || isChannelVisible('personal_whatsapp')) && (
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
         <div className="p-6 border-b border-gray-100">
           <div className="flex items-center gap-2 mb-1">
-            <Bell className="h-5 w-5 text-blue-600" />
-            <h2 className="text-lg font-semibold text-gray-900">Post-Conversation Follow-ups</h2>
+            <Bell className="h-5 w-5 text-green-600" />
+            <h2 className="text-lg font-semibold text-gray-900">WhatsApp Follow-ups</h2>
+            <span className="flex items-center gap-1.5 ml-1 px-2 py-0.5 text-[11px] font-medium text-green-700 bg-green-50 border border-green-200 rounded-full">
+              <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+              WhatsApp only
+            </span>
           </div>
           <p className="text-sm text-gray-500">
-            Configure when automated follow-up messages are sent after a conversation ends.
-            Each stage fires once at the scheduled delay.
+            Configure when automated follow-up messages are sent after a WhatsApp conversation ends.
+            Each stage fires once at the scheduled delay. Booking reminders below also send via WhatsApp.
           </p>
         </div>
         <div className="p-6 space-y-5">
           {/* Master enable */}
           <div className="flex items-center justify-between">
             <div>
-              <p className="text-sm font-medium text-gray-800">Enable Post-Conversation Follow-ups</p>
+              <p className="text-sm font-medium text-gray-800">Enable WhatsApp Follow-ups</p>
               <p className="text-xs text-gray-500 mt-0.5">
-                Automatically send follow-up messages when a customer stops responding
+                Automatically send follow-up messages when a customer stops responding on WhatsApp
               </p>
             </div>
             <button
@@ -2097,6 +2107,7 @@ export function ChatSettings() {
           </div>
         </div>
       </div>
+      )}
 
       {/* ── Section 7: LinkedIn Automation ──────────────────────── */}
       {/* Both LinkedIn cards (Automation + Follow-up Sequence) hide together
@@ -2109,6 +2120,10 @@ export function ChatSettings() {
           <div className="flex items-center gap-2 mb-1">
             <Linkedin className="h-5 w-5 text-blue-600" />
             <h2 className="text-lg font-semibold text-gray-900">LinkedIn Automation</h2>
+            <span className="flex items-center gap-1.5 ml-1 px-2 py-0.5 text-[11px] font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-full">
+              <span className="h-1.5 w-1.5 rounded-full bg-blue-600" />
+              LinkedIn only
+            </span>
           </div>
           <p className="text-sm text-gray-500">
             Automatically engage with the post used to personalise each connection request or follow-up message.
@@ -2272,6 +2287,10 @@ export function ChatSettings() {
               <Clock className="h-5 w-5 text-amber-600" />
             </div>
             <h3 className="text-lg font-semibold text-gray-900">LinkedIn Follow-up Sequence</h3>
+            <span className="flex items-center gap-1.5 ml-1 px-2 py-0.5 text-[11px] font-medium text-blue-700 bg-blue-50 border border-blue-200 rounded-full">
+              <span className="h-1.5 w-1.5 rounded-full bg-blue-600" />
+              LinkedIn only
+            </span>
           </div>
           <p className="text-sm text-gray-500">
             After a connection request is accepted, the AI agent schedules this sequence of messages towards booking a meeting. Each message uses your LinkedIn chat-agent prompt (above), is auto-cancelled when the lead replies, and is dynamically rescheduled when the lead asks for a specific future time.

--- a/web/src/components/settings/ChatSettings.tsx
+++ b/web/src/components/settings/ChatSettings.tsx
@@ -212,17 +212,30 @@ async function fetchFollowupConfig(): Promise<FollowupTimingConfig> {
   }
 }
 
-async function updateFollowupConfig(config: FollowupTimingConfig): Promise<boolean> {
+async function updateFollowupConfig(
+  config: FollowupTimingConfig
+): Promise<{ ok: boolean; error?: string }> {
   try {
     const res = await fetchWithTenant(FOLLOWUP_CONFIG_API, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(config),
     });
-    const data = await res.json();
-    return data.success ?? false;
-  } catch {
-    return false;
+    const data = await res.json().catch(() => ({}));
+    if (data.success) return { ok: true };
+    // Surface the backend's reason — FastAPI validation errors arrive as
+    // `detail` (e.g. the H16 guard: an enabled stage past the 24h window
+    // with no template). A bare "Failed to save" hides the actionable part.
+    return {
+      ok: false,
+      error:
+        (typeof data.detail === 'string' && data.detail) ||
+        data.error ||
+        data.message ||
+        `Save failed (HTTP ${res.status})`,
+    };
+  } catch (e: any) {
+    return { ok: false, error: e?.message || 'Network error while saving' };
   }
 }
 
@@ -729,9 +742,32 @@ export function ChatSettings() {
   // ── Follow-up Timing save ────────────────────────────────────
 
   const handleSaveFollowup = useCallback(async () => {
+    // Pre-check mirroring the backend H16 guard: an ENABLED stage that fires
+    // past Meta's 24h customer-service window MUST have an approved template
+    // (free-form text is rejected there, so the stage would never send).
+    // Catching it here gives a friendlier message than the API's 400.
+    const STAGE_LABELS: Record<string, string> = {
+      FIRST: '1st Follow-up', SECOND: '2nd Follow-up', THIRD: '3rd Follow-up', FOURTH: 'Final message',
+    };
+    const offending = (Object.keys(followupConfig.stages) as Array<keyof typeof followupConfig.stages>)
+      .filter((k) => {
+        const s = followupConfig.stages[k];
+        return s.enabled && (s.delay_hours ?? 0) > 24 && !(s.template_name || '').trim();
+      })
+      .map((k) => STAGE_LABELS[k] || k);
+    // NOTE: the backend enforces this per-stage regardless of the master
+    // enabled flag, so the pre-check must too.
+    if (offending.length > 0) {
+      showToast(
+        `${offending.join(', ')}: delays past 24h need an approved WhatsApp template — pick one or disable the stage`,
+        'error'
+      );
+      return;
+    }
+
     setSavingFollowup(true);
-    const ok = await updateFollowupConfig(followupConfig);
-    showToast(ok ? 'Follow-up timing saved' : 'Failed to save', ok ? 'success' : 'error');
+    const result = await updateFollowupConfig(followupConfig);
+    showToast(result.ok ? 'Follow-up timing saved' : (result.error || 'Failed to save'), result.ok ? 'success' : 'error');
     setSavingFollowup(false);
   }, [followupConfig, showToast]);
 

--- a/web/src/components/settings/ChatSettings.tsx
+++ b/web/src/components/settings/ChatSettings.tsx
@@ -1713,9 +1713,10 @@ export function ChatSettings() {
       </div>
 
       {/* ── Section 3: Chat Behaviour ────────────────────────────── */}
-      {/* Both rows are WhatsApp-channel settings — hide the whole card when
-          neither WhatsApp flavour is connected. */}
-      {(isChannelVisible('personal_whatsapp') || isChannelVisible('waba')) && (
+      {/* Channel-specific settings follow the ACTIVE System Prompts tab: the
+          typing rows are WhatsApp settings, so this card only shows while a
+          WhatsApp tab is selected — and only the selected flavour's row. */}
+      {(activeChannel === 'personal_whatsapp' || activeChannel === 'waba') && (
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
         <div className="p-6 border-b border-gray-100">
           <div className="flex items-center gap-2 mb-1">
@@ -1732,12 +1733,11 @@ export function ChatSettings() {
             <p className="text-sm font-medium text-gray-800 mb-1">Typing Indicator</p>
             <p className="text-xs text-gray-500 mb-3">
               Show &quot;typing…&quot; to the contact while the AI is composing a reply.
-              Configure separately for each channel.
             </p>
 
             <div className="space-y-3 border border-gray-100 rounded-lg divide-y divide-gray-100 overflow-hidden">
               {/* Personal WhatsApp row */}
-              {isChannelVisible('personal_whatsapp') && (
+              {activeChannel === 'personal_whatsapp' && (
               <div className="flex items-center justify-between px-4 py-3">
                 <div className="flex items-center gap-2.5">
                   <span className="h-2 w-2 rounded-full bg-emerald-400 flex-shrink-0" />
@@ -1762,7 +1762,7 @@ export function ChatSettings() {
               )}
 
               {/* WABA row */}
-              {isChannelVisible('waba') && (
+              {activeChannel === 'waba' && (
               <div className="flex items-center justify-between px-4 py-3">
                 <div className="flex items-center gap-2.5">
                   <span className="h-2 w-2 rounded-full bg-green-500 flex-shrink-0" />
@@ -1811,9 +1811,9 @@ export function ChatSettings() {
       {/* WhatsApp-only: the config lives in the whatsapp-conversations service
           (FOLLOWUP_CONFIG_API) and the stages/booking reminders send via
           WhatsApp templates. Titled + badged accordingly (users assumed it
-          applied to every channel) and hidden when no WhatsApp is connected.
-          LinkedIn has its own follow-up card below; other channels have none. */}
-      {(isChannelVisible('waba') || isChannelVisible('personal_whatsapp')) && (
+          applied to every channel) and shown only while a WhatsApp tab is
+          selected. LinkedIn has its own follow-up card; other channels none. */}
+      {(activeChannel === 'waba' || activeChannel === 'personal_whatsapp') && (
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
         <div className="p-6 border-b border-gray-100">
           <div className="flex items-center gap-2 mb-1">
@@ -2110,10 +2110,10 @@ export function ChatSettings() {
       )}
 
       {/* ── Section 7: LinkedIn Automation ──────────────────────── */}
-      {/* Both LinkedIn cards (Automation + Follow-up Sequence) hide together
-          when LinkedIn isn't connected; saved values persist and the cards
-          reappear on reconnect. */}
-      {isChannelVisible('linkedin') && (
+      {/* Both LinkedIn cards (Automation + Follow-up Sequence) follow the
+          active System Prompts tab — shown only while LinkedIn is selected.
+          Saved values persist regardless of visibility. */}
+      {activeChannel === 'linkedin' && (
       <>
       <div className="bg-white rounded-lg border border-gray-200 shadow-sm">
         <div className="p-6 border-b border-gray-100">

--- a/web/src/components/settings/LinkedInIntegration.tsx
+++ b/web/src/components/settings/LinkedInIntegration.tsx
@@ -55,10 +55,6 @@ interface LinkedInAutomationSettings {
   auto_comment_posts: boolean;
   ai_agent_enabled: boolean;
   ai_agent_reply_delay_seconds: number;
-  // Auto-withdraw of stale pending connection requests (daily cron). Days is
-  // floored at 30 server-side so fresh invitations are never retracted.
-  auto_withdraw_pending_enabled: boolean;
-  auto_withdraw_pending_days: number;
 }
 type AuthMethod = 'credentials' | 'cookies';
 export const LinkedInIntegration: React.FC = () => {
@@ -98,22 +94,6 @@ export const LinkedInIntegration: React.FC = () => {
   const [automationSettings, setAutomationSettings] = useState<LinkedInAutomationSettings | null>(null);
   const [aiRepliesSaving, setAiRepliesSaving] = useState(false);
   const [aiToast, setAiToast] = useState<{ kind: 'ok' | 'err'; message: string } | null>(null);
-  // ── Auto-withdraw old pending requests (tenant-level) ──────────────────────
-  // Draft values edited in the "LinkedIn Automation" card and persisted via the
-  // "Save LinkedIn Settings" button (same automation-settings PUT as AI Replies).
-  const [withdrawEnabledDraft, setWithdrawEnabledDraft] = useState<boolean>(false);
-  const [withdrawDaysDraft, setWithdrawDaysDraft] = useState<number>(90);
-  const [savingWithdraw, setSavingWithdraw] = useState(false);
-  // Sync the draft when settings (re)load. fetchAutomationSettings is not in the
-  // 30s poll, so this can't clobber an in-progress edit.
-  useEffect(() => {
-    if (!automationSettings) return;
-    setWithdrawEnabledDraft(automationSettings.auto_withdraw_pending_enabled ?? false);
-    setWithdrawDaysDraft(automationSettings.auto_withdraw_pending_days ?? 90);
-  }, [
-    automationSettings?.auto_withdraw_pending_enabled,
-    automationSettings?.auto_withdraw_pending_days,
-  ]);
   // Auto-dismiss the AI Replies toast after a few seconds (mirrors Instagram).
   useEffect(() => {
     if (!aiToast) return;
@@ -407,46 +387,6 @@ export const LinkedInIntegration: React.FC = () => {
       });
     } finally {
       setAiRepliesSaving(false);
-    }
-  };
-  // Persist the auto-withdraw settings via the automation-settings PUT. Resends
-  // the other automation flags unchanged (the backend partial-merges, but this
-  // keeps parity with the AI-reply toggle path). Days is floored at 30 to match
-  // the server clamp so the UI can never request a shorter window.
-  const saveWithdrawSettings = async () => {
-    if (!automationSettings || savingWithdraw) return;
-    const days = Math.max(30, Math.floor(Number(withdrawDaysDraft) || 90));
-    setSavingWithdraw(true);
-    try {
-      const response = await fetch(
-        `${getApiBaseUrl()}/api/social-integration/linkedin/automation-settings`,
-        {
-          method: 'PUT',
-          headers: getAuthHeaders(),
-          body: JSON.stringify({
-            auto_like_posts: automationSettings.auto_like_posts,
-            auto_comment_posts: automationSettings.auto_comment_posts,
-            ai_agent_enabled: automationSettings.ai_agent_enabled,
-            ai_agent_reply_delay_seconds: automationSettings.ai_agent_reply_delay_seconds,
-            auto_withdraw_pending_enabled: withdrawEnabledDraft,
-            auto_withdraw_pending_days: days,
-          }),
-        }
-      );
-      const data = await response.json().catch(() => ({}));
-      if (!response.ok || !data?.success) {
-        throw new Error(data?.error || data?.message || 'Failed to save LinkedIn settings');
-      }
-      if (data.data) setAutomationSettings(data.data as LinkedInAutomationSettings);
-      setWithdrawDaysDraft(days);
-      setAiToast({ kind: 'ok', message: 'LinkedIn automation settings saved.' });
-    } catch (error) {
-      setAiToast({
-        kind: 'err',
-        message: error instanceof Error ? error.message : 'Could not save LinkedIn settings.',
-      });
-    } finally {
-      setSavingWithdraw(false);
     }
   };
   const handleConnect = async () => {
@@ -921,72 +861,6 @@ export const LinkedInIntegration: React.FC = () => {
           </div>
         )}
         <div className="space-y-4">
-          {/* ── LinkedIn Automation: auto-withdraw old pending requests ──────
-              Tenant-level. Shown once settings load (needs a connected account).
-              Persisted via the automation-settings PUT below. */}
-          {automationSettings && (
-            <div className="border-t border-gray-200 pt-4">
-              <h4 className="font-medium text-gray-900 mb-1">LinkedIn Automation</h4>
-              <p className="text-sm text-gray-500 mb-3">
-                Automatically clean up connection requests that have been pending too long.
-              </p>
-              <div className="rounded-lg border border-gray-200 p-3 sm:p-4 space-y-3">
-                <div className="flex items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-gray-900">Auto-withdraw old pending requests</p>
-                    <p className="text-xs text-gray-500 mt-0.5">
-                      Withdraws sent invitations that are still unanswered after the set number of days.
-                    </p>
-                  </div>
-                  <button
-                    type="button"
-                    role="switch"
-                    aria-checked={withdrawEnabledDraft}
-                    onClick={() => setWithdrawEnabledDraft((v) => !v)}
-                    disabled={savingWithdraw}
-                    className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-60 ${
-                      withdrawEnabledDraft ? 'bg-blue-600' : 'bg-gray-300'
-                    }`}
-                  >
-                    <span
-                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
-                        withdrawEnabledDraft ? 'translate-x-6' : 'translate-x-1'
-                      }`}
-                    />
-                  </button>
-                </div>
-                <div className={`flex items-center gap-2 ${withdrawEnabledDraft ? '' : 'opacity-50'}`}>
-                  <label htmlFor="withdrawDays" className="text-sm text-gray-700">
-                    older than
-                  </label>
-                  <input
-                    id="withdrawDays"
-                    type="number"
-                    min={30}
-                    step={1}
-                    value={withdrawDaysDraft}
-                    disabled={!withdrawEnabledDraft || savingWithdraw}
-                    onChange={(e) => setWithdrawDaysDraft(parseInt(e.target.value, 10) || 0)}
-                    onBlur={() => setWithdrawDaysDraft((d) => Math.max(30, Math.floor(Number(d) || 90)))}
-                    className="w-20 rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-gray-100"
-                  />
-                  <span className="text-sm text-gray-700">days</span>
-                  <span className="text-xs text-gray-400">(minimum 30)</span>
-                </div>
-                <div className="flex justify-end">
-                  <button
-                    type="button"
-                    onClick={saveWithdrawSettings}
-                    disabled={savingWithdraw}
-                    className="inline-flex items-center gap-2 rounded-lg bg-blue-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-800 disabled:cursor-not-allowed disabled:bg-blue-300"
-                  >
-                    {savingWithdraw && <Loader2 className="h-4 w-4 animate-spin" />}
-                    {savingWithdraw ? 'Saving…' : 'Save LinkedIn Settings'}
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
           {/* <div className="border-t border-gray-200 pt-4">
             <h4 className="font-medium text-gray-900 mb-3">Features</h4>
             <ul className="space-y-2 text-sm text-gray-600">

--- a/web/src/components/settings/LinkedInIntegration.tsx
+++ b/web/src/components/settings/LinkedInIntegration.tsx
@@ -55,6 +55,10 @@ interface LinkedInAutomationSettings {
   auto_comment_posts: boolean;
   ai_agent_enabled: boolean;
   ai_agent_reply_delay_seconds: number;
+  // Auto-withdraw of stale pending connection requests (daily cron). Days is
+  // floored at 30 server-side so fresh invitations are never retracted.
+  auto_withdraw_pending_enabled: boolean;
+  auto_withdraw_pending_days: number;
 }
 type AuthMethod = 'credentials' | 'cookies';
 export const LinkedInIntegration: React.FC = () => {
@@ -94,6 +98,22 @@ export const LinkedInIntegration: React.FC = () => {
   const [automationSettings, setAutomationSettings] = useState<LinkedInAutomationSettings | null>(null);
   const [aiRepliesSaving, setAiRepliesSaving] = useState(false);
   const [aiToast, setAiToast] = useState<{ kind: 'ok' | 'err'; message: string } | null>(null);
+  // ── Auto-withdraw old pending requests (tenant-level) ──────────────────────
+  // Draft values edited in the "LinkedIn Automation" card and persisted via the
+  // "Save LinkedIn Settings" button (same automation-settings PUT as AI Replies).
+  const [withdrawEnabledDraft, setWithdrawEnabledDraft] = useState<boolean>(false);
+  const [withdrawDaysDraft, setWithdrawDaysDraft] = useState<number>(90);
+  const [savingWithdraw, setSavingWithdraw] = useState(false);
+  // Sync the draft when settings (re)load. fetchAutomationSettings is not in the
+  // 30s poll, so this can't clobber an in-progress edit.
+  useEffect(() => {
+    if (!automationSettings) return;
+    setWithdrawEnabledDraft(automationSettings.auto_withdraw_pending_enabled ?? false);
+    setWithdrawDaysDraft(automationSettings.auto_withdraw_pending_days ?? 90);
+  }, [
+    automationSettings?.auto_withdraw_pending_enabled,
+    automationSettings?.auto_withdraw_pending_days,
+  ]);
   // Auto-dismiss the AI Replies toast after a few seconds (mirrors Instagram).
   useEffect(() => {
     if (!aiToast) return;
@@ -387,6 +407,46 @@ export const LinkedInIntegration: React.FC = () => {
       });
     } finally {
       setAiRepliesSaving(false);
+    }
+  };
+  // Persist the auto-withdraw settings via the automation-settings PUT. Resends
+  // the other automation flags unchanged (the backend partial-merges, but this
+  // keeps parity with the AI-reply toggle path). Days is floored at 30 to match
+  // the server clamp so the UI can never request a shorter window.
+  const saveWithdrawSettings = async () => {
+    if (!automationSettings || savingWithdraw) return;
+    const days = Math.max(30, Math.floor(Number(withdrawDaysDraft) || 90));
+    setSavingWithdraw(true);
+    try {
+      const response = await fetch(
+        `${getApiBaseUrl()}/api/social-integration/linkedin/automation-settings`,
+        {
+          method: 'PUT',
+          headers: getAuthHeaders(),
+          body: JSON.stringify({
+            auto_like_posts: automationSettings.auto_like_posts,
+            auto_comment_posts: automationSettings.auto_comment_posts,
+            ai_agent_enabled: automationSettings.ai_agent_enabled,
+            ai_agent_reply_delay_seconds: automationSettings.ai_agent_reply_delay_seconds,
+            auto_withdraw_pending_enabled: withdrawEnabledDraft,
+            auto_withdraw_pending_days: days,
+          }),
+        }
+      );
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || !data?.success) {
+        throw new Error(data?.error || data?.message || 'Failed to save LinkedIn settings');
+      }
+      if (data.data) setAutomationSettings(data.data as LinkedInAutomationSettings);
+      setWithdrawDaysDraft(days);
+      setAiToast({ kind: 'ok', message: 'LinkedIn automation settings saved.' });
+    } catch (error) {
+      setAiToast({
+        kind: 'err',
+        message: error instanceof Error ? error.message : 'Could not save LinkedIn settings.',
+      });
+    } finally {
+      setSavingWithdraw(false);
     }
   };
   const handleConnect = async () => {
@@ -861,6 +921,72 @@ export const LinkedInIntegration: React.FC = () => {
           </div>
         )}
         <div className="space-y-4">
+          {/* ── LinkedIn Automation: auto-withdraw old pending requests ──────
+              Tenant-level. Shown once settings load (needs a connected account).
+              Persisted via the automation-settings PUT below. */}
+          {automationSettings && (
+            <div className="border-t border-gray-200 pt-4">
+              <h4 className="font-medium text-gray-900 mb-1">LinkedIn Automation</h4>
+              <p className="text-sm text-gray-500 mb-3">
+                Automatically clean up connection requests that have been pending too long.
+              </p>
+              <div className="rounded-lg border border-gray-200 p-3 sm:p-4 space-y-3">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-gray-900">Auto-withdraw old pending requests</p>
+                    <p className="text-xs text-gray-500 mt-0.5">
+                      Withdraws sent invitations that are still unanswered after the set number of days.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={withdrawEnabledDraft}
+                    onClick={() => setWithdrawEnabledDraft((v) => !v)}
+                    disabled={savingWithdraw}
+                    className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-60 ${
+                      withdrawEnabledDraft ? 'bg-blue-600' : 'bg-gray-300'
+                    }`}
+                  >
+                    <span
+                      className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+                        withdrawEnabledDraft ? 'translate-x-6' : 'translate-x-1'
+                      }`}
+                    />
+                  </button>
+                </div>
+                <div className={`flex items-center gap-2 ${withdrawEnabledDraft ? '' : 'opacity-50'}`}>
+                  <label htmlFor="withdrawDays" className="text-sm text-gray-700">
+                    older than
+                  </label>
+                  <input
+                    id="withdrawDays"
+                    type="number"
+                    min={30}
+                    step={1}
+                    value={withdrawDaysDraft}
+                    disabled={!withdrawEnabledDraft || savingWithdraw}
+                    onChange={(e) => setWithdrawDaysDraft(parseInt(e.target.value, 10) || 0)}
+                    onBlur={() => setWithdrawDaysDraft((d) => Math.max(30, Math.floor(Number(d) || 90)))}
+                    className="w-20 rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:bg-gray-100"
+                  />
+                  <span className="text-sm text-gray-700">days</span>
+                  <span className="text-xs text-gray-400">(minimum 30)</span>
+                </div>
+                <div className="flex justify-end">
+                  <button
+                    type="button"
+                    onClick={saveWithdrawSettings}
+                    disabled={savingWithdraw}
+                    className="inline-flex items-center gap-2 rounded-lg bg-blue-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-800 disabled:cursor-not-allowed disabled:bg-blue-300"
+                  >
+                    {savingWithdraw && <Loader2 className="h-4 w-4 animate-spin" />}
+                    {savingWithdraw ? 'Saving…' : 'Save LinkedIn Settings'}
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
           {/* <div className="border-t border-gray-200 pt-4">
             <h4 className="font-medium text-gray-900 mb-3">Features</h4>
             <ul className="space-y-2 text-sm text-gray-600">

--- a/web/src/hooks/useConnectedChannels.ts
+++ b/web/src/hooks/useConnectedChannels.ts
@@ -8,12 +8,13 @@
  * channels reappear automatically when the tenant reconnects, because
  * visibility is derived from live status on every mount — nothing is deleted).
  *
- * Probes mirror IntegrationsSettings.refreshStatuses, but with one deliberate
- * difference: FAIL-OPEN semantics. There, a probe error just shows a "Connect"
- * card (harmless); here it would HIDE a tenant's settings (harmful). So only a
- * successful response that positively shows no active account yields
- * 'disconnected' — network errors, 4xx/5xx, and in-flight probes all stay
- * 'unknown', and callers treat 'unknown' as visible.
+ * Probes mirror IntegrationsSettings.refreshStatuses, but with different
+ * error semantics because here a wrong answer HIDES a tenant's settings:
+ *   - 2xx with no active account  → 'disconnected' (positively not connected)
+ *   - 404                         → 'disconnected' (route/service absent in
+ *     this environment — the channel is genuinely unusable here, not flaky)
+ *   - 5xx / network error / other → 'unknown' (transient — FAIL-OPEN, treated
+ *     as visible so an outage can never make settings vanish)
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -30,66 +31,73 @@ const INITIAL: Record<ChannelId, ChannelStatus> = {
   instagram: 'unknown',
 };
 
-/** Shared helper: fetch JSON, or null on any failure (fail-open). */
-async function tryJson(path: string, init?: RequestInit): Promise<any | null> {
+type ProbeResult =
+  | { kind: 'ok'; data: any }
+  | { kind: 'absent' }     // HTTP 404 — endpoint not available in this env
+  | { kind: 'error' };     // network failure or non-404 error status
+
+async function probe(path: string, init?: RequestInit): Promise<ProbeResult> {
   try {
     const res = await fetchWithTenant(path, init);
-    if (!res.ok) return null;
-    return await res.json();
+    if (res.status === 404) return { kind: 'absent' };
+    if (!res.ok) return { kind: 'error' };
+    return { kind: 'ok', data: await res.json() };
   } catch {
-    return null;
+    return { kind: 'error' };
   }
 }
 
+/** Map a probe outcome to a status given an "any active account?" predicate. */
+function toStatus(result: ProbeResult, hasActive: (data: any) => boolean): ChannelStatus {
+  if (result.kind === 'absent') return 'disconnected';
+  if (result.kind === 'error') return 'unknown';
+  return hasActive(result.data) ? 'connected' : 'disconnected';
+}
+
 async function probePersonalWhatsapp(): Promise<ChannelStatus> {
-  const data = await tryJson('/api/personal-whatsapp/accounts');
-  if (!data) return 'unknown';
-  const accounts = Array.isArray(data?.accounts) ? data.accounts : [];
-  return accounts.some((a: any) => a.status === 'connected') ? 'connected' : 'disconnected';
+  return toStatus(await probe('/api/personal-whatsapp/accounts'), (data) => {
+    const accounts = Array.isArray(data?.accounts) ? data.accounts : [];
+    return accounts.some((a: any) => a.status === 'connected');
+  });
 }
 
 async function probeWaba(): Promise<ChannelStatus> {
-  const data = await tryJson('/api/whatsapp-conversations/admin/whatsapp-accounts');
-  if (!data) return 'unknown';
-  const accounts = Array.isArray(data) ? data : (Array.isArray(data?.accounts) ? data.accounts : []);
-  return accounts.some((a: any) => a.status === 'active' || a.status === 'connected')
-    ? 'connected'
-    : 'disconnected';
+  return toStatus(await probe('/api/whatsapp-conversations/admin/whatsapp-accounts'), (data) => {
+    const accounts = Array.isArray(data) ? data : (Array.isArray(data?.accounts) ? data.accounts : []);
+    return accounts.some((a: any) => a.status === 'active' || a.status === 'connected');
+  });
 }
 
 async function probeLinkedin(): Promise<ChannelStatus> {
-  const data = await tryJson('/api/campaigns/linkedin/accounts');
-  if (!data) return 'unknown';
-  const accounts = Array.isArray(data) ? data : (Array.isArray(data?.accounts) ? data.accounts : []);
-  return accounts.some((a: any) => a.status === 'connected' || a.status === 'active')
-    ? 'connected'
-    : 'disconnected';
+  return toStatus(await probe('/api/campaigns/linkedin/accounts'), (data) => {
+    const accounts = Array.isArray(data) ? data : (Array.isArray(data?.accounts) ? data.accounts : []);
+    return accounts.some((a: any) => a.status === 'connected' || a.status === 'active');
+  });
 }
 
 /**
  * The "Gmail" prompts channel drives email-agent replies for whichever email
  * provider is connected, so it counts as connected when EITHER Google or
- * Microsoft is. Fail-open: if one probe fails and the other says disconnected,
- * we can't be sure → 'unknown'.
+ * Microsoft is. Unknown only when a transient failure leaves the answer
+ * genuinely ambiguous.
  */
 async function probeEmail(): Promise<ChannelStatus> {
   const [google, microsoft] = await Promise.all([
-    tryJson('/api/social-integration/email/google/status', { method: 'POST' }),
-    tryJson('/api/social-integration/email/microsoft/status', { method: 'POST' }),
+    probe('/api/social-integration/email/google/status', { method: 'POST' }),
+    probe('/api/social-integration/email/microsoft/status', { method: 'POST' }),
   ]);
-  if (google?.connected || microsoft?.connected) return 'connected';
-  if (google && microsoft) return 'disconnected';
-  return 'unknown';
+  const g = toStatus(google, (d) => !!d?.connected);
+  const m = toStatus(microsoft, (d) => !!d?.connected);
+  if (g === 'connected' || m === 'connected') return 'connected';
+  if (g === 'unknown' || m === 'unknown') return 'unknown';
+  return 'disconnected';
 }
 
 async function probeInstagram(): Promise<ChannelStatus> {
-  const data = await tryJson('/api/instagram-conversations/accounts');
-  if (!data) return 'unknown';
-  const accounts = Array.isArray(data?.accounts) ? data.accounts : [];
-  const connected = accounts.some(
-    (a: any) => (a.status ?? 'active') !== 'inactive' && !a.is_deleted,
-  );
-  return connected ? 'connected' : 'disconnected';
+  return toStatus(await probe('/api/instagram-conversations/accounts'), (data) => {
+    const accounts = Array.isArray(data?.accounts) ? data.accounts : [];
+    return accounts.some((a: any) => (a.status ?? 'active') !== 'inactive' && !a.is_deleted);
+  });
 }
 
 export function useConnectedChannels() {
@@ -108,13 +116,11 @@ export function useConnectedChannels() {
         probeEmail(),
         probeInstagram(),
       ]);
-      setStatuses({
-        waba,
-        personal_whatsapp: personal,
-        linkedin,
-        gmail,
-        instagram,
-      });
+      const next = { waba, personal_whatsapp: personal, linkedin, gmail, instagram };
+      // Visible in devtools so "why is this tab shown/hidden?" is answerable.
+      // 'unknown' = probe failed transiently → treated as visible (fail-open).
+      console.debug('[useConnectedChannels] statuses', next);
+      setStatuses(next);
       setLoaded(true);
     } finally {
       inFlight.current = false;

--- a/web/src/hooks/useConnectedChannels.ts
+++ b/web/src/hooks/useConnectedChannels.ts
@@ -1,0 +1,135 @@
+'use client';
+
+/**
+ * useConnectedChannels — which conversation channels does this tenant have
+ * integrated right now?
+ *
+ * Used by Chat Settings to show settings only for connected channels (hidden
+ * channels reappear automatically when the tenant reconnects, because
+ * visibility is derived from live status on every mount — nothing is deleted).
+ *
+ * Probes mirror IntegrationsSettings.refreshStatuses, but with one deliberate
+ * difference: FAIL-OPEN semantics. There, a probe error just shows a "Connect"
+ * card (harmless); here it would HIDE a tenant's settings (harmful). So only a
+ * successful response that positively shows no active account yields
+ * 'disconnected' — network errors, 4xx/5xx, and in-flight probes all stay
+ * 'unknown', and callers treat 'unknown' as visible.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { fetchWithTenant } from '@/lib/fetch-with-tenant';
+
+export type ChannelId = 'waba' | 'personal_whatsapp' | 'linkedin' | 'gmail' | 'instagram';
+export type ChannelStatus = 'connected' | 'disconnected' | 'unknown';
+
+const INITIAL: Record<ChannelId, ChannelStatus> = {
+  waba: 'unknown',
+  personal_whatsapp: 'unknown',
+  linkedin: 'unknown',
+  gmail: 'unknown',
+  instagram: 'unknown',
+};
+
+/** Shared helper: fetch JSON, or null on any failure (fail-open). */
+async function tryJson(path: string, init?: RequestInit): Promise<any | null> {
+  try {
+    const res = await fetchWithTenant(path, init);
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
+async function probePersonalWhatsapp(): Promise<ChannelStatus> {
+  const data = await tryJson('/api/personal-whatsapp/accounts');
+  if (!data) return 'unknown';
+  const accounts = Array.isArray(data?.accounts) ? data.accounts : [];
+  return accounts.some((a: any) => a.status === 'connected') ? 'connected' : 'disconnected';
+}
+
+async function probeWaba(): Promise<ChannelStatus> {
+  const data = await tryJson('/api/whatsapp-conversations/admin/whatsapp-accounts');
+  if (!data) return 'unknown';
+  const accounts = Array.isArray(data) ? data : (Array.isArray(data?.accounts) ? data.accounts : []);
+  return accounts.some((a: any) => a.status === 'active' || a.status === 'connected')
+    ? 'connected'
+    : 'disconnected';
+}
+
+async function probeLinkedin(): Promise<ChannelStatus> {
+  const data = await tryJson('/api/campaigns/linkedin/accounts');
+  if (!data) return 'unknown';
+  const accounts = Array.isArray(data) ? data : (Array.isArray(data?.accounts) ? data.accounts : []);
+  return accounts.some((a: any) => a.status === 'connected' || a.status === 'active')
+    ? 'connected'
+    : 'disconnected';
+}
+
+/**
+ * The "Gmail" prompts channel drives email-agent replies for whichever email
+ * provider is connected, so it counts as connected when EITHER Google or
+ * Microsoft is. Fail-open: if one probe fails and the other says disconnected,
+ * we can't be sure → 'unknown'.
+ */
+async function probeEmail(): Promise<ChannelStatus> {
+  const [google, microsoft] = await Promise.all([
+    tryJson('/api/social-integration/email/google/status', { method: 'POST' }),
+    tryJson('/api/social-integration/email/microsoft/status', { method: 'POST' }),
+  ]);
+  if (google?.connected || microsoft?.connected) return 'connected';
+  if (google && microsoft) return 'disconnected';
+  return 'unknown';
+}
+
+async function probeInstagram(): Promise<ChannelStatus> {
+  const data = await tryJson('/api/instagram-conversations/accounts');
+  if (!data) return 'unknown';
+  const accounts = Array.isArray(data?.accounts) ? data.accounts : [];
+  const connected = accounts.some(
+    (a: any) => (a.status ?? 'active') !== 'inactive' && !a.is_deleted,
+  );
+  return connected ? 'connected' : 'disconnected';
+}
+
+export function useConnectedChannels() {
+  const [statuses, setStatuses] = useState<Record<ChannelId, ChannelStatus>>(INITIAL);
+  const [loaded, setLoaded] = useState(false);
+  const inFlight = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (inFlight.current) return;
+    inFlight.current = true;
+    try {
+      const [waba, personal, linkedin, gmail, instagram] = await Promise.all([
+        probeWaba(),
+        probePersonalWhatsapp(),
+        probeLinkedin(),
+        probeEmail(),
+        probeInstagram(),
+      ]);
+      setStatuses({
+        waba,
+        personal_whatsapp: personal,
+        linkedin,
+        gmail,
+        instagram,
+      });
+      setLoaded(true);
+    } finally {
+      inFlight.current = false;
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  /** Visible unless positively disconnected — loading/unknown stay visible. */
+  const isVisible = useCallback(
+    (id: ChannelId) => statuses[id] !== 'disconnected',
+    [statuses],
+  );
+
+  return { statuses, loaded, refresh, isVisible };
+}


### PR DESCRIPTION
## Summary

Frontend half of LinkedIn connection-request withdrawal (LAD-Backend PR #329), plus a Chat Settings restructure so users only see settings for channels they've integrated and selected.

### LinkedIn withdrawal
- SDK `withdrawConnection(campaignLeadId, campaignId?)` (`sdk/features/campaigns/api.ts`).
- **Withdraw button** in `LiveActivityTable` beside Retry — shown for leads with a still-pending sent request (SENT, not accepted/replied/withdrawn); confirm dialog; optimistic refetch; friendly toast on `no_pending_invite`; `CONNECTION_WITHDRAWN` rows render as terminal "Withdrawn" state.
- **Auto-withdraw setting** in the LinkedIn Automation panel (ChatSettings Section 7): toggle + "older than N days" input (min 30), saved via the existing automation-settings PUT.

### Connection-aware Chat Settings
- New `useConnectedChannels` hook probes the same five status endpoints as the Integrations tab. Semantics tuned for hiding *settings* (not showing connect cards): 2xx-with-no-account **or 404** (route absent in this env) → hidden; 5xx/network error → **fail-open visible** so an outage can never make a tenant's settings vanish. Resolved statuses are `console.debug`-logged.
- System Prompts tabs show only connected channels; hidden ones collapse into a dashed "+N more" chip; a quiet bottom strip lists hidden channels with a "Connect channels" action; full empty state when nothing is connected. Nothing is deleted — reconnecting restores settings with saved values.

### Channel-scoped layout (tab drives the page)
- Global sections (Knowledge Base, Shareable Assets, Company Website Context) always visible.
- WABA / Personal WhatsApp tab → Chat Behaviour (that flavour's typing row) + WhatsApp Follow-ups; LinkedIn tab → LinkedIn Automation + Follow-up Sequence; Gmail/Instagram → globals only.
- "Post-Conversation Follow-ups" retitled **WhatsApp Follow-ups** with a "WhatsApp only" badge (its config lives in the whatsapp-conversations service); LinkedIn cards get matching "LinkedIn only" badges.

### Fixes & cleanup
- Removed the unused **Campaign Settings** card (`campaign_frequency` has zero consumers across LAD_backend/WAPA/WABA).
- WhatsApp follow-up save failures now surface the backend's actual reason (FastAPI `detail`) plus a client-side pre-check naming offending stages ("2nd Follow-up: delays past 24h need an approved template…") instead of a bare "Failed to save".
- Booking-reminder template dropdown: empty value is now a first-class **"— AI-generated (default) —"** option (pairs with LAD-WABA-Comms `feat/ai-booking-reminders`).

`tsc --noEmit`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)