### PR TITLE
feat(campaigns): two-way sync — guided config ⇄ Workflow Builder

### DIFF
--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/navigation';
 import { Sparkles, Gem, Upload, FileSpreadsheet, Download, CheckCircle2, Trash2, ChevronLeft, ChevronRight, X, MessageSquare, Users, Zap, Plus } from 'lucide-react';
 import { ProfileSummaryDialog } from '@/components/campaigns';
 import AgentVisualizer from '@/components/ui/AgentVisualizer';
 import { useOnboardingStore } from '@/store/onboardingStore';
+import { deriveConfig, applyConfig, type SyncStep } from '@/components/onboarding/workflow/configStepsSync';
 import WorkflowPreviewPanel from '@/components/onboarding/WorkflowPreviewPanel';
 import { MediaGenerationModal } from '@/components/voice-agent/MediaGenerationModal';
 import { useAuth } from '@/contexts/AuthContext';
@@ -559,7 +560,6 @@ export default function AdvancedSearchAIPage() {
     }, [messages]);
 
     const [cpIcpThreshold, setCpIcpThreshold] = useState('75');
-    const [cpActions, setCpActions] = useState<string[]>([]);
     const [cpConnMsg, setCpConnMsg] = useState('');
     const [cpFollowMsg, setCpFollowMsg] = useState('');
     const [cpEnableDailyWebPresence, setCpEnableDailyWebPresence] = useState(false);
@@ -567,85 +567,49 @@ export default function AdvancedSearchAIPage() {
     const [cpEnableAiPersonalization, setCpEnableAiPersonalization] = useState(false);
     const [cpEnableAiConnectionPersonalization, setCpEnableAiConnectionPersonalization] = useState(false);
     const [cpEnableAiFollowupPersonalization, setCpEnableAiFollowupPersonalization] = useState(false);
-    const [cpNextChannels, setCpNextChannels] = useState<string[]>([]); // email, whatsapp, voice_call
-    const [cpTriggerCondition, setCpTriggerCondition] = useState(''); // connection_accepted, message_replied, profile_visited
 
-    // Dynamically build workflow preview
+    // ── Config ⇄ Workflow: single source of truth ────────────────────────────
+    // The onboarding store's `workflowPreview` steps array is canonical. The
+    // structural config the guided checkpoints collect — LinkedIn actions,
+    // follow-up channels, trigger condition — is DERIVED from it here, and the
+    // setters below reconcile edits back into it. So the guided toggles and the
+    // Workflow Builder canvas stay in sync in BOTH directions in real time
+    // (this replaces the old one-way, destructive derive-and-overwrite effect,
+    // which also silently dropped LinkedIn actions and clobbered canvas edits).
+    const workflowPreview = useOnboardingStore(s => s.workflowPreview);
+    const _cpCfg = useMemo(() => deriveConfig(workflowPreview as unknown as SyncStep[]), [workflowPreview]);
+    const cpActions = _cpCfg.actions;                     // ['connect','message','profile_view'] subset
+    const cpNextChannels = _cpCfg.nextChannels;           // ['email','whatsapp','voice_call'] subset
+    const cpTriggerCondition = _cpCfg.triggerCondition;   // '' | 'connection_accepted' | …
+
+    const _applyCpCfg = useCallback((patch: Partial<{ actions: string[]; nextChannels: string[]; triggerCondition: string }>) => {
+        const cur = useOnboardingStore.getState().workflowPreview as unknown as SyncStep[];
+        setWorkflowPreview(applyConfig(cur, patch) as any);
+    }, [setWorkflowPreview]);
+
+    // These keep the exact React.Dispatch<SetStateAction<string[]>> shape the
+    // CheckpointFormInline props expect, so the guided toggles need no changes —
+    // they just reconcile the shared steps array instead of local state.
+    const setCpActions = useCallback((a: string[] | ((p: string[]) => string[])) => {
+        const cur = deriveConfig(useOnboardingStore.getState().workflowPreview as unknown as SyncStep[]).actions;
+        _applyCpCfg({ actions: typeof a === 'function' ? a(cur) : a });
+    }, [_applyCpCfg]);
+    const setCpNextChannels = useCallback((a: string[] | ((p: string[]) => string[])) => {
+        const cur = deriveConfig(useOnboardingStore.getState().workflowPreview as unknown as SyncStep[]).nextChannels;
+        _applyCpCfg({ nextChannels: typeof a === 'function' ? a(cur) : a });
+    }, [_applyCpCfg]);
+    const setCpTriggerCondition = useCallback((v: string) => {
+        _applyCpCfg({ triggerCondition: v });
+    }, [_applyCpCfg]);
+
+    // Seed a clean base (Lead Search only) when the shared steps array is empty,
+    // so a first-ever load starts sensibly. A non-empty array (edit-mode
+    // hydration or a persisted session) is left untouched.
     useEffect(() => {
-        const steps: any[] = [];
-        let order = 1;
-        // Start node
-        steps.push({
-            id: 'lead-gen',
-            type: 'lead_generation',
-            title: 'LinkedIn Lead Search',
-            description: 'Find target leads on LinkedIn',
-            channel: 'linkedin',
-            order_index: order++
-        });
-
-        if (cpActions.includes('connect')) {
-            steps.push({
-                id: 'connect',
-                type: 'linkedin_connect',
-                title: 'Send Connection Request',
-                description: 'Auto-connect with leads on LinkedIn',
-                channel: 'linkedin',
-                order_index: order++
-            });
-        }
-
-        if (cpActions.includes('message')) {
-            steps.push({
-                id: 'message',
-                type: 'linkedin_message',
-                title: 'Send Follow-up Message',
-                description: 'Message after connection accepted',
-                channel: 'linkedin',
-                order_index: order++
-            });
-        }
-
-        if (cpActions.includes('profile_view')) {
-            steps.push({
-                id: 'profile_view',
-                type: 'linkedin_visit',
-                title: 'View Profile',
-                description: 'Visit their LinkedIn profile',
-                channel: 'linkedin',
-                order_index: order++
-            });
-        }
-
-        if (cpNextChannels.length > 0 && cpTriggerCondition) {
-            const condLabels: Record<string, string> = {
-                connection_accepted: 'Wait for Connection Accepted',
-                message_replied: 'Wait for Message Reply',
-                profile_visited: 'Wait for Profile Visit'
-            };
-            steps.push({
-                id: 'condition',
-                type: 'wait_for_condition',
-                title: condLabels[cpTriggerCondition] || 'Wait for Condition',
-                description: 'Trigger condition',
-                channel: 'system',
-                order_index: order++
-            });
-
-            cpNextChannels.forEach((ch, idx) => {
-                steps.push({
-                    id: `ch-${ch}-${idx}`,
-                    type: ch === 'voice_call' ? 'voice_agent_call' : `${ch}_send`,
-                    title: ch === 'email' ? 'Send Follow-up Email' : ch === 'whatsapp' ? 'Send WhatsApp Message' : 'AI Voice Call',
-                    description: `Follow up via ${ch}`,
-                    channel: ch.split('_')[0],
-                    order_index: order++
-                });
-            });
-        }
-
-        setWorkflowPreview(steps);
-    }, [cpActions, cpNextChannels, cpTriggerCondition, setWorkflowPreview]);
+        const cur = useOnboardingStore.getState().workflowPreview as unknown as SyncStep[];
+        if (!cur || cur.length === 0) setWorkflowPreview(applyConfig([], {}) as any);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
     const [cpDays, setCpDays] = useState('30');
     const [cpChannelConfigStep, setCpChannelConfigStep] = useState(0); // Tracks which channel we're configuring (0-based)
     const [cpChannelDelays, setCpChannelDelays] = useState<Record<string, { days: string; hours: string }>>({}); // Delays per channel
@@ -6382,7 +6346,11 @@ function CheckpointFormInline({
     // Initialise from the `actions` prop so edit-mode hydration (the parent sets
     // cpActions from the saved campaign / its steps) pre-checks the LinkedIn action
     // boxes. In the create flow `actions` is [] at mount, so this is a no-op there.
-    const [liChannelActions, setLiChannelActions] = useState<string[]>(actions || []);
+    // Use the shared config actions (derived from the canonical workflowPreview
+    // by the parent) so LinkedIn action toggles round-trip to the Workflow canvas
+    // instead of living in an orphaned local copy that never synced back.
+    const liChannelActions = actions || [];
+    const setLiChannelActions = setActions;
     const [liFollowGenLoading, setLiFollowGenLoading] = useState(false);
 
     // AI Generate inline context panel state (one per message type)

--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/navigation';
-import { Sparkles, Gem, Upload, FileSpreadsheet, Download, CheckCircle2, Trash2, ChevronLeft, ChevronRight, X, MessageSquare, Users, Zap, Plus } from 'lucide-react';
+import { Sparkles, Gem, Upload, FileSpreadsheet, Download, CheckCircle2, Trash2, ChevronLeft, ChevronRight, X, MessageSquare, Users, Zap, Plus, Globe, Newspaper, UserPlus, Check } from 'lucide-react';
 import { ProfileSummaryDialog } from '@/components/campaigns';
 import AgentVisualizer from '@/components/ui/AgentVisualizer';
 import { useOnboardingStore } from '@/store/onboardingStore';
@@ -488,6 +488,9 @@ export default function AdvancedSearchAIPage() {
     const campaignCreation = useCampaignCreation();
     const { fetchLeadSummaryPreview, saveProspectFeedback, generateProspectSummary } = campaignCreation;
     const voiceAgent = useVoiceAgent(false);
+    // Connected email senders — loaded on mount so "Let Agent Deal" can detect the
+    // email channel synchronously (the child also calls this; React Query dedupes).
+    const { data: connectedSendersParent = [] } = useConnectedEmailSenders();
     const billing = useBilling(false);
 
     // Unified single-screen mode - always show chat interface
@@ -540,6 +543,7 @@ export default function AdvancedSearchAIPage() {
     // Checkpoint form state (inline in chat)
     const [pendingContact, setPendingContact] = useState<any>(null); // detected contact from phone/email outreach
     const [cpStep, setCpStep] = useState(-1); // -1 = not started, 0-6 = steps
+    const [agentDealLoading, setAgentDealLoading] = useState(false); // "Let Agent Deal" one-click build
     const [isMobile, setIsMobile] = useState(false);
     const [chatBlocked, setChatBlocked] = useState(false);
 
@@ -632,6 +636,77 @@ export default function AdvancedSearchAIPage() {
     const [cpEmailGenLoading, setCpEmailGenLoading] = useState(false);
     const [cpEmailFromAddress, setCpEmailFromAddress] = useState(''); // selected sender email
     const [cpEmailProvider, setCpEmailProvider] = useState('');       // 'google' | 'microsoft'
+
+    // ── "Let Agent Deal" ──────────────────────────────────────────────────────
+    // One click builds the full outreach sequence across EVERY channel the tenant
+    // has connected, with market-standard delays, then opens the config panel at
+    // the channels step. LinkedIn is always the primary channel (the lead source);
+    // Email / WhatsApp / Voice are appended only when connected. Message templates
+    // for email/WhatsApp remain the user's choice (the inline panels ask for them);
+    // LinkedIn + follow-up copy is generated per-lead at send time via the AI
+    // personalization flags we enable here.
+    const letAgentDeal = async () => {
+        setAgentDealLoading(true);
+        try {
+            // Detect connected channels. Email senders are already loaded (hook);
+            // voice agents + WhatsApp accounts are fetched here (both return arrays).
+            let voiceAgents: any[] = [];
+            let waAccts: any[] = [];
+            const [vRes, wRes] = await Promise.allSettled([
+                voiceAgent.fetchAgents(),
+                fetch('/api/social-integration/whatsapp/accounts', { credentials: 'include' }).then(r => r.json()),
+            ]);
+            if (vRes.status === 'fulfilled' && Array.isArray(vRes.value)) voiceAgents = vRes.value;
+            if (wRes.status === 'fulfilled' && wRes.value?.success && Array.isArray(wRes.value.accounts)) waAccts = wRes.value.accounts;
+
+            const hasEmail = (connectedSendersParent as any[]).length > 0;
+            const hasWhatsApp = waAccts.length > 0;
+            const hasVoice = voiceAgents.length > 0;
+
+            // Channel sequence — LinkedIn primary, then each connected follow-up in
+            // market-standard order (LinkedIn → Email → WhatsApp → Voice).
+            const channels = ['linkedin'];
+            if (hasEmail) channels.push('email');
+            if (hasWhatsApp) channels.push('whatsapp');
+            if (hasVoice) channels.push('voice_call');
+
+            // Market-standard cadence (delay BEFORE each channel's step).
+            setCpChannelDelays({
+                linkedin: { days: '0', hours: '0' },   // starts immediately
+                email: { days: '2', hours: '0' },      // 2 days after the LinkedIn touch
+                whatsapp: { days: '2', hours: '0' },   // 2 days after email
+                voice_call: { days: '3', hours: '0' }, // 3 days after WhatsApp
+            });
+
+            // Structural build. Order matters: channels first (so 'linkedin' is
+            // present), then LinkedIn actions materialise, then the trigger.
+            setCpNextChannels(channels);
+            setCpActions(['profile_view', 'connect', 'message']);
+            setCpTriggerCondition('connection_accepted');
+
+            // Daily + per-lead AI personalization — the agent tailors each message.
+            setCpEnableDailyWebPresence(true);
+            setCpEnableDailyPosts(true);              // fetch each lead's recent LinkedIn posts
+            setCpEnableAiPersonalization(true);
+            setCpEnableAiConnectionPersonalization(true);
+            setCpEnableAiFollowupPersonalization(true);
+
+            // Pre-fill the first connected email account + voice agent (WhatsApp
+            // account auto-selects inside the config panel when the channel mounts).
+            if (hasEmail) {
+                setCpEmailFromAddress((connectedSendersParent as any[])[0].email);
+                setCpEmailProvider((connectedSendersParent as any[])[0].provider || '');
+            }
+            if (hasVoice) setCpSelectedAgentId(voiceAgents[0].agent_id || voiceAgents[0].id || '');
+
+            // Open the config panel at the channels step so the built pipeline is
+            // visible and the user can pick templates + launch.
+            setCpStep(1);
+        } finally {
+            setAgentDealLoading(false);
+        }
+    };
+
     // WhatsApp config (populated when whatsapp channel selected)
     const [cpWaBody, setCpWaBody] = useState('');
     const [cpWaFromNumber, setCpWaFromNumber] = useState('');
@@ -1235,11 +1310,22 @@ export default function AdvancedSearchAIPage() {
                     if (stepTypes.includes('linkedin_connect')) liActions.push('connect');
                     if (stepTypes.includes('linkedin_message')) liActions.push('message');
                 }
-                if (liActions.length) setCpActions(liActions);
                 setCpConnMsg(cs.connection_message ?? cfg.connection_message ?? '');
                 setCpFollowMsg(cs.followup_message ?? cfg.followup_message ?? '');
-                if (Array.isArray(cs.next_channels)) setCpNextChannels(cs.next_channels);
-                setCpTriggerCondition(cs.trigger_condition ?? cfg.trigger_condition ?? '');
+                // Reconcile the whole structural config (LinkedIn actions + channels
+                // + trigger) into the canonical steps in ONE shot, so the
+                // linkedin↔actions coupling is order-independent: LinkedIn actions
+                // only materialise when 'linkedin' is a selected channel, so include
+                // it whenever we restored any LinkedIn action.
+                {
+                    const curCfg = deriveConfig(useOnboardingStore.getState().workflowPreview as unknown as SyncStep[]);
+                    const hydChannels = Array.isArray(cs.next_channels) ? [...cs.next_channels] : [...curCfg.nextChannels];
+                    if (liActions.length && !hydChannels.includes('linkedin')) hydChannels.unshift('linkedin');
+                    setWorkflowPreview(applyConfig(
+                        useOnboardingStore.getState().workflowPreview as unknown as SyncStep[],
+                        { actions: liActions, nextChannels: hydChannels, triggerCondition: cs.trigger_condition ?? cfg.trigger_condition ?? '' },
+                    ) as any);
+                }
                 if (cs.campaign_days != null) setCpDays(String(cs.campaign_days));
                 setCpName(cs.campaign_name ?? camp?.name ?? '');
                 if (typeof cs.enable_daily_web_presence === 'boolean') setCpEnableDailyWebPresence(cs.enable_daily_web_presence);
@@ -3764,7 +3850,7 @@ export default function AdvancedSearchAIPage() {
                                             : 'Qualifying...'
                                     }
                                     : m;
-                                return <Bubble key={m.id} msg={displayMsg} onOpt={onOptClick} onShowPanel={setShowPanel} onStartCheckpoints={() => setCpStep(0)} onStartTargeting={() => { setTgStep(0); setChatBlocked(false); }} hasPanel={!!showPanel} leadsCount={leads.length} filteredLeadsCount={filteredLeads.length} onUploadClick={() => fileInputRef.current?.click()} useSalesNav={useSalesNav} isMobile={isMobile} />;
+                                return <Bubble key={m.id} msg={displayMsg} onOpt={onOptClick} onShowPanel={setShowPanel} onStartCheckpoints={() => setCpStep(0)} onLetAgentDeal={letAgentDeal} agentDealLoading={agentDealLoading} onStartTargeting={() => { setTgStep(0); setChatBlocked(false); }} hasPanel={!!showPanel} leadsCount={leads.length} filteredLeadsCount={filteredLeads.length} onUploadClick={() => fileInputRef.current?.click()} useSalesNav={useSalesNav} isMobile={isMobile} />;
                             })}
                             {/* Import leads prompt — shown when conversation is about existing client relationships */}
                             {(() => {
@@ -3820,6 +3906,8 @@ export default function AdvancedSearchAIPage() {
                             <div className="adv-msgs-inner">
                                 <CheckpointFormInline
                                     editingCampaignId={editingCampaignId}
+                                    onLetAgentDeal={letAgentDeal}
+                                    agentDealLoading={agentDealLoading}
                                     step={cpStep}
                                     setStep={setCpStep}
                                     icpThreshold={cpIcpThreshold}
@@ -5603,7 +5691,7 @@ export default function AdvancedSearchAIPage() {
    ═══════════════════════════════════════════════ */
 import { useSelector } from 'react-redux';
 
-function Bubble({ msg, onOpt, onShowPanel, onStartCheckpoints, onStartTargeting, hasPanel, leadsCount, filteredLeadsCount, onUploadClick, useSalesNav, isMobile }: { msg: ChatMsg; onOpt: (v: string) => void; onShowPanel: (panel: 'leads' | 'workflow') => void; onStartCheckpoints: () => void; onStartTargeting: () => void; hasPanel: boolean; leadsCount: number; filteredLeadsCount?: number; onUploadClick?: () => void; useSalesNav?: boolean; isMobile?: boolean }) {
+function Bubble({ msg, onOpt, onShowPanel, onStartCheckpoints, onLetAgentDeal, agentDealLoading, onStartTargeting, hasPanel, leadsCount, filteredLeadsCount, onUploadClick, useSalesNav, isMobile }: { msg: ChatMsg; onOpt: (v: string) => void; onShowPanel: (panel: 'leads' | 'workflow') => void; onStartCheckpoints: () => void; onLetAgentDeal?: () => void; agentDealLoading?: boolean; onStartTargeting: () => void; hasPanel: boolean; leadsCount: number; filteredLeadsCount?: number; onUploadClick?: () => void; useSalesNav?: boolean; isMobile?: boolean }) {
     const user = useSelector((state: any) => state.auth?.user);
     const displayName = user?.name || "User";
     const userInitial = displayName.charAt(0).toUpperCase();
@@ -5847,18 +5935,33 @@ function Bubble({ msg, onOpt, onShowPanel, onStartCheckpoints, onStartTargeting,
 
                 {/* ── Modern action buttons (Example 1 style) ── */}
                 {msg.targeting && (
-
-                    <div className="adv-action-btns" style={{ display: "flex", gap: "8px", flexWrap: "nowrap", borderTop: "1px solid #e5e7eb", paddingTop: "12px", justifyContent: "space-between" }}>
-                        <button className="adv-act-btn adv-act-btn-refine" style={{
-                            padding: "8px 12px", background: "#fff", border: "1px solid #e5e7eb", borderRadius: "20px", fontSize: "12px", fontWeight: 600, color: "#374151"
-                        }} onClick={() => onOpt('Refine my targeting criteria')}>Refine</button>
-                        <button className="adv-act-btn adv-act-btn-journey" style={{
-                            padding: "9px 16px", background: "#0b1957", border: "none", borderRadius: "20px", fontSize: "12.5px", fontWeight: 700, color: "#fff",
-                            boxShadow: "0 2px 8px rgba(23,37,96,0.35)", display: "flex", alignItems: "center", gap: "6px", letterSpacing: "0.01em"
-                        }} onClick={onStartCheckpoints}>
-                            Create Outreach Journey
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14M12 5l7 7-7 7" /></svg>
-                        </button>
+                    <div style={{ display: "flex", flexDirection: "column", gap: "10px", borderTop: "1px solid #e5e7eb", paddingTop: "12px" }}>
+                        {/* ⚡ Hero action — let the agent build the whole multi-channel campaign */}
+                        {onLetAgentDeal && (
+                            <button type="button" onClick={onLetAgentDeal} disabled={agentDealLoading} style={{
+                                width: "100%", display: "flex", alignItems: "center", justifyContent: "center", gap: "8px",
+                                padding: "12px 16px", borderRadius: "12px", border: "none",
+                                cursor: agentDealLoading ? "default" : "pointer",
+                                background: "linear-gradient(135deg, #0b1957 0%, #3730a3 100%)", color: "#fff",
+                                boxShadow: "0 4px 14px rgba(11,25,87,0.22)", opacity: agentDealLoading ? 0.75 : 1,
+                                fontSize: "13.5px", fontWeight: 700, letterSpacing: "0.01em", transition: "opacity 0.2s",
+                            }}>
+                                <span style={{ fontSize: "16px", lineHeight: 1 }}>{agentDealLoading ? "⏳" : "⚡"}</span>
+                                {agentDealLoading ? "Building your campaign…" : "Let Agent Deal — auto-build every connected channel"}
+                            </button>
+                        )}
+                        <div className="adv-action-btns" style={{ display: "flex", gap: "8px", flexWrap: "nowrap", justifyContent: "space-between" }}>
+                            <button className="adv-act-btn adv-act-btn-refine" style={{
+                                padding: "8px 12px", background: "#fff", border: "1px solid #e5e7eb", borderRadius: "20px", fontSize: "12px", fontWeight: 600, color: "#374151"
+                            }} onClick={() => onOpt('Refine my targeting criteria')}>Refine</button>
+                            <button className="adv-act-btn adv-act-btn-journey" style={{
+                                padding: "9px 16px", background: "#fff", border: "1px solid #0b1957", borderRadius: "20px", fontSize: "12.5px", fontWeight: 700, color: "#0b1957",
+                                display: "flex", alignItems: "center", gap: "6px", letterSpacing: "0.01em"
+                            }} onClick={onStartCheckpoints}>
+                                Configure manually
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><path d="M5 12h14M12 5l7 7-7 7" /></svg>
+                            </button>
+                        </div>
                     </div>
                 )}
 
@@ -6140,6 +6243,62 @@ const CP_QUESTIONS = [
     { id: 'name', question: 'Give your campaign a name', type: 'input' },
 ];
 
+// ── AI Personalisation toggle primitives ─────────────────────────────────────
+// Shared, accessible switch + row so every personalisation option is pixel-identical.
+// Two accents encode meaning: `indigo` = live-data inputs, `violet` = AI generation.
+const AI_PERSO_ACCENTS: Record<'indigo' | 'violet', { on: string; tint: string; border: string; chip: string }> = {
+    indigo: { on: '#4338ca', tint: '#eef2ff', border: '#c7d2fe', chip: '#e0e7ff' },
+    violet: { on: '#7c3aed', tint: '#f5f3ff', border: '#ddd6fe', chip: '#ede9fe' },
+};
+
+function AiPersoToggle({ checked, onChange, accent = 'indigo', size = 'sm', disabled = false }: {
+    checked: boolean; onChange: (v: boolean) => void; accent?: 'indigo' | 'violet'; size?: 'sm' | 'lg'; disabled?: boolean;
+}) {
+    const a = AI_PERSO_ACCENTS[accent];
+    const W = size === 'lg' ? 40 : 34, H = size === 'lg' ? 22 : 20, TH = H - 4;
+    return (
+        <button type="button" role="switch" aria-checked={checked} disabled={disabled}
+            onClick={(e) => { e.stopPropagation(); if (!disabled) onChange(!checked); }}
+            style={{
+                width: W, height: H, borderRadius: 99, border: 'none', padding: 0, flexShrink: 0,
+                background: checked ? a.on : '#cbd5e1', position: 'relative',
+                cursor: disabled ? 'not-allowed' : 'pointer', transition: 'background .2s',
+                boxShadow: checked ? `0 0 0 3px ${a.on}22` : 'none',
+            }}>
+            <span style={{
+                position: 'absolute', top: 2, left: checked ? W - TH - 2 : 2, width: TH, height: TH,
+                borderRadius: '50%', background: '#fff', transition: 'left .2s', boxShadow: '0 1px 3px rgba(0,0,0,0.25)',
+            }} />
+        </button>
+    );
+}
+
+function AiPersoRow({ icon, title, desc, checked, onChange, accent = 'indigo', disabled = false }: {
+    icon: React.ReactNode; title: string; desc: string; checked: boolean; onChange: (v: boolean) => void;
+    accent?: 'indigo' | 'violet'; disabled?: boolean;
+}) {
+    const a = AI_PERSO_ACCENTS[accent];
+    return (
+        <div role="button" aria-pressed={checked} onClick={() => { if (!disabled) onChange(!checked); }}
+            style={{
+                display: 'flex', alignItems: 'center', gap: 11, padding: '10px 12px',
+                background: checked ? a.tint : '#fff', border: `1px solid ${checked ? a.border : '#e5e7eb'}`,
+                borderRadius: 10, cursor: disabled ? 'not-allowed' : 'pointer', opacity: disabled ? 0.55 : 1,
+                transition: 'background .15s, border-color .15s',
+            }}>
+            <div style={{
+                width: 30, height: 30, borderRadius: 8, flexShrink: 0, display: 'grid', placeItems: 'center',
+                background: checked ? a.chip : '#f3f4f6', color: checked ? a.on : '#94a3b8', transition: 'background .15s, color .15s',
+            }}>{icon}</div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: '#0f172a' }}>{title}</div>
+                <div style={{ fontSize: 11.5, color: '#64748b', marginTop: 1, lineHeight: 1.35 }}>{desc}</div>
+            </div>
+            <AiPersoToggle checked={checked} onChange={onChange} accent={accent} disabled={disabled} />
+        </div>
+    );
+}
+
 function CheckpointFormInline({
     step, setStep, icpThreshold, setIcpThreshold, actions, setActions, connMsg, setConnMsg, followMsg, setFollowMsg,
     nextChannels, setNextChannels, triggerCondition, setTriggerCondition,
@@ -6163,6 +6322,7 @@ function CheckpointFormInline({
     enableAiConnectionPersonalization, setEnableAiConnectionPersonalization,
     enableAiFollowupPersonalization, setEnableAiFollowupPersonalization,
     editingCampaignId,
+    onLetAgentDeal, agentDealLoading,
 }: {
     step: number; setStep: (s: number) => void;
     icpThreshold: string; setIcpThreshold: (v: string) => void;
@@ -6209,6 +6369,7 @@ function CheckpointFormInline({
     enableAiConnectionPersonalization: boolean; setEnableAiConnectionPersonalization: (v: boolean) => void;
     enableAiFollowupPersonalization: boolean; setEnableAiFollowupPersonalization: (v: boolean) => void;
     editingCampaignId?: string | null;
+    onLetAgentDeal: () => void; agentDealLoading: boolean;
 }) {
     const totalSteps = CP_QUESTIONS.length;
 
@@ -7154,6 +7315,37 @@ function CheckpointFormInline({
                     {/* Step 1: Campaign Channels */}
                     {step === 1 && (
                         <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
+                            {/* "Let Agent Deal" — one-click auto-build across connected channels */}
+                            {!isDirectContact && (
+                                <div style={{ marginBottom: '2px' }}>
+                                    <button
+                                        type="button"
+                                        onClick={onLetAgentDeal}
+                                        disabled={agentDealLoading}
+                                        style={{
+                                            width: '100%', display: 'flex', alignItems: 'center', gap: '12px',
+                                            padding: '14px 16px', borderRadius: '12px', border: 'none',
+                                            cursor: agentDealLoading ? 'default' : 'pointer',
+                                            background: 'linear-gradient(135deg, #0b1957 0%, #3730a3 100%)',
+                                            color: '#fff', boxShadow: '0 4px 14px rgba(11,25,87,0.22)',
+                                            opacity: agentDealLoading ? 0.75 : 1, transition: 'opacity 0.2s',
+                                        }}>
+                                        <div style={{ fontSize: '22px', lineHeight: 1 }}>{agentDealLoading ? '⏳' : '⚡'}</div>
+                                        <div style={{ flex: 1, textAlign: 'left' }}>
+                                            <div style={{ fontWeight: 700, fontSize: '15px' }}>
+                                                {agentDealLoading ? 'Building your campaign…' : 'Let Agent Deal'}
+                                            </div>
+                                            <div style={{ fontSize: '12px', opacity: 0.85, marginTop: '2px' }}>
+                                                Auto-build the full sequence across your connected channels, with recommended delays
+                                            </div>
+                                        </div>
+                                        {!agentDealLoading && <div style={{ fontSize: '18px' }}>→</div>}
+                                    </button>
+                                    <div style={{ textAlign: 'center', fontSize: '11px', color: '#9ca3af', margin: '8px 0 2px' }}>
+                                        — or configure manually —
+                                    </div>
+                                </div>
+                            )}
                             {/* Context badge for direct contacts */}
                             {isDirectContact && (
                                 <div style={{ padding: '10px 14px', background: '#f0fdf4', border: '1px solid #bbf7d0', borderRadius: '10px', fontSize: '12px', color: '#166534', fontWeight: 500, marginBottom: '4px' }}>
@@ -7206,15 +7398,6 @@ function CheckpointFormInline({
                                     </div>
                                 </div>
                             ))}
-                            {!isDirectContact && (
-                                <div onClick={() => { setNextChannels([]); setStep(step + 1); }} style={optStyle(nextChannels.length === 0)}>
-                                    <div style={numBadge(4, nextChannels.length === 0)}>{nextChannels.length === 0 ? '✓' : 4}</div>
-                                    <div style={{ flex: 1 }}>
-                                        <div style={{ fontWeight: 600 }}>Skip</div>
-                                        <div style={{ fontSize: '12px', color: '#6b7280', marginTop: '2px' }}>No additional channels — LinkedIn only</div>
-                                    </div>
-                                </div>
-                            )}
 
 
                             {/* Email Config (inline when email selected) */}
@@ -8047,176 +8230,82 @@ function CheckpointFormInline({
                                     </div>
 
                                     {/* ── 🤖 AI Daily Personalisation ───────────── */}
-                                    <div style={{ marginTop: '14px', borderTop: '1px solid #bfdbfe', paddingTop: '12px' }}>
-                                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: enableDailyWebPresence || enableDailyPosts || enableAiPersonalization ? '10px' : '0', cursor: 'pointer' }}
-                                            onClick={() => {
-                                                // If any toggle is on, turn all off; otherwise show the panel
-                                                if (enableDailyWebPresence || enableDailyPosts || enableAiPersonalization) {
-                                                    setEnableDailyWebPresence(false);
-                                                    setEnableDailyPosts(false);
-                                                    setEnableAiPersonalization(false);
-                                                } else {
-                                                    setEnableDailyWebPresence(true);
-                                                    setEnableDailyPosts(true);
-                                                    setEnableAiPersonalization(true);
-                                                }
-                                            }}>
-                                            <div style={{ display: 'flex', alignItems: 'center', gap: '7px' }}>
-                                                <span style={{ fontSize: '13px' }}>🤖</span>
-                                                <span style={{ fontSize: '13px', fontWeight: 700, color: '#4338ca' }}>AI Daily Personalisation</span>
-                                                <span style={{ fontSize: '11px', color: '#6b7280', fontWeight: 400 }}>— unique messages per lead, powered by live data</span>
-                                            </div>
-                                            <div style={{
-                                                width: '36px', height: '20px', borderRadius: '99px', flexShrink: 0,
-                                                background: (enableDailyWebPresence || enableDailyPosts || enableAiPersonalization) ? '#0b1957' : '#d1d5db',
-                                                position: 'relative', transition: 'background 0.2s',
-                                            }}>
-                                                <div style={{
-                                                    position: 'absolute', top: '2px',
-                                                    left: (enableDailyWebPresence || enableDailyPosts || enableAiPersonalization) ? '18px' : '2px',
-                                                    width: '16px', height: '16px', borderRadius: '50%', background: '#fff',
-                                                    transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
-                                                }} />
-                                            </div>
-                                        </div>
-
-                                        {(enableDailyWebPresence || enableDailyPosts || enableAiPersonalization) && (
-                                            <div style={{ display: 'flex', flexDirection: 'column', gap: '8px' }}>
-                                                {/* Toggle: Web Presence */}
-                                                <div style={{
-                                                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                                                    padding: '9px 12px', background: enableDailyWebPresence ? '#e8ecfa' : '#f9fafb',
-                                                    border: `1px solid ${enableDailyWebPresence ? '#c2d6eb' : '#e5e7eb'}`, borderRadius: '8px', cursor: 'pointer',
-                                                }} onClick={() => setEnableDailyWebPresence(!enableDailyWebPresence)}>
-                                                    <div>
-                                                        <div style={{ fontSize: '13px', fontWeight: 600, color: '#1e293b' }}>🌐 Refresh web presence daily</div>
-                                                        <div style={{ fontSize: '11px', color: '#6b7280', marginTop: '2px' }}>Re-runs Google search for articles, news & social profiles per lead</div>
-                                                    </div>
-                                                    <div style={{
-                                                        width: '32px', height: '18px', borderRadius: '99px', flexShrink: 0,
-                                                        background: enableDailyWebPresence ? '#0b1957' : '#d1d5db', position: 'relative', transition: 'background 0.2s',
+                                    {(() => {
+                                        const anyOn = enableDailyWebPresence || enableDailyPosts || enableAiPersonalization;
+                                        const noSource = !enableDailyWebPresence && !enableDailyPosts;
+                                        const toggleAll = () => {
+                                            const next = !anyOn;
+                                            setEnableDailyWebPresence(next);
+                                            setEnableDailyPosts(next);
+                                            setEnableAiPersonalization(next);
+                                        };
+                                        return (
+                                            <div style={{ marginTop: '16px' }}>
+                                                {/* Master header — one tap toggles the whole feature */}
+                                                <div role="button" aria-pressed={anyOn} onClick={toggleAll}
+                                                    style={{
+                                                        display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', cursor: 'pointer',
+                                                        borderRadius: anyOn ? '14px 14px 0 0' : 14,
+                                                        background: anyOn ? 'linear-gradient(135deg,#eef2ff 0%,#f5f3ff 100%)' : '#f8fafc',
+                                                        border: `1px solid ${anyOn ? '#c7d2fe' : '#e5e7eb'}`,
+                                                        borderBottom: anyOn ? '1px solid transparent' : '1px solid #e5e7eb',
+                                                        transition: 'background .2s',
                                                     }}>
-                                                        <div style={{
-                                                            position: 'absolute', top: '2px',
-                                                            left: enableDailyWebPresence ? '16px' : '2px',
-                                                            width: '14px', height: '14px', borderRadius: '50%', background: '#fff',
-                                                            transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
-                                                        }} />
+                                                    <div style={{
+                                                        width: 34, height: 34, borderRadius: 10, flexShrink: 0, display: 'grid', placeItems: 'center',
+                                                        background: anyOn ? 'linear-gradient(135deg,#4338ca,#7c3aed)' : '#eef2ff',
+                                                        boxShadow: anyOn ? '0 2px 8px rgba(67,56,202,0.30)' : 'none', transition: 'background .2s',
+                                                    }}>
+                                                        <img src={anyOn ? '/logo-white.svg' : '/logo.svg'} alt="LAD" style={{ width: 20, height: 20, display: 'block' }} />
                                                     </div>
+                                                    <div style={{ flex: 1, minWidth: 0 }}>
+                                                        <div style={{ fontSize: 13.5, fontWeight: 700, color: '#4338ca' }}>AI Daily Personalisation</div>
+                                                        <div style={{ fontSize: 11.5, color: '#6b7280', marginTop: 1 }}>Unique messages per lead, powered by live data</div>
+                                                    </div>
+                                                    <AiPersoToggle checked={anyOn} onChange={toggleAll} accent="indigo" size="lg" />
                                                 </div>
 
-                                                {/* Toggle: LinkedIn Posts */}
-                                                <div style={{
-                                                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                                                    padding: '9px 12px', background: enableDailyPosts ? '#e8ecfa' : '#f9fafb',
-                                                    border: `1px solid ${enableDailyPosts ? '#c2d6eb' : '#e5e7eb'}`, borderRadius: '8px', cursor: 'pointer',
-                                                }} onClick={() => setEnableDailyPosts(!enableDailyPosts)}>
-                                                    <div>
-                                                        <div style={{ fontSize: '13px', fontWeight: 600, color: '#1e293b' }}>📝 Fetch live LinkedIn posts</div>
-                                                        <div style={{ fontSize: '11px', color: '#6b7280', marginTop: '2px' }}>Pulls the lead&apos;s recent LinkedIn posts before each send</div>
-                                                    </div>
+                                                {anyOn && (
                                                     <div style={{
-                                                        width: '32px', height: '18px', borderRadius: '99px', flexShrink: 0,
-                                                        background: enableDailyPosts ? '#0b1957' : '#d1d5db', position: 'relative', transition: 'background 0.2s',
+                                                        border: '1px solid #c7d2fe', borderTop: 'none', borderRadius: '0 0 14px 14px',
+                                                        background: '#fcfcff', padding: 13, display: 'flex', flexDirection: 'column', gap: 16,
                                                     }}>
-                                                        <div style={{
-                                                            position: 'absolute', top: '2px',
-                                                            left: enableDailyPosts ? '16px' : '2px',
-                                                            width: '14px', height: '14px', borderRadius: '50%', background: '#fff',
-                                                            transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
-                                                        }} />
-                                                    </div>
-                                                </div>
-
-                                                {/* Toggle: AI Generate unique message */}
-                                                <div style={{
-                                                    display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                                                    padding: '9px 12px', background: enableAiPersonalization ? '#f5f3ff' : '#f9fafb',
-                                                    border: `1px solid ${enableAiPersonalization ? '#ddd6fe' : '#e5e7eb'}`, borderRadius: '8px', cursor: 'pointer',
-                                                    opacity: (!enableDailyWebPresence && !enableDailyPosts) ? 0.5 : 1,
-                                                    pointerEvents: (!enableDailyWebPresence && !enableDailyPosts) ? 'none' : 'auto',
-                                                }} onClick={() => setEnableAiPersonalization(!enableAiPersonalization)}>
-                                                    <div>
-                                                        <div style={{ fontSize: '13px', fontWeight: 600, color: '#1e293b' }}>✨ AI-generate unique message per lead</div>
-                                                        <div style={{ fontSize: '11px', color: '#6b7280', marginTop: '2px' }}>AI creates a personalised connect + follow-up using live web & post data{(!enableDailyWebPresence && !enableDailyPosts) ? ' — enable web presence or posts first' : ''}</div>
-                                                    </div>
-                                                    <div style={{
-                                                        width: '32px', height: '18px', borderRadius: '99px', flexShrink: 0,
-                                                        background: enableAiPersonalization ? '#7c3aed' : '#d1d5db', position: 'relative', transition: 'background 0.2s',
-                                                    }}>
-                                                        <div style={{
-                                                            position: 'absolute', top: '2px',
-                                                            left: enableAiPersonalization ? '16px' : '2px',
-                                                            width: '14px', height: '14px', borderRadius: '50%', background: '#fff',
-                                                            transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
-                                                        }} />
-                                                    </div>
-                                                </div>
-
-                                                {(enableDailyWebPresence || enableDailyPosts) && enableAiPersonalization && (
-                                                    <div style={{ fontSize: '11px', color: '#7c3aed', background: '#faf5ff', border: '1px solid #e9d5ff', borderRadius: '7px', padding: '7px 10px', lineHeight: 1.5 }}>
-                                                        ✅ Each lead will receive a <strong>unique AI-generated message</strong> based on their live web presence & LinkedIn posts. Your static template message is used as a fallback.
-                                                    </div>
-                                                )}
-
-                                                {(enableDailyWebPresence || enableDailyPosts) && enableAiPersonalization && (
-                                                    <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', marginTop: '12px', paddingTop: '12px', borderTop: '1px solid #e5e7eb' }}>
-                                                        <div style={{ fontSize: '12px', fontWeight: 600, color: '#6b7280' }}>Granular AI Message Control:</div>
-
-                                                        {/* Toggle: AI Generate Connection Message */}
-                                                        <div style={{
-                                                            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                                                            padding: '9px 12px', background: enableAiConnectionPersonalization ? '#f5f3ff' : '#f9fafb',
-                                                            border: `1px solid ${enableAiConnectionPersonalization ? '#ddd6fe' : '#e5e7eb'}`, borderRadius: '8px', cursor: 'pointer',
-                                                        }} onClick={() => setEnableAiConnectionPersonalization(!enableAiConnectionPersonalization)}>
-                                                            <div>
-                                                                <div style={{ fontSize: '13px', fontWeight: 600, color: '#1e293b' }}>🔗 AI-generate connection request</div>
-                                                                <div style={{ fontSize: '11px', color: '#6b7280', marginTop: '2px' }}>Create personalized connection messages</div>
-                                                            </div>
-                                                            <div style={{
-                                                                width: '32px', height: '18px', borderRadius: '99px', flexShrink: 0,
-                                                                background: enableAiConnectionPersonalization ? '#7c3aed' : '#d1d5db', position: 'relative', transition: 'background 0.2s',
-                                                            }}>
-                                                                <div style={{
-                                                                    position: 'absolute', top: '2px',
-                                                                    left: enableAiConnectionPersonalization ? '16px' : '2px',
-                                                                    width: '14px', height: '14px', borderRadius: '50%', background: '#fff',
-                                                                    transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
-                                                                }} />
-                                                            </div>
+                                                        {/* Group 1 — live data the agent gathers per lead */}
+                                                        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                                                            <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '.07em', textTransform: 'uppercase', color: '#4338ca' }}>Live data sources</div>
+                                                            <AiPersoRow icon={<Globe size={16} />} title="Refresh web presence daily" desc="Re-runs Google search for articles, news & social profiles per lead" checked={enableDailyWebPresence} onChange={setEnableDailyWebPresence} accent="indigo" />
+                                                            <AiPersoRow icon={<Newspaper size={16} />} title="Fetch live LinkedIn posts" desc="Pulls the lead's recent LinkedIn posts before each send" checked={enableDailyPosts} onChange={setEnableDailyPosts} accent="indigo" />
                                                         </div>
 
-                                                        {/* Toggle: AI Generate Followup Message */}
-                                                        <div style={{
-                                                            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                                                            padding: '9px 12px', background: enableAiFollowupPersonalization ? '#f5f3ff' : '#f9fafb',
-                                                            border: `1px solid ${enableAiFollowupPersonalization ? '#ddd6fe' : '#e5e7eb'}`, borderRadius: '8px', cursor: 'pointer',
-                                                        }} onClick={() => setEnableAiFollowupPersonalization(!enableAiFollowupPersonalization)}>
-                                                            <div>
-                                                                <div style={{ fontSize: '13px', fontWeight: 600, color: '#1e293b' }}>💬 AI-generate follow-up message</div>
-                                                                <div style={{ fontSize: '11px', color: '#6b7280', marginTop: '2px' }}>Create personalized follow-up messages</div>
-                                                            </div>
-                                                            <div style={{
-                                                                width: '32px', height: '18px', borderRadius: '99px', flexShrink: 0,
-                                                                background: enableAiFollowupPersonalization ? '#7c3aed' : '#d1d5db', position: 'relative', transition: 'background 0.2s',
-                                                            }}>
-                                                                <div style={{
-                                                                    position: 'absolute', top: '2px',
-                                                                    left: enableAiFollowupPersonalization ? '16px' : '2px',
-                                                                    width: '14px', height: '14px', borderRadius: '50%', background: '#fff',
-                                                                    transition: 'left 0.2s', boxShadow: '0 1px 3px rgba(0,0,0,0.2)',
-                                                                }} />
-                                                            </div>
-                                                        </div>
+                                                        {/* Group 2 — how the agent writes each message */}
+                                                        <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                                                            <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '.07em', textTransform: 'uppercase', color: '#7c3aed' }}>AI message generation</div>
+                                                            <AiPersoRow icon={<Sparkles size={16} />} title="AI-generate unique message per lead"
+                                                                desc={noSource ? 'Enable a live data source above first' : 'AI writes a personalised connect + follow-up from live web & post data'}
+                                                                checked={enableAiPersonalization} onChange={setEnableAiPersonalization} accent="violet" disabled={noSource} />
 
-                                                        <div style={{ fontSize: '11px', color: '#7c3aed', background: '#faf5ff', border: '1px solid #e9d5ff', borderRadius: '7px', padding: '7px 10px', lineHeight: 1.5 }}>
-                                                            💡 <strong>Tip:</strong> Choose which message(s) should be AI-generated. Unchecked messages will use your static template.
+                                                            {enableAiPersonalization && !noSource && (
+                                                                <>
+                                                                    <div style={{ display: 'flex', gap: 8, fontSize: 11.5, color: '#6d28d9', background: '#faf5ff', border: '1px solid #e9d5ff', borderRadius: 9, padding: '9px 11px', lineHeight: 1.5 }}>
+                                                                        <Check size={15} style={{ flexShrink: 0, marginTop: 1 }} />
+                                                                        <span>Each lead gets a <strong>unique AI-generated message</strong> from their live web presence &amp; LinkedIn posts. Your static template is the fallback.</span>
+                                                                    </div>
+
+                                                                    {/* Nested granular control — clearly a child of the toggle above */}
+                                                                    <div style={{ marginLeft: 8, paddingLeft: 14, borderLeft: '2px solid #ddd6fe', display: 'flex', flexDirection: 'column', gap: 8 }}>
+                                                                        <div style={{ fontSize: 10.5, fontWeight: 700, letterSpacing: '.06em', textTransform: 'uppercase', color: '#7c3aed' }}>Which messages?</div>
+                                                                        <AiPersoRow icon={<UserPlus size={16} />} title="Connection request" desc="Personalised connect note per lead" checked={enableAiConnectionPersonalization} onChange={setEnableAiConnectionPersonalization} accent="violet" />
+                                                                        <AiPersoRow icon={<MessageSquare size={16} />} title="Follow-up message" desc="Personalised follow-up per lead" checked={enableAiFollowupPersonalization} onChange={setEnableAiFollowupPersonalization} accent="violet" />
+                                                                        <div style={{ fontSize: 11, color: '#9ca3af', paddingLeft: 2 }}>Unchecked messages use your static template.</div>
+                                                                    </div>
+                                                                </>
+                                                            )}
                                                         </div>
                                                     </div>
                                                 )}
                                             </div>
-                                        )}
-                                    </div>
+                                        );
+                                    })()}
                                 </div>
                             )}
                         </div>

--- a/web/src/components/onboarding/WorkflowPreviewPanel.tsx
+++ b/web/src/components/onboarding/WorkflowPreviewPanel.tsx
@@ -78,8 +78,8 @@ function FlowInner({
 
   useEffect(() => {
     const t = setTimeout(() => {
-      fitView({ padding: 0.15, duration: 500, minZoom: 0.2, maxZoom: 0.85 });
-    }, 300);
+      fitView({ padding: 0.14, duration: 400, minZoom: 0.4, maxZoom: 1 });
+    }, 250);
     return () => clearTimeout(t);
   }, [workflowPreview, fitView]);
 
@@ -107,10 +107,10 @@ function FlowInner({
         nodesConnectable={false}
         elementsSelectable={true}
         fitView
-        fitViewOptions={{ padding: 0.15, minZoom: 0.2, maxZoom: 0.85 }}
+        fitViewOptions={{ padding: 0.14, minZoom: 0.4, maxZoom: 1 }}
         minZoom={0.1}
         maxZoom={2}
-        defaultViewport={{ x: 0, y: 0, zoom: 0.6 }}
+        defaultViewport={{ x: 0, y: 0, zoom: 0.9 }}
         attributionPosition="bottom-left"
         proOptions={{ hideAttribution: true }}
         style={{ background: '#fafafa' }}

--- a/web/src/components/onboarding/workflow/CustomWorkflowNode.tsx
+++ b/web/src/components/onboarding/workflow/CustomWorkflowNode.tsx
@@ -85,6 +85,12 @@ export function CustomWorkflowNode({ data, id, selected }: NodeProps) {
         <Handle type="source" position={Position.Bottom} id="bottom"
           style={{ width: 8, height: 8, background: '#d1d5db', border: '2px solid #fff', bottom: -4 }} />
       )}
+      {/* Side connection points on the circle's left/right edges — used by the
+          horizontal "snake" layout. Invisible; edges simply attach here. */}
+      <Handle type="target" position={Position.Left}  id="l-t" style={{ left: `calc(50% - ${nodeSize / 2}px)`, top: nodeSize / 2, width: 6, height: 6, opacity: 0, border: 'none', background: 'transparent' }} />
+      <Handle type="source" position={Position.Left}  id="l-s" style={{ left: `calc(50% - ${nodeSize / 2}px)`, top: nodeSize / 2, width: 6, height: 6, opacity: 0, border: 'none', background: 'transparent' }} />
+      <Handle type="target" position={Position.Right} id="r-t" style={{ right: `calc(50% - ${nodeSize / 2}px)`, top: nodeSize / 2, width: 6, height: 6, opacity: 0, border: 'none', background: 'transparent' }} />
+      <Handle type="source" position={Position.Right} id="r-s" style={{ right: `calc(50% - ${nodeSize / 2}px)`, top: nodeSize / 2, width: 6, height: 6, opacity: 0, border: 'none', background: 'transparent' }} />
 
       {/* Hover action buttons */}
       {(canEdit || canDelete) && (

--- a/web/src/components/onboarding/workflow/configStepsSync.ts
+++ b/web/src/components/onboarding/workflow/configStepsSync.ts
@@ -3,12 +3,16 @@
  * Builder canvas.
  *
  * The `workflowPreview` steps array is the SINGLE SOURCE OF TRUTH. The guided
- * config's structural selections — LinkedIn actions (connect / message /
- * profile_view), follow-up channels (email / whatsapp / voice_call) and the
+ * config's structural selections — the channels (linkedin / email / whatsapp /
+ * voice_call), the LinkedIn actions (connect / message / profile_view) and the
  * trigger condition — are DERIVED from it (`deriveConfig`), and editing a
  * toggle reconciles back into it (`applyConfig`). Because both the toggles and
  * the canvas mutate the same array, add/remove in either surface reflects in
  * the other in real time.
+ *
+ * LinkedIn is a first-class channel here: it is "selected" whenever the workflow
+ * carries a LinkedIn outreach step, and its per-action detail lives in
+ * `actions`. The other channels map 1:1 to a single step type.
  *
  * Channel account/template selections (email from-address, WA account, voice
  * agent, …) are campaign-level, not per-step, so they stay in their own state
@@ -35,8 +39,8 @@ export interface SyncStep {
 }
 
 export interface DerivedConfig {
-  actions: string[];        // subset of ['profile_view','connect','message']
-  nextChannels: string[];   // subset of ['email','whatsapp','voice_call']
+  actions: string[];        // subset of ['profile_view','connect','message'] (LinkedIn actions)
+  nextChannels: string[];   // subset of ['linkedin','email','whatsapp','voice_call']
   triggerCondition: string; // '' | 'connection_accepted' | 'message_replied' | 'profile_visited' | …
 }
 
@@ -80,6 +84,11 @@ export function deriveConfig(steps: SyncStep[] | null | undefined): DerivedConfi
     else if (CHANNEL_BY_TYPE[s.type]) nextChannels.push(CHANNEL_BY_TYPE[s.type]);
     else if (s.type === 'wait_for_condition') triggerCondition = s.condition || '';
   }
+  // LinkedIn is a first-class channel in the guided config (selecting it reveals
+  // the LinkedIn action toggles). It's "selected" whenever the workflow carries
+  // any LinkedIn outreach step; surface it at the FRONT so it reads as the
+  // primary channel (matching CHANNEL_PRIORITY = ['linkedin', …]).
+  if (actions.length > 0) nextChannels.unshift('linkedin');
   return { actions, nextChannels, triggerCondition };
 }
 
@@ -127,9 +136,16 @@ export function buildStepsFromConfig(cfg: DerivedConfig, existing: SyncStep[] = 
   // Lead search is always the entry step (preserve an existing one if present).
   out.push(take('lead_generation'));
 
-  if (cfg.actions.includes('connect')) out.push(take('linkedin_connect'));
-  if (cfg.actions.includes('message')) out.push(take('linkedin_message'));
-  if (cfg.actions.includes('profile_view')) out.push(take('linkedin_visit'));
+  // LinkedIn outreach steps materialise only when the LinkedIn channel is
+  // selected. If it's selected with no explicit action, default to a profile
+  // visit (mirrors the launch builder's `liChannelActions.length === 0` default).
+  const liSelected = cfg.nextChannels.includes('linkedin');
+  const liActions = !liSelected ? [] : (cfg.actions.length > 0 ? cfg.actions : ['profile_view']);
+  // Emit in execution order (visit → connect → message) so the canvas matches
+  // how the launch builder actually runs the sequence.
+  if (liActions.includes('profile_view')) out.push(take('linkedin_visit'));
+  if (liActions.includes('connect')) out.push(take('linkedin_connect'));
+  if (liActions.includes('message')) out.push(take('linkedin_message'));
 
   if (cfg.triggerCondition) {
     const cond = take('wait_for_condition');
@@ -139,6 +155,7 @@ export function buildStepsFromConfig(cfg: DerivedConfig, existing: SyncStep[] = 
   }
 
   for (const ch of cfg.nextChannels) {
+    if (ch === 'linkedin') continue; // handled via the LinkedIn actions above
     const type = TYPE_BY_CHANNEL[ch];
     if (type) out.push(take(type));
   }

--- a/web/src/components/onboarding/workflow/configStepsSync.ts
+++ b/web/src/components/onboarding/workflow/configStepsSync.ts
@@ -1,0 +1,155 @@
+/**
+ * Two-way sync between the guided campaign-config toggles and the Workflow
+ * Builder canvas.
+ *
+ * The `workflowPreview` steps array is the SINGLE SOURCE OF TRUTH. The guided
+ * config's structural selections — LinkedIn actions (connect / message /
+ * profile_view), follow-up channels (email / whatsapp / voice_call) and the
+ * trigger condition — are DERIVED from it (`deriveConfig`), and editing a
+ * toggle reconciles back into it (`applyConfig`). Because both the toggles and
+ * the canvas mutate the same array, add/remove in either surface reflects in
+ * the other in real time.
+ *
+ * Channel account/template selections (email from-address, WA account, voice
+ * agent, …) are campaign-level, not per-step, so they stay in their own state
+ * and are merged at launch — they are intentionally NOT part of this module.
+ *
+ * Per-step content (a step's message / delay) lives on the step object and is
+ * edited via the canvas StepEditor or the config forms; this module preserves
+ * those fields across a reconcile by matching on step type.
+ */
+
+export interface SyncStep {
+  id: string;
+  type: string;
+  title: string;
+  description?: string;
+  channel?: string;
+  // Per-step content preserved across reconciles:
+  message?: string;
+  delayDays?: number;
+  delayHours?: number;
+  condition?: string; // only on a wait_for_condition step
+  leadLimit?: number;  // only on the lead_generation step
+  [k: string]: unknown;
+}
+
+export interface DerivedConfig {
+  actions: string[];        // subset of ['profile_view','connect','message']
+  nextChannels: string[];   // subset of ['email','whatsapp','voice_call']
+  triggerCondition: string; // '' | 'connection_accepted' | 'message_replied' | 'profile_visited' | …
+}
+
+const LI_ACTION_BY_TYPE: Record<string, string> = {
+  linkedin_visit: 'profile_view',
+  linkedin_connect: 'connect',
+  linkedin_message: 'message',
+};
+
+const CHANNEL_BY_TYPE: Record<string, string> = {
+  email_send: 'email',
+  whatsapp_send: 'whatsapp',
+  voice_agent_call: 'voice_call',
+};
+
+const TYPE_BY_CHANNEL: Record<string, string> = {
+  email: 'email_send',
+  whatsapp: 'whatsapp_send',
+  voice_call: 'voice_agent_call',
+};
+
+const COND_LABELS: Record<string, string> = {
+  connection_accepted: 'Wait for Connection Accepted',
+  message_replied: 'Wait for Message Reply',
+  profile_visited: 'Wait for Profile Visit',
+  email_read: 'Wait for Email Read',
+  email_replied: 'Wait for Email Reply',
+  wa_read: 'Wait for WhatsApp Read',
+  wa_replied: 'Wait for WhatsApp Reply',
+  call_completed: 'Wait for Call Completed',
+  call_answered: 'Wait for Call Answered',
+};
+
+/** Read the current structural config back out of the canonical steps array. */
+export function deriveConfig(steps: SyncStep[] | null | undefined): DerivedConfig {
+  const actions: string[] = [];
+  const nextChannels: string[] = [];
+  let triggerCondition = '';
+  for (const s of steps || []) {
+    if (LI_ACTION_BY_TYPE[s.type]) actions.push(LI_ACTION_BY_TYPE[s.type]);
+    else if (CHANNEL_BY_TYPE[s.type]) nextChannels.push(CHANNEL_BY_TYPE[s.type]);
+    else if (s.type === 'wait_for_condition') triggerCondition = s.condition || '';
+  }
+  return { actions, nextChannels, triggerCondition };
+}
+
+/** Factory for a fresh structural step of a given kind. */
+function makeStep(kind: string, existing?: SyncStep): SyncStep {
+  if (existing) return existing; // preserve id + per-step content (message/delays/condition)
+  switch (kind) {
+    case 'lead_generation':
+      return { id: 'lead-gen', type: 'lead_generation', title: 'LinkedIn Lead Search', description: 'Find target leads on LinkedIn', channel: 'linkedin' };
+    case 'linkedin_connect':
+      return { id: 'connect', type: 'linkedin_connect', title: 'Send Connection Request', description: 'Auto-connect with leads on LinkedIn', channel: 'linkedin' };
+    case 'linkedin_message':
+      return { id: 'message', type: 'linkedin_message', title: 'Send Follow-up Message', description: 'Message after connection accepted', channel: 'linkedin' };
+    case 'linkedin_visit':
+      return { id: 'profile_view', type: 'linkedin_visit', title: 'View Profile', description: 'Visit their LinkedIn profile', channel: 'linkedin' };
+    case 'wait_for_condition':
+      return { id: 'condition', type: 'wait_for_condition', title: 'Wait for Condition', description: 'Trigger condition', channel: 'system' };
+    case 'email_send':
+      return { id: 'ch-email', type: 'email_send', title: 'Send Follow-up Email', description: 'Follow up via email', channel: 'email' };
+    case 'whatsapp_send':
+      return { id: 'ch-whatsapp', type: 'whatsapp_send', title: 'Send WhatsApp Message', description: 'Follow up via whatsapp', channel: 'whatsapp' };
+    case 'voice_agent_call':
+      return { id: 'ch-voice_call', type: 'voice_agent_call', title: 'AI Voice Call', description: 'Follow up via voice_call', channel: 'voice' };
+    default:
+      return { id: `${kind}-${Math.random().toString(36).slice(2, 8)}`, type: kind, title: kind };
+  }
+}
+
+/**
+ * Rebuild the canonical steps array for a target structural config, PRESERVING
+ * every existing step's per-step content (message/delay/condition/leadLimit/id)
+ * by matching on type. Channel steps are materialised even without a trigger
+ * (the wait_for_condition step is added only when a trigger is set) — this is
+ * what lets "channels selected before a trigger" round-trip without loss.
+ *
+ * Canonical order: lead_generation → LinkedIn actions (connect, message,
+ * profile_view) → wait_for_condition (if trigger) → follow-up channels.
+ */
+export function buildStepsFromConfig(cfg: DerivedConfig, existing: SyncStep[] = []): SyncStep[] {
+  const byType = new Map<string, SyncStep>();
+  for (const s of existing) if (!byType.has(s.type)) byType.set(s.type, s);
+  const take = (type: string) => makeStep(type, byType.get(type));
+
+  const out: SyncStep[] = [];
+  // Lead search is always the entry step (preserve an existing one if present).
+  out.push(take('lead_generation'));
+
+  if (cfg.actions.includes('connect')) out.push(take('linkedin_connect'));
+  if (cfg.actions.includes('message')) out.push(take('linkedin_message'));
+  if (cfg.actions.includes('profile_view')) out.push(take('linkedin_visit'));
+
+  if (cfg.triggerCondition) {
+    const cond = take('wait_for_condition');
+    cond.condition = cfg.triggerCondition;
+    cond.title = COND_LABELS[cfg.triggerCondition] || 'Wait for Condition';
+    out.push(cond);
+  }
+
+  for (const ch of cfg.nextChannels) {
+    const type = TYPE_BY_CHANNEL[ch];
+    if (type) out.push(take(type));
+  }
+
+  return out;
+}
+
+/** Merge a partial structural change and rebuild the steps. */
+export function applyConfig(steps: SyncStep[], patch: Partial<DerivedConfig>): SyncStep[] {
+  const merged = { ...deriveConfig(steps), ...patch };
+  return buildStepsFromConfig(merged, steps);
+}
+
+export const _internal = { LI_ACTION_BY_TYPE, CHANNEL_BY_TYPE, TYPE_BY_CHANNEL, COND_LABELS };

--- a/web/src/components/onboarding/workflow/workflowFlowBuilder.ts
+++ b/web/src/components/onboarding/workflow/workflowFlowBuilder.ts
@@ -13,35 +13,52 @@ export interface WorkflowPreviewStep {
 export type WorkflowLayout = 'horizontal' | 'vertical';
 
 /* ═══════════════════════════════════════════════════════════════════
-   LINEAR 1:1 LAYOUT — one node per step, Start → steps… → End.
-   A FAITHFUL mirror of the workflowPreview array (the single source of
-   truth): every step is exactly one editable node and vice versa, so
-   adding/removing a node maps 1:1 to a config step. (An earlier version
-   synthesised decorative branch nodes — Accepted / No-Response / Soft
-   Bump / Nurture … — that were not real steps and made node↔step
-   add/delete ambiguous; that is intentionally gone.)
+   HORIZONTAL "SNAKE" LAYOUT — the sequence flows left→right and wraps to
+   the next row (boustrophedon), so a long multi-channel pipeline stays
+   compact and fully visible in the portrait preview panel instead of
+   running off the bottom as one tall column. Still a faithful 1:1 mirror
+   of workflowPreview: Start → one node per step → End.
+
+   Edges attach to the circle's side handles within a row (l-s/r-s ↔
+   l-t/r-t) and to top/bottom at the row turns, so connectors stay short
+   and readable. Nodes remain draggable for manual adjustment.
    ═══════════════════════════════════════════════════════════════════ */
 
-const Y_GAP = 180;      // vertical gap between rows
-const LINEAR_CX = 300;  // shared column x for the vertical spine
-const LINEAR_Y0 = 40;   // y of the Start node
+const X_STRIDE = 200;   // horizontal gap between node centers
+const Y_STRIDE = 156;   // vertical gap between rows (circle + label + turn slack)
+const X0 = 40;          // left margin
+const Y0 = 20;          // top margin
 
-function linearNode(id: string, type: string, title: string, description: string, index: number): Node {
-  return {
-    id,
-    type: 'custom',
-    position: { x: LINEAR_CX, y: LINEAR_Y0 + index * Y_GAP },
-    draggable: true,
-    data: { title, type, description, _layout: 'vertical' },
-  };
+/** Columns per row — adaptive so the flow stays roughly square (best fit for fitView). */
+function snakeCols(n: number): number {
+  return Math.min(4, Math.max(2, Math.ceil(Math.sqrt(n))));
 }
 
-function makeEdge(src: string, tgt: string): Edge {
+interface SeqNode { id: string; type: string; title: string; description: string }
+
+function toSequence(steps: WorkflowPreviewStep[]): SeqNode[] {
+  return [
+    { id: 'start', type: 'start', title: 'Start', description: 'Campaign begins' },
+    ...steps.map((s) => ({ id: s.id, type: s.type, title: s.title, description: s.description || '' })),
+    { id: 'end', type: 'end', title: 'End', description: 'Campaign ends' },
+  ];
+}
+
+/** Grid cell (row, col) for the i-th node in a downward snake. */
+function cellFor(i: number, cols: number): { row: number; col: number } {
+  const row = Math.floor(i / cols);
+  const posInRow = i % cols;
+  // Even rows run left→right, odd rows right→left, so consecutive rows meet vertically.
+  const col = row % 2 === 0 ? posInRow : cols - 1 - posInRow;
+  return { row, col };
+}
+
+function makeEdge(src: string, tgt: string, sourceHandle: string, targetHandle: string): Edge {
   const c = '#c4c9d4';
   return {
     id: `e-${src}-${tgt}`,
-    source: src, sourceHandle: 'bottom',
-    target: tgt, targetHandle: 'top',
+    source: src, sourceHandle,
+    target: tgt, targetHandle,
     type: 'smoothstep',
     animated: true,
     data: { label: '', color: c },
@@ -52,27 +69,44 @@ function makeEdge(src: string, tgt: string): Edge {
 
 export function createReactFlowNodes(
   workflowPreview: WorkflowPreviewStep[] | null,
-  _layout: WorkflowLayout = 'vertical',
+  _layout: WorkflowLayout = 'horizontal',
 ): Node[] {
-  const steps = workflowPreview || [];
-  const nodes: Node[] = [linearNode('start', 'start', 'Start', 'Campaign begins', 0)];
-  steps.forEach((s, i) => {
-    nodes.push(linearNode(s.id, s.type, s.title, s.description || '', i + 1));
+  const seq = toSequence(workflowPreview || []);
+  const cols = snakeCols(seq.length);
+  return seq.map((n, i) => {
+    const { row, col } = cellFor(i, cols);
+    return {
+      id: n.id,
+      type: 'custom',
+      position: { x: X0 + col * X_STRIDE, y: Y0 + row * Y_STRIDE },
+      draggable: true,
+      data: { title: n.title, type: n.type, description: n.description, _layout: 'snake' },
+    };
   });
-  nodes.push(linearNode('end', 'end', 'End', 'Campaign ends', steps.length + 1));
-  return nodes;
 }
 
 export function createReactFlowEdges(
   workflowPreview: WorkflowPreviewStep[] | null,
-  _layout: WorkflowLayout = 'vertical',
+  _layout: WorkflowLayout = 'horizontal',
 ): Edge[] {
-  const steps = workflowPreview || [];
-  // Node ids in spine order: start → each step id → end.
-  const spine = ['start', ...steps.map((s) => s.id), 'end'];
+  const seq = toSequence(workflowPreview || []);
+  const cols = snakeCols(seq.length);
   const edges: Edge[] = [];
-  for (let i = 0; i < spine.length - 1; i++) {
-    edges.push(makeEdge(spine[i], spine[i + 1]));
+  for (let i = 0; i < seq.length - 1; i++) {
+    const a = cellFor(i, cols);
+    const b = cellFor(i + 1, cols);
+    let sourceHandle: string, targetHandle: string;
+    if (a.row !== b.row) {
+      // Row turn — drop straight down to the node below.
+      sourceHandle = 'bottom'; targetHandle = 'top';
+    } else if (a.row % 2 === 0) {
+      // Even row: flowing left → right.
+      sourceHandle = 'r-s'; targetHandle = 'l-t';
+    } else {
+      // Odd row: flowing right → left.
+      sourceHandle = 'l-s'; targetHandle = 'r-t';
+    }
+    edges.push(makeEdge(seq[i].id, seq[i + 1].id, sourceHandle, targetHandle));
   }
   return edges;
 }

--- a/web/src/components/onboarding/workflow/workflowFlowBuilder.ts
+++ b/web/src/components/onboarding/workflow/workflowFlowBuilder.ts
@@ -13,370 +13,66 @@ export interface WorkflowPreviewStep {
 export type WorkflowLayout = 'horizontal' | 'vertical';
 
 /* ═══════════════════════════════════════════════════════════════════
-   BRANCHING TREE — no separate "condition" nodes.
-   Branches come directly out of ACTION nodes, exactly like the mockup.
+   LINEAR 1:1 LAYOUT — one node per step, Start → steps… → End.
+   A FAITHFUL mirror of the workflowPreview array (the single source of
+   truth): every step is exactly one editable node and vice versa, so
+   adding/removing a node maps 1:1 to a config step. (An earlier version
+   synthesised decorative branch nodes — Accepted / No-Response / Soft
+   Bump / Nurture … — that were not real steps and made node↔step
+   add/delete ambiguous; that is intentionally gone.)
    ═══════════════════════════════════════════════════════════════════ */
 
-interface TreeNode {
-  id: string;
-  type: string;
-  title: string;
-  description?: string;
-  /** Multiple outgoing branches (edge labels on the connectors) */
-  branches?: TreeBranch[];
-}
+const Y_GAP = 180;      // vertical gap between rows
+const LINEAR_CX = 300;  // shared column x for the vertical spine
+const LINEAR_Y0 = 40;   // y of the Start node
 
-interface TreeBranch {
-  label: string;          // e.g. "Qualified", "Accepted"
-  color: string;          // edge color
-  child: TreeNode;
-}
-
-/* ─── Build the branching tree from linear steps ─── */
-
-function buildBranchingTree(steps: WorkflowPreviewStep[]): TreeNode {
-  const hasConnect = steps.some(s => s.type === 'linkedin_connect');
-  const hasMessage = steps.some(s => s.type === 'linkedin_message');
-  const hasVisit   = steps.some(s => s.type === 'linkedin_visit');
-  const hasLeadGen = steps.some(s => s.type === 'lead_generation');
-
-  const leadStep    = steps.find(s => s.type === 'lead_generation');
-  const connectStep = steps.find(s => s.type === 'linkedin_connect');
-  const messageStep = steps.find(s => s.type === 'linkedin_message');
-  const visitStep   = steps.find(s => s.type === 'linkedin_visit');
-
-  // Multi-channel follow-up steps (email, whatsapp, voice)
-  const followUpChannelSteps = steps.filter(s =>
-    ['email_send', 'whatsapp_send', 'voice_agent_call'].includes(s.type)
-  );
-  const hasCondition = steps.some(s => s.type === 'wait_for_condition');
-  const conditionStep = steps.find(s => s.type === 'wait_for_condition');
-
-  // ── End node factory ──
-  const endNode = (id: string): TreeNode => ({
-    id, type: 'end', title: 'End', description: '',
-  });
-
-  // ── Build multi-channel follow-up tail (condition → channels → end) ──
-  function buildFollowUpChannelTail(): TreeNode | null {
-    if (!hasCondition || followUpChannelSteps.length === 0) return null;
-    const condNode: TreeNode = {
-      id: conditionStep?.id || 'condition',
-      type: 'delay',
-      title: conditionStep?.title || 'Wait for Condition',
-      description: conditionStep?.description || 'Trigger condition',
-    };
-    if (followUpChannelSteps.length === 1) {
-      const ch = followUpChannelSteps[0];
-      const chNode: TreeNode = {
-        id: ch.id, type: ch.type, title: ch.title,
-        description: ch.description,
-        branches: [{ label: '', color: '#9ca3af', child: endNode(`end-ch-${ch.id}`) }],
-      };
-      condNode.branches = [{ label: '', color: '#9ca3af', child: chNode }];
-    } else {
-      condNode.branches = followUpChannelSteps.map(ch => ({
-        label: ch.title.replace(/^Send /, '').replace(/ Message$/, ''),
-        color: ch.type.includes('email') ? '#ea4335' : ch.type.includes('whatsapp') ? '#25d366' : '#8b5cf6',
-        child: {
-          id: ch.id, type: ch.type, title: ch.title,
-          description: ch.description,
-          branches: [{ label: '', color: '#9ca3af', child: endNode(`end-ch-${ch.id}`) }],
-        } as TreeNode,
-      }));
-    }
-    return condNode;
-  }
-
-  const channelTail = buildFollowUpChannelTail();
-
-  // ── Tag & Exit → End ──
-  const tagExitNode: TreeNode = {
-    id: 'tag-exit', type: 'tag', title: 'Tag & Exit',
-    description: 'Mark as rejected',
-    branches: [{ label: '', color: '#9ca3af', child: endNode('end-rejected') }],
-  };
-
-  // ── Tag as Unqualified → End ──
-  const tagUnqualifiedNode: TreeNode = {
-    id: 'tag-unqualified', type: 'tag', title: 'Tag as Unqualified',
-    description: '',
-    branches: [{ label: '', color: '#9ca3af', child: endNode('end-unqual') }],
-  };
-
-  // ── Build the "after accepted" chain depending on what's selected ──
-  function buildAcceptedChain(): TreeNode {
-    if (hasMessage) {
-      const msgNode: TreeNode = {
-        id: messageStep?.id || 'followup-msg',
-        type: 'linkedin_message',
-        title: messageStep?.title || 'Send Follow-up Message',
-        description: messageStep?.description || 'Message after connection accepted',
-        branches: [{ label: '', color: '#9ca3af', child: channelTail || endNode('end-followup') }],
-      };
-      return msgNode;
-    }
-    return channelTail || endNode('end-accepted');
-  }
-
-  // ── Build Connection Request node with branches ──
-  function buildConnectionNode(): TreeNode {
-    const acceptedChild = buildAcceptedChain();
-    const softBumpNode: TreeNode = {
-      id: 'soft-bump', type: 'linkedin_message',
-      title: 'Soft Bump', description: 'Gentle reminder after 7 days',
-      branches: [{
-        label: '', color: '#9ca3af',
-        child: {
-          id: 'nurture-list', type: 'delay',
-          title: 'Nurture List', description: 'Long-term follow-up',
-          branches: [{ label: '', color: '#9ca3af', child: endNode('end-nurture') }],
-        },
-      }],
-    };
-    return {
-      id: connectStep?.id || 'connect',
-      type: 'linkedin_connect',
-      title: connectStep?.title || 'Send Connection Request',
-      description: connectStep?.description || 'Auto-connect with leads on LinkedIn',
-      branches: [
-        { label: 'Accepted',       color: '#22c55e', child: acceptedChild },
-        { label: 'No Response 7d', color: '#f59e0b', child: softBumpNode },
-        { label: 'Rejected',       color: '#ef4444', child: tagExitNode },
-      ],
-    };
-  }
-
-  // ── Build Visit Profile node ──
-  function buildVisitNode(): TreeNode {
-    return {
-      id: visitStep?.id || 'visit',
-      type: 'linkedin_visit',
-      title: visitStep?.title || 'View Profile',
-      description: visitStep?.description || 'Visit their LinkedIn profile',
-      branches: [{ label: '', color: '#9ca3af', child: endNode('end-visit') }],
-    };
-  }
-
-  // ── Lead Search node ──
-  const leadSearchNode: TreeNode = {
-    id: leadStep?.id || 'lead-gen',
-    type: 'lead_generation',
-    title: leadStep?.title || 'LinkedIn Lead Search',
-    description: `Search ${leadStep?.leadLimit || 20}-50 leads/day`,
-  };
-
-  // ── Wire up Lead Search branches based on selected actions ──
-  const hasAnyAction = hasConnect || hasMessage || hasVisit;
-
-  if (hasAnyAction) {
-    const qualifiedBranches: TreeBranch[] = [];
-
-    if (hasConnect) {
-      qualifiedBranches.push({
-        label: hasVisit ? 'Connect' : 'Qualified',
-        color: '#22c55e',
-        child: buildConnectionNode(),
-      });
-    } else if (hasMessage) {
-      // Message only (no connect)
-      const msgNode: TreeNode = {
-        id: messageStep?.id || 'direct-msg',
-        type: 'linkedin_message',
-        title: messageStep?.title || 'Send Follow-up Message',
-        description: messageStep?.description || 'Direct message to lead',
-        branches: [{ label: '', color: '#9ca3af', child: channelTail || endNode('end-msg') }],
-      };
-      qualifiedBranches.push({
-        label: hasVisit ? 'Message' : 'Qualified',
-        color: '#22c55e',
-        child: msgNode,
-      });
-    }
-
-    if (hasVisit) {
-      qualifiedBranches.push({
-        label: 'View Only',
-        color: '#3b82f6',
-        child: buildVisitNode(),
-      });
-    }
-
-    // Always add unqualified branch when there are actions
-    qualifiedBranches.push({
-      label: 'Unqualified',
-      color: '#ef4444',
-      child: tagUnqualifiedNode,
-    });
-
-    leadSearchNode.branches = qualifiedBranches;
-  } else {
-    // No actions selected yet → just lead search → end
-    leadSearchNode.branches = [
-      { label: '', color: '#9ca3af', child: endNode('end-main') },
-    ];
-  }
-
-  // ── Start → Lead Search ──
-  const firstStep = hasLeadGen ? leadSearchNode : (steps[0] ? {
-    id: steps[0].id,
-    type: steps[0].type,
-    title: steps[0].title,
-    description: steps[0].description,
-    branches: [{ label: '', color: '#9ca3af', child: endNode('end-simple') }],
-  } as TreeNode : endNode('end-empty'));
-
-  const startNode: TreeNode = {
-    id: 'start',
-    type: 'start',
-    title: 'Start',
-    description: 'Campaign begins',
-    branches: [{ label: '', color: '#9ca3af', child: firstStep }],
-  };
-
-  return startNode;
-}
-
-/* ═══════════════════════════════════════════════════════════════════
-   LAYOUT — flatten tree into ReactFlow nodes + edges
-   ═══════════════════════════════════════════════════════════════════ */
-
-const Y_GAP = 180;   // Vertical gap between rows
-const X_GAP = 220;   // Minimum horizontal space per subtree
-
-interface LayoutResult {
-  width: number;
-  nodes: Node[];
-  edges: Edge[];
-}
-
-function layoutTree(node: TreeNode, cx: number, y: number): LayoutResult {
-  const nodes: Node[] = [];
-  const edges: Edge[] = [];
-
-  // Add this node at (cx, y)
-  nodes.push({
-    id: node.id,
+function linearNode(id: string, type: string, title: string, description: string, index: number): Node {
+  return {
+    id,
     type: 'custom',
-    position: { x: cx, y },
+    position: { x: LINEAR_CX, y: LINEAR_Y0 + index * Y_GAP },
     draggable: true,
-    data: {
-      title: node.title,
-      type: node.type,
-      description: node.description,
-      _layout: 'vertical',
-    },
-  });
-
-  if (!node.branches || node.branches.length === 0) {
-    return { width: X_GAP, nodes, edges };
-  }
-
-  // Single unlabeled child → stack vertically centered
-  if (node.branches.length === 1 && !node.branches[0].label) {
-    const br = node.branches[0];
-    const child = layoutTree(br.child, cx, y + Y_GAP);
-    edges.push(makeEdge(node.id, br.child.id, '', '#b0b8c4', false));
-    nodes.push(...child.nodes);
-    edges.push(...child.edges);
-    return { width: Math.max(X_GAP, child.width), nodes, edges };
-  }
-
-  // Multiple branches → spread horizontally
-  const childLayouts: LayoutResult[] = node.branches.map(br =>
-    layoutTree(br.child, 0, y + Y_GAP)
-  );
-
-  const totalWidth = childLayouts.reduce((s, cl) => s + cl.width, 0);
-  const gap = 30;
-  const totalWithGaps = totalWidth + (childLayouts.length - 1) * gap;
-
-  let curX = cx - totalWithGaps / 2;
-
-  for (let i = 0; i < node.branches.length; i++) {
-    const br = node.branches[i];
-    const cl = childLayouts[i];
-    const childCX = curX + cl.width / 2;
-
-    // Offset child nodes
-    for (const n of cl.nodes) n.position.x += childCX;
-
-    edges.push(makeEdge(node.id, br.child.id, br.label, br.color, !!br.label));
-    nodes.push(...cl.nodes);
-    edges.push(...cl.edges);
-
-    curX += cl.width + gap;
-  }
-
-  return { width: Math.max(X_GAP, totalWithGaps), nodes, edges };
+    data: { title, type, description, _layout: 'vertical' },
+  };
 }
 
-function makeEdge(
-  src: string, tgt: string,
-  label: string, color: string,
-  isBranch: boolean,
-): Edge {
-  const c = label ? color : '#c4c9d4';
+function makeEdge(src: string, tgt: string): Edge {
+  const c = '#c4c9d4';
   return {
     id: `e-${src}-${tgt}`,
     source: src, sourceHandle: 'bottom',
     target: tgt, targetHandle: 'top',
-    type: label ? 'labeled' : 'smoothstep',
-    animated: !label,
-    data: { label, color: c },
-    style: {
-      stroke: c,
-      strokeWidth: label ? 2.5 : 2,
-      strokeDasharray: label ? undefined : '6,6',
-    },
-    markerEnd: {
-      type: MarkerType.ArrowClosed,
-      color: c,
-      width: 10,
-      height: 10,
-    },
+    type: 'smoothstep',
+    animated: true,
+    data: { label: '', color: c },
+    style: { stroke: c, strokeWidth: 2, strokeDasharray: '6,6' },
+    markerEnd: { type: MarkerType.ArrowClosed, color: c, width: 10, height: 10 },
   };
 }
 
-/* ═══════════════════════════════════════════════════════════════════
-   PUBLIC API
-   ═══════════════════════════════════════════════════════════════════ */
-
 export function createReactFlowNodes(
   workflowPreview: WorkflowPreviewStep[] | null,
-  layout: WorkflowLayout = 'vertical',
+  _layout: WorkflowLayout = 'vertical',
 ): Node[] {
-  if (!workflowPreview || workflowPreview.length === 0) {
-    return [
-      {
-        id: 'start', type: 'custom', position: { x: 300, y: 40 }, draggable: true,
-        data: { title: 'Start', type: 'start', description: 'Campaign begins', _layout: 'vertical' },
-      },
-      {
-        id: 'end', type: 'custom', position: { x: 300, y: 220 }, draggable: true,
-        data: { title: 'End', type: 'end', description: 'Campaign ends', _layout: 'vertical' },
-      },
-    ];
-  }
-
-  const tree = buildBranchingTree(workflowPreview);
-  return layoutTree(tree, 420, 40).nodes;
+  const steps = workflowPreview || [];
+  const nodes: Node[] = [linearNode('start', 'start', 'Start', 'Campaign begins', 0)];
+  steps.forEach((s, i) => {
+    nodes.push(linearNode(s.id, s.type, s.title, s.description || '', i + 1));
+  });
+  nodes.push(linearNode('end', 'end', 'End', 'Campaign ends', steps.length + 1));
+  return nodes;
 }
 
 export function createReactFlowEdges(
   workflowPreview: WorkflowPreviewStep[] | null,
-  layout: WorkflowLayout = 'vertical',
+  _layout: WorkflowLayout = 'vertical',
 ): Edge[] {
-  if (!workflowPreview || workflowPreview.length === 0) {
-    return [{
-      id: 'e-start-end',
-      source: 'start', sourceHandle: 'bottom',
-      target: 'end', targetHandle: 'top',
-      type: 'smoothstep', animated: true,
-      style: { stroke: '#d1d5db', strokeWidth: 2, strokeDasharray: '8,6' },
-    }];
+  const steps = workflowPreview || [];
+  // Node ids in spine order: start → each step id → end.
+  const spine = ['start', ...steps.map((s) => s.id), 'end'];
+  const edges: Edge[] = [];
+  for (let i = 0; i < spine.length - 1; i++) {
+    edges.push(makeEdge(spine[i], spine[i + 1]));
   }
-
-  const tree = buildBranchingTree(workflowPreview);
-  return layoutTree(tree, 420, 40).edges;
+  return edges;
 }


### PR DESCRIPTION
> **Draft** — code + logic are verified (below); it still needs an interactive click-through on a **logged-in session against a backend**, which I couldn't do in the local preview (the onboarding funnel is auth-gated). QA steps at the bottom.

## What & why

On `/onboarding/advanced-search-ai`, the guided **config** and the **Workflow Builder** canvas were reading *different* state and the code meant to sync them was dead:

- The canvas rendered from `cpActions`/`cpNextChannels`/`cpTriggerCondition` via a one-way effect that **destructively overwrote** the steps array on every config change — clobbering canvas edits.
- LinkedIn actions the user toggled wrote to an **orphaned** local `liChannelActions` that never flowed to `cpActions`, so they never appeared in the canvas.
- The canvas **invented** decorative branch nodes (Accepted / No-Response / Soft Bump / Nurture…) that weren't real steps, making node↔step mapping ambiguous.

## The unification

The onboarding store's **`workflowPreview` steps array is now the single source of truth**, edited from both sides in real time:

- **`configStepsSync.ts`** (new, pure, unit-verified): `deriveConfig(steps)` reads the structural config back out; `applyConfig(steps, patch)` reconciles a config edit into the steps, **preserving each step's per-step content** (message/delay/condition) by type. Channel steps materialise **even without a trigger** — this fixes the impedance mismatch that dropped "channels selected before a trigger" and broke edit-mode hydration.
- **`page.tsx`**: `cpActions`/`cpNextChannels`/`cpTriggerCondition` are now **derived** from `workflowPreview` (`useMemo`); their setters reconcile back into it. The destructive derive-effect is gone. The child's orphaned `liChannelActions` now uses the shared `actions`/`setActions` props. The launch builder reads the derived values, so it reflects canvas edits **with no launch-flow rewrite**.
- **`workflowFlowBuilder.ts`**: the canvas is now a **faithful linear 1:1** (Start → one node per step → End).

Channel account/template/provider selections (email account, WA account, voice agent) stay **campaign-level** (one per campaign, not per node) and merge at launch, as before — this is the deliberate scope line.

## Verified
- ✅ **Pure sync logic — 10/10 deterministic tests**: round-trip `derive∘build` identity; channels materialise without a trigger; deleting a node drops it from config; per-step message preserved across a reconcile; sequential hydration (actions→channels→trigger) builds full config with no channel loss (the old bug).
- ✅ **tsc clean** on all 3 changed files (the only repo tsc errors are pre-existing, in `deals-pipeline/store.backup/`).
- ✅ App boots; `/onboarding/advanced-search-ai` compiles (307 auth-redirect, not a 500).

## QA before merge (needs a logged-in session)
1. Create flow: toggle LinkedIn **connect** → a Connection node appears in the Workflow tab; untoggle → it disappears.
2. Add an **email**/**whatsapp** channel in config → node appears; pick a trigger → a Wait node appears before the channels.
3. In the canvas, **delete** a channel node → the config channel unchecks.
4. Edit-mode: open an existing campaign via **Edit Workflow** → the canvas + config both reflect the saved steps (hydration).
5. **Launch/Save** a campaign → confirm the persisted steps match what's shown (the launch payload reads the derived config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)