### PR TITLE
feat(leads): show company name under lead name in list rows

### DIFF
--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -4383,8 +4383,10 @@ export default function AdvancedSearchAIPage() {
                                                         )}
                                                     </div>
                                                     <div className="adv-lead-title">
-                                                        {lead.headline || lead.current_company || (lead.profile_url ? 'LinkedIn User' : lead.phone ? 'Phone Contact' : lead.email ? 'Email Contact' : 'Contact')}
+                                                        {lead.headline || (lead.profile_url ? 'LinkedIn User' : lead.phone ? 'Phone Contact' : lead.email ? 'Email Contact' : 'Contact')}
                                                     </div>
+                                                    {/* Company name under the name/title */}
+                                                    {lead.current_company && <div className="adv-lead-company">{lead.current_company}</div>}
                                                     {lead.location && <div className="adv-lead-location">📍 {lead.location}</div>}
                                                     {lead.inferred_nationality && (
                                                         <div style={{ display: 'flex', alignItems: 'center', gap: '4px', marginTop: '3px' }}>
@@ -4539,8 +4541,10 @@ export default function AdvancedSearchAIPage() {
                                                                 )}
                                                             </div>
                                                             <div className="adv-lead-title" style={{ color: '#9ca3af' }}>
-                                                                {lead.headline || lead.current_company || (lead.profile_url ? 'LinkedIn User' : 'Contact')}
+                                                                {lead.headline || (lead.profile_url ? 'LinkedIn User' : 'Contact')}
                                                             </div>
+                                                            {/* Company name under the name/title */}
+                                                            {lead.current_company && <div className="adv-lead-company" style={{ color: '#9ca3af' }}>{lead.current_company}</div>}
                                                             {lead.location && <div className="adv-lead-location" style={{ color: '#9ca3af' }}>📍 {lead.location}</div>}
                                                             {lead.icp_reasoning && (
                                                                 <div style={{ fontSize: '11px', color: '#9ca3af', marginTop: '4px', lineHeight: '1.4', fontStyle: 'italic' }}>
@@ -9170,6 +9174,7 @@ const css = `
             .adv-lead-name {font-size:14px; font-weight:700; color:#111827; display:flex; align-items:center; gap:4px; }
             .adv-verified {background:#10b981; color:#fff; border-radius:50%; width:16px; height:16px; display:inline-flex; align-items:center; justify-content:center; font-size:9px; font-weight:800; }
             .adv-lead-title {font-size:12px; color:#6b7280; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+            .adv-lead-company {font-size:12px; font-weight:600; color:#374151; margin-top:1px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
             .adv-lead-platform {margin - top:4px; display:flex; gap:4px; }
             .adv-lead-action {width:36px; height:36px; border-radius:50%; border:1.5px solid #e5e7eb; background:#fff; display:flex; align-items:center; justify-content:center; cursor:pointer; flex-shrink:0; transition:all .15s; }
             .adv-lead-action:hover:not(:disabled) {border-color:#0b1957; background:#f2f6fa; }
@@ -9566,6 +9571,7 @@ const css = `
             .dark .adv-lead-card:hover { background: #253456; }
             .dark .adv-lead-name { color: #ffffff; }
             .dark .adv-lead-title { color: #7a8ba3; }
+            .dark .adv-lead-company { color: #b8c4d6; }
             .dark .adv-lead-action { background: #1A2A43; border-color: #000724; color: #ffffff; }
             .dark .adv-lead-action:hover:not(:disabled) { border-color: #000724; background: #253456; }
             .dark .adv-lead-avatar-img { border-color: #000724; }

--- a/web/src/components/campaigns/EmployeeCard.tsx
+++ b/web/src/components/campaigns/EmployeeCard.tsx
@@ -194,14 +194,12 @@ export default function EmployeeCard({
             {(employee.title || employee.company) && (
               <div
                 className={`
-                  text-sm text-gray-600 dark:text-[#7a8ba3] w-full min-w-0
-                  ${employeeViewMode === 'grid' ? 'text-center' : 'text-left'}
+                  flex flex-col gap-1 w-full min-w-0
+                  text-sm text-gray-600 dark:text-[#7a8ba3]
+                  ${employeeViewMode === 'grid' ? 'items-center text-center' : 'items-start text-left'}
                 `}
               >
-                {employee.title && employee.company && (
-                  <span className="line-clamp-2 break-words">{employee.title} at {employee.company}</span>
-                )}
-                {employee.title && !employee.company && (
+                {employee.title && (
                   <Badge
                     variant="default"
                     className={`
@@ -212,8 +210,11 @@ export default function EmployeeCard({
                     {employee.title}
                   </Badge>
                 )}
-                {!employee.title && employee.company && (
-                  <span className="line-clamp-1 break-words">{employee.company}</span>
+                {/* Company shown on its own line, under the name/title chip */}
+                {employee.company && (
+                  <span className="line-clamp-1 break-words text-gray-500 dark:text-[#7a8ba3]">
+                    {employee.company}
+                  </span>
                 )}
               </div>
             )}


### PR DESCRIPTION
## What & why

Show the lead's **company on its own line, under the name and title chip**, in the lead result rows so users can see where each lead works at a glance. Pairs with the backend PR (techiemaya-admin/LAD-Backend#339) that produces the ICP-grounded profile summary shown in the detail dialog.

## Changes

- **`web/src/components/campaigns/EmployeeCard.tsx`** (used by `campaigns/leads` and `campaigns/[id]/analytics/leads`): the title is now a chip with the **company on a separate line beneath it** (previously `Title at Company` on one line).
- **`web/src/app/onboarding/advanced-search-ai/page.tsx`** results panel (both card variants): add a company line under the title chip, backed by a new `.adv-lead-company` style (light + dark). Company is no longer only a title fallback.
- Empty company is handled gracefully — the line is omitted when unknown.

## Notes

- The profile-summary **dialog wiring already exists** on `develop` (loading state + endpoint calls on all three pages); this PR does not change it. The backend PR is what upgrades the summary content and adds the graceful "not enough data" message (which flows through the existing `summary` prop).
- Typecheck: no new errors introduced by these files (pre-existing errors are confined to `features/deals-pipeline/store.backup/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)