### PR TITLE
feat(campaigns): Scheduled Follow-ups manager modal (schedule/remove per accepted lead)

### DIFF
--- a/web/src/app/api/campaigns/[id]/leads/[leadId]/scheduled-followups/[followupId]/route.ts
+++ b/web/src/app/api/campaigns/[id]/leads/[leadId]/scheduled-followups/[followupId]/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function getBackendBase() {
+  return (process.env.BACKEND_INTERNAL_URL || '').replace(/\/$/, '');
+}
+function getAuthHeaders(req: NextRequest): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const token = req.cookies.get('token')?.value || req.headers.get('authorization')?.replace('Bearer ', '');
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+/** DELETE /api/campaigns/[id]/leads/[leadId]/scheduled-followups/[followupId] — remove a pending follow-up */
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; leadId: string; followupId: string }> }
+) {
+  try {
+    const { id, leadId, followupId } = await params;
+    const url = `${getBackendBase()}/api/campaigns/${id}/leads/${leadId}/scheduled-followups/${followupId}`;
+    const resp = await fetch(url, { method: 'DELETE', headers: getAuthHeaders(req) });
+    const data = await resp.json().catch(() => ({}));
+    return NextResponse.json(data, { status: resp.ok ? 200 : resp.status });
+  } catch (e: any) {
+    return NextResponse.json({ error: 'Internal error', details: e?.message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/campaigns/[id]/leads/[leadId]/scheduled-followups/route.ts
+++ b/web/src/app/api/campaigns/[id]/leads/[leadId]/scheduled-followups/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function getBackendBase() {
+  return (process.env.BACKEND_INTERNAL_URL || '').replace(/\/$/, '');
+}
+function getAuthHeaders(req: NextRequest): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const token = req.cookies.get('token')?.value || req.headers.get('authorization')?.replace('Bearer ', '');
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+/** POST /api/campaigns/[id]/leads/[leadId]/scheduled-followups — schedule one more follow-up */
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string; leadId: string }> }
+) {
+  try {
+    const { id, leadId } = await params;
+    const body = await req.json().catch(() => ({}));
+    const url = `${getBackendBase()}/api/campaigns/${id}/leads/${leadId}/scheduled-followups`;
+    const resp = await fetch(url, { method: 'POST', headers: getAuthHeaders(req), body: JSON.stringify(body) });
+    const data = await resp.json().catch(() => ({}));
+    return NextResponse.json(data, { status: resp.ok ? 200 : resp.status });
+  } catch (e: any) {
+    return NextResponse.json({ error: 'Internal error', details: e?.message }, { status: 500 });
+  }
+}

--- a/web/src/app/api/campaigns/[id]/scheduled-followups/route.ts
+++ b/web/src/app/api/campaigns/[id]/scheduled-followups/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+function getBackendBase() {
+  return (process.env.BACKEND_INTERNAL_URL || '').replace(/\/$/, '');
+}
+function getAuthHeaders(req: NextRequest): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const token = req.cookies.get('token')?.value || req.headers.get('authorization')?.replace('Bearer ', '');
+  if (token) headers['Authorization'] = `Bearer ${token}`;
+  return headers;
+}
+
+/** GET /api/campaigns/[id]/scheduled-followups — accepted leads + their scheduled follow-ups */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const url = `${getBackendBase()}/api/campaigns/${id}/scheduled-followups`;
+    const resp = await fetch(url, { method: 'GET', headers: getAuthHeaders(req), cache: 'no-store' });
+    const data = await resp.json().catch(() => ({}));
+    return NextResponse.json(data, { status: resp.ok ? 200 : resp.status });
+  } catch (e: any) {
+    return NextResponse.json({ error: 'Internal error', details: e?.message }, { status: 500 });
+  }
+}

--- a/web/src/app/campaigns/[id]/analytics/page.tsx
+++ b/web/src/app/campaigns/[id]/analytics/page.tsx
@@ -13,12 +13,13 @@ import {
   AlertCircle, Linkedin, Phone, MessageCircle,
   Reply, MousePointerClick, BarChart, Activity, Rocket, Zap, Lightbulb,
   Megaphone, Gauge, Moon, Sun, Wifi, WifiOff, Loader2, RadioTower,
-  SquarePen, Sparkles, ChevronDown, ChevronUp, RefreshCw
+  SquarePen, Sparkles, ChevronDown, ChevronUp, RefreshCw, CalendarClock
 } from 'lucide-react';
 import { useCampaignAnalytics, useCampaignLeads } from '@lad/frontend-features/campaigns';
 import { useToast } from '@/components/ui/app-toaster';
 import AnalyticsCharts from '@/components/analytics/AnalyticsCharts';
 import { LiveActivityTable } from '@/components/campaigns';
+import ScheduledFollowupsModal from '@/components/campaigns/ScheduledFollowupsModal';
 import { LiveBadge } from '@/components/LiveBadge';
 import { proxyPost } from '@/lib/api';
 
@@ -62,6 +63,7 @@ export default function CampaignAnalyticsPage() {
   // ── Bulk Follow-up state ───────────────────────────────────────────────────
   const { leads: allLeads, loading: leadsLoading } = useCampaignLeads(campaignId);
   const [followupPanelOpen, setFollowupPanelOpen] = useState(false);
+  const [scheduleManagerOpen, setScheduleManagerOpen] = useState(false);
   const [selectedLeadIds, setSelectedLeadIds] = useState<Set<string>>(new Set());
   const [bulkChannel, setBulkChannel] = useState<string>('');
   const [bulkStatus, setBulkStatus] = useState<'idle' | 'running' | 'done'>('idle');
@@ -586,28 +588,40 @@ export default function CampaignAnalyticsPage() {
       {/* ── Bulk Follow-up Panel ────────────────────────────────────────── */}
       <div className="mb-8">
         {/* Collapsed header — always visible */}
-        <button
-          onClick={() => { setFollowupPanelOpen(v => !v); setBulkStatus('idle'); setLeadProgress([]); setSelectedLeadIds(new Set()); }}
-          className="w-full flex items-center justify-between px-5 py-4 bg-white dark:bg-[#1a2a43] rounded-2xl border border-slate-200 dark:border-[#262831] shadow-sm hover:border-[#0b1957]/40 hover:shadow-md transition-all"
-        >
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 rounded-full bg-[#0b1957]/10 flex items-center justify-center">
-              <Send className="w-5 h-5 text-[#0b1957]" />
+        <div className="flex items-stretch gap-2">
+          <button
+            onClick={() => { setFollowupPanelOpen(v => !v); setBulkStatus('idle'); setLeadProgress([]); setSelectedLeadIds(new Set()); }}
+            className="flex-1 flex items-center justify-between px-5 py-4 bg-white dark:bg-[#1a2a43] rounded-2xl border border-slate-200 dark:border-[#262831] shadow-sm hover:border-[#0b1957]/40 hover:shadow-md transition-all"
+          >
+            <div className="flex items-center gap-3">
+              <div className="w-10 h-10 rounded-full bg-[#0b1957]/10 flex items-center justify-center">
+                <Send className="w-5 h-5 text-[#0b1957]" />
+              </div>
+              <div className="text-left">
+                <p className="font-bold text-[#1E293B] dark:text-white text-base">Send Follow-up</p>
+                <p className="text-xs text-slate-500 dark:text-[#7a8ba3]">Select leads → choose channel → AI generates personalised messages and sends</p>
+              </div>
             </div>
-            <div className="text-left">
-              <p className="font-bold text-[#1E293B] dark:text-white text-base">Send Follow-up</p>
-              <p className="text-xs text-slate-500 dark:text-[#7a8ba3]">Select leads → choose channel → AI generates personalised messages and sends</p>
+            <div className="flex items-center gap-3">
+              {selectedLeadIds.size > 0 && !followupPanelOpen && (
+                <span className="text-xs bg-[#0b1957] text-white px-2.5 py-1 rounded-full font-semibold">
+                  {selectedLeadIds.size} selected
+                </span>
+              )}
+              {followupPanelOpen ? <ChevronUp className="w-5 h-5 text-slate-400" /> : <ChevronDown className="w-5 h-5 text-slate-400" />}
             </div>
-          </div>
-          <div className="flex items-center gap-3">
-            {selectedLeadIds.size > 0 && !followupPanelOpen && (
-              <span className="text-xs bg-[#0b1957] text-white px-2.5 py-1 rounded-full font-semibold">
-                {selectedLeadIds.size} selected
-              </span>
-            )}
-            {followupPanelOpen ? <ChevronUp className="w-5 h-5 text-slate-400" /> : <ChevronDown className="w-5 h-5 text-slate-400" />}
-          </div>
-        </button>
+          </button>
+
+          {/* Manage the auto follow-up SCHEDULE for connection-accepted leads */}
+          <button
+            onClick={() => setScheduleManagerOpen(true)}
+            title="View & manage scheduled follow-ups for connection-accepted leads"
+            className="flex items-center gap-2 px-4 rounded-2xl border border-slate-200 dark:border-[#262831] bg-white dark:bg-[#1a2a43] text-sm font-semibold text-[#0b1957] dark:text-white shadow-sm hover:border-[#0b1957]/40 hover:shadow-md transition-all whitespace-nowrap"
+          >
+            <CalendarClock className="w-4 h-4" />
+            <span className="hidden sm:inline">Manage schedule</span>
+          </button>
+        </div>
 
         {/* Expanded panel */}
         {followupPanelOpen && (
@@ -976,6 +990,13 @@ export default function CampaignAnalyticsPage() {
           <Button onClick={() => router.push(`/campaigns/${campaignId}`)} style={{ background: 'linear-gradient(135deg, #6366F1 0%, #8B5CF6 100%)' }} className="font-semibold">Configure Campaign</Button>
         </Card>
       )} */}
+
+      {/* Scheduled Follow-ups manager (connection-accepted leads) */}
+      <ScheduledFollowupsModal
+        campaignId={campaignId}
+        open={scheduleManagerOpen}
+        onClose={() => setScheduleManagerOpen(false)}
+      />
     </div>
   );
 }

--- a/web/src/components/campaigns/ScheduledFollowupsModal.tsx
+++ b/web/src/components/campaigns/ScheduledFollowupsModal.tsx
@@ -1,0 +1,456 @@
+'use client';
+
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useToast } from '@/components/ui/app-toaster';
+import { proxyGet, proxyPost, proxyDelete } from '@/lib/api';
+import {
+  CalendarClock, Clock, Loader2, Plus, Trash2, Linkedin, Search,
+  CheckCircle2, ChevronUp, CalendarPlus,
+} from 'lucide-react';
+
+type FollowupStatus = 'pending' | 'sent' | 'failed' | 'cancelled';
+
+interface Followup {
+  id: string;
+  followupNumber: number;
+  scheduledAt: string;
+  status: FollowupStatus;
+  parentStepId: string | null;
+  cancelledReason: string | null;
+  sentAt: string | null;
+  createdAt: string;
+}
+
+interface AcceptedLead {
+  campaignLeadId: string;
+  leadId: string | null;
+  acceptedAt: string | null;
+  name: string;
+  first_name: string;
+  title: string;
+  company: string;
+  linkedin_url: string;
+  photo_url: string | null;
+  followups: Followup[];
+  pendingCount: number;
+  sentCount: number;
+}
+
+interface Props {
+  campaignId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+const PRESETS: Array<{ label: string; hours: number }> = [
+  { label: '+1 day', hours: 24 },
+  { label: '+3 days', hours: 72 },
+  { label: '+7 days', hours: 168 },
+];
+
+function fmtDateTime(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleString(undefined, {
+    month: 'short', day: 'numeric', year: 'numeric', hour: 'numeric', minute: '2-digit',
+  });
+}
+
+/** Human "in 3 days" / "2 hours ago" style hint for a scheduled time. */
+function fmtRelative(iso: string | null): string {
+  if (!iso) return '';
+  const ms = new Date(iso).getTime() - Date.now();
+  if (Number.isNaN(ms)) return '';
+  const abs = Math.abs(ms);
+  const mins = Math.round(abs / 60000);
+  const hrs = Math.round(abs / 3600000);
+  const days = Math.round(abs / 86400000);
+  const unit = days >= 1 ? `${days} day${days === 1 ? '' : 's'}`
+    : hrs >= 1 ? `${hrs} hour${hrs === 1 ? '' : 's'}`
+    : `${Math.max(1, mins)} min`;
+  return ms >= 0 ? `in ${unit}` : `${unit} ago`;
+}
+
+/** Default value for a datetime-local input: now + 1 day, in local time. */
+function defaultLocalDateTime(): string {
+  const d = new Date(Date.now() + 24 * 3600 * 1000);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function initialOf(lead: AcceptedLead): string {
+  return (lead.first_name?.[0] || lead.name?.[0] || '?').toUpperCase();
+}
+
+export default function ScheduledFollowupsModal({ campaignId, open, onClose }: Props) {
+  const { push } = useToast();
+  const [leads, setLeads] = useState<AcceptedLead[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [search, setSearch] = useState('');
+  // Which lead's inline scheduler is open, plus its custom inputs.
+  const [schedulerFor, setSchedulerFor] = useState<string | null>(null);
+  const [customHours, setCustomHours] = useState('');
+  const [customWhen, setCustomWhen] = useState('');
+  // Per-action loading keys: `sched:<leadId>` and `rm:<followupId>`.
+  const [busy, setBusy] = useState<Set<string>>(new Set());
+
+  const setBusyKey = (key: string, on: boolean) =>
+    setBusy((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(key); else next.delete(key);
+      return next;
+    });
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await proxyGet<{ success: boolean; leads: AcceptedLead[] }>(
+        `/api/campaigns/${campaignId}/scheduled-followups`
+      );
+      setLeads(res.leads || []);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load scheduled follow-ups');
+    } finally {
+      setLoading(false);
+    }
+  }, [campaignId]);
+
+  useEffect(() => {
+    if (open) {
+      load();
+    } else {
+      // Reset transient UI when closed.
+      setSchedulerFor(null);
+      setSearch('');
+      setCustomHours('');
+      setCustomWhen('');
+    }
+  }, [open, load]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return leads;
+    return leads.filter((l) =>
+      [l.name, l.title, l.company].some((v) => (v || '').toLowerCase().includes(q))
+    );
+  }, [leads, search]);
+
+  const totalPending = useMemo(
+    () => leads.reduce((sum, l) => sum + (l.pendingCount || 0), 0),
+    [leads]
+  );
+
+  const openScheduler = (leadId: string) => {
+    setSchedulerFor((cur) => (cur === leadId ? null : leadId));
+    setCustomHours('');
+    setCustomWhen(defaultLocalDateTime());
+  };
+
+  const schedule = useCallback(
+    async (lead: AcceptedLead, body: { delayHours?: number; scheduledAt?: string }, label: string) => {
+      const key = `sched:${lead.campaignLeadId}`;
+      setBusyKey(key, true);
+      try {
+        await proxyPost<{ success: boolean; id?: string; error?: string }>(
+          `/api/campaigns/${campaignId}/leads/${lead.campaignLeadId}/scheduled-followups`,
+          body
+        );
+        push({ variant: 'success', title: 'Follow-up scheduled', description: `${lead.name} · ${label}` });
+        setSchedulerFor(null);
+        await load();
+      } catch (e: any) {
+        push({ variant: 'error', title: 'Could not schedule', description: e?.message || 'Please try again' });
+      } finally {
+        setBusyKey(key, false);
+      }
+    },
+    [campaignId, load, push]
+  );
+
+  const remove = useCallback(
+    async (lead: AcceptedLead, followup: Followup) => {
+      const key = `rm:${followup.id}`;
+      setBusyKey(key, true);
+      try {
+        await proxyDelete<{ success: boolean; removed?: number; error?: string }>(
+          `/api/campaigns/${campaignId}/leads/${lead.campaignLeadId}/scheduled-followups/${followup.id}`
+        );
+        push({ variant: 'success', title: 'Follow-up removed', description: `Scheduled ${fmtDateTime(followup.scheduledAt)}` });
+        await load();
+      } catch (e: any) {
+        push({ variant: 'error', title: 'Could not remove', description: e?.message || 'Please try again' });
+      } finally {
+        setBusyKey(key, false);
+      }
+    },
+    [campaignId, load, push]
+  );
+
+  const submitCustomHours = (lead: AcceptedLead) => {
+    const h = parseInt(customHours, 10);
+    if (!Number.isFinite(h) || h <= 0) {
+      push({ variant: 'warning', title: 'Enter hours', description: 'Enter a positive number of hours.' });
+      return;
+    }
+    schedule(lead, { delayHours: h }, `in ${h} hour${h === 1 ? '' : 's'}`);
+  };
+
+  const submitCustomWhen = (lead: AcceptedLead) => {
+    if (!customWhen) {
+      push({ variant: 'warning', title: 'Pick a time', description: 'Choose a date and time.' });
+      return;
+    }
+    const when = new Date(customWhen);
+    if (Number.isNaN(when.getTime()) || when.getTime() < Date.now()) {
+      push({ variant: 'warning', title: 'Pick a future time', description: 'The time must be in the future.' });
+      return;
+    }
+    schedule(lead, { scheduledAt: when.toISOString() }, fmtDateTime(when.toISOString()));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+      <DialogContent className="sm:max-w-3xl">
+        <DialogHeader>
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 rounded-full bg-[#0b1957]/10 flex items-center justify-center shrink-0">
+              <CalendarClock className="w-5 h-5 text-[#0b1957] dark:text-indigo-300" />
+            </div>
+            <div>
+              <DialogTitle>Scheduled Follow-ups</DialogTitle>
+              <DialogDescription>
+                Connection-accepted leads — schedule or remove upcoming LinkedIn follow-ups.
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+
+        {/* Search + summary */}
+        <div className="flex items-center gap-3 px-4 sm:px-8 py-3 border-b border-gray-100 dark:border-[#262831] shrink-0">
+          <div className="relative flex-1">
+            <Search className="w-4 h-4 text-slate-400 absolute left-3 top-1/2 -translate-y-1/2" />
+            <Input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search accepted leads…"
+              className="pl-9 h-9 rounded-xl"
+            />
+          </div>
+          <span className="text-xs font-semibold text-slate-500 dark:text-[#7a8ba3] whitespace-nowrap">
+            {leads.length} lead{leads.length === 1 ? '' : 's'} · {totalPending} scheduled
+          </span>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 overflow-y-auto px-4 sm:px-8 py-4">
+          {loading ? (
+            <div className="flex flex-col items-center justify-center py-16 text-slate-400">
+              <Loader2 className="w-6 h-6 animate-spin mb-2" />
+              <span className="text-sm">Loading scheduled follow-ups…</span>
+            </div>
+          ) : error ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <p className="text-sm text-rose-500 mb-3">{error}</p>
+              <Button variant="outline" size="sm" onClick={load}>Retry</Button>
+            </div>
+          ) : filtered.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center text-slate-400">
+              <CalendarClock className="w-8 h-8 mb-2 opacity-50" />
+              <p className="text-sm font-medium">
+                {leads.length === 0 ? 'No connection-accepted leads yet' : 'No leads match your search'}
+              </p>
+              {leads.length === 0 && (
+                <p className="text-xs mt-1">Once a lead accepts the connection, they’ll appear here.</p>
+              )}
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {filtered.map((lead) => {
+                const pending = lead.followups.filter((f) => f.status === 'pending');
+                const sent = lead.followups.filter((f) => f.status === 'sent');
+                const isSchedOpen = schedulerFor === lead.campaignLeadId;
+                const schedBusy = busy.has(`sched:${lead.campaignLeadId}`);
+                return (
+                  <div
+                    key={lead.campaignLeadId}
+                    className="rounded-2xl border border-slate-200 dark:border-[#262831] bg-white dark:bg-[#1a2a43] overflow-hidden"
+                  >
+                    {/* Lead header row */}
+                    <div className="flex items-center gap-3 px-4 py-3">
+                      {lead.photo_url ? (
+                        // eslint-disable-next-line @next/next/no-img-element
+                        <img src={lead.photo_url} alt={lead.name} className="w-9 h-9 rounded-full object-cover shrink-0" />
+                      ) : (
+                        <div className="w-9 h-9 rounded-full bg-[#0b1957]/10 dark:bg-indigo-500/20 flex items-center justify-center shrink-0">
+                          <span className="text-xs font-bold text-[#0b1957] dark:text-indigo-200">{initialOf(lead)}</span>
+                        </div>
+                      )}
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2">
+                          <p className="text-sm font-semibold text-slate-800 dark:text-white truncate">{lead.name}</p>
+                          {lead.linkedin_url && (
+                            <a
+                              href={lead.linkedin_url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-[#0A66C2] hover:opacity-80 shrink-0"
+                              title="Open LinkedIn profile"
+                            >
+                              <Linkedin className="w-3.5 h-3.5" />
+                            </a>
+                          )}
+                        </div>
+                        <p className="text-xs text-slate-400 dark:text-[#7a8ba3] truncate">
+                          {[lead.title, lead.company].filter(Boolean).join(' · ') || 'LinkedIn lead'}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2 shrink-0">
+                        <span
+                          className={
+                            'text-xs px-2.5 py-1 rounded-full font-semibold ' +
+                            (pending.length > 0
+                              ? 'bg-[#0b1957]/10 text-[#0b1957] dark:bg-indigo-500/20 dark:text-indigo-200'
+                              : 'bg-slate-100 text-slate-400 dark:bg-slate-800 dark:text-slate-500')
+                          }
+                        >
+                          {pending.length} scheduled
+                        </span>
+                        <Button
+                          size="sm"
+                          onClick={() => openScheduler(lead.campaignLeadId)}
+                          className="h-8 rounded-xl bg-[#0b1957] hover:bg-[#0b1957]/90 text-white text-xs font-semibold gap-1"
+                        >
+                          {isSchedOpen ? <ChevronUp className="w-3.5 h-3.5" /> : <Plus className="w-3.5 h-3.5" />}
+                          Schedule
+                        </Button>
+                      </div>
+                    </div>
+
+                    {/* Inline scheduler */}
+                    {isSchedOpen && (
+                      <div className="px-4 pb-4 pt-1 border-t border-slate-100 dark:border-[#262831] bg-slate-50/60 dark:bg-[#16233a]">
+                        <p className="text-xs font-semibold text-slate-500 dark:text-[#7a8ba3] mt-3 mb-2">
+                          Quick schedule
+                        </p>
+                        <div className="flex flex-wrap items-center gap-2">
+                          {PRESETS.map((p) => (
+                            <button
+                              key={p.hours}
+                              disabled={schedBusy}
+                              onClick={() => schedule(lead, { delayHours: p.hours }, p.label)}
+                              className="px-3 py-1.5 rounded-lg text-xs font-semibold border border-slate-200 dark:border-[#2c3d57] bg-white dark:bg-[#1a2a43] text-slate-700 dark:text-slate-200 hover:border-[#0b1957]/50 hover:text-[#0b1957] disabled:opacity-50 transition-colors"
+                            >
+                              {p.label}
+                            </button>
+                          ))}
+                          {schedBusy && <Loader2 className="w-4 h-4 animate-spin text-slate-400" />}
+                        </div>
+
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mt-3">
+                          {/* Custom hours */}
+                          <div>
+                            <label className="text-xs font-semibold text-slate-500 dark:text-[#7a8ba3] mb-1 block">
+                              In N hours
+                            </label>
+                            <div className="flex items-center gap-2">
+                              <Input
+                                type="number"
+                                min={1}
+                                value={customHours}
+                                onChange={(e) => setCustomHours(e.target.value)}
+                                placeholder="e.g. 12"
+                                className="h-9 rounded-xl"
+                              />
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={schedBusy}
+                                onClick={() => submitCustomHours(lead)}
+                                className="h-9 rounded-xl gap-1 shrink-0"
+                              >
+                                <Clock className="w-3.5 h-3.5" /> Add
+                              </Button>
+                            </div>
+                          </div>
+
+                          {/* Exact date/time */}
+                          <div>
+                            <label className="text-xs font-semibold text-slate-500 dark:text-[#7a8ba3] mb-1 block">
+                              At a specific time
+                            </label>
+                            <div className="flex items-center gap-2">
+                              <Input
+                                type="datetime-local"
+                                value={customWhen}
+                                onChange={(e) => setCustomWhen(e.target.value)}
+                                className="h-9 rounded-xl"
+                              />
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={schedBusy}
+                                onClick={() => submitCustomWhen(lead)}
+                                className="h-9 rounded-xl gap-1 shrink-0"
+                              >
+                                <CalendarPlus className="w-3.5 h-3.5" /> Add
+                              </Button>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Scheduled + sent list */}
+                    {(pending.length > 0 || sent.length > 0) && (
+                      <div className="px-4 pb-3 pt-1 border-t border-slate-100 dark:border-[#262831]">
+                        {pending.map((f) => {
+                          const rmBusy = busy.has(`rm:${f.id}`);
+                          return (
+                            <div key={f.id} className="flex items-center gap-2 py-1.5">
+                              <CalendarClock className="w-4 h-4 text-[#0b1957] dark:text-indigo-300 shrink-0" />
+                              <span className="text-sm text-slate-700 dark:text-slate-200">
+                                {fmtDateTime(f.scheduledAt)}
+                              </span>
+                              <span className="text-xs text-slate-400 dark:text-[#7a8ba3]">
+                                {fmtRelative(f.scheduledAt)}
+                              </span>
+                              <div className="flex-1" />
+                              <button
+                                disabled={rmBusy}
+                                onClick={() => remove(lead, f)}
+                                title="Remove scheduled follow-up"
+                                className="inline-flex items-center justify-center w-7 h-7 rounded-lg text-slate-400 hover:text-rose-600 hover:bg-rose-50 dark:hover:bg-rose-950/40 disabled:opacity-50 transition-colors"
+                              >
+                                {rmBusy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Trash2 className="w-4 h-4" />}
+                              </button>
+                            </div>
+                          );
+                        })}
+                        {sent.map((f) => (
+                          <div key={f.id} className="flex items-center gap-2 py-1.5 opacity-70">
+                            <CheckCircle2 className="w-4 h-4 text-emerald-500 shrink-0" />
+                            <span className="text-sm text-slate-500 dark:text-slate-400">
+                              Sent {fmtDateTime(f.sentAt || f.scheduledAt)}
+                            </span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
Adds a **Scheduled Follow-ups manager** to the campaign analytics page so users can, for a campaign's connection-accepted leads, view scheduled LinkedIn follow-ups, **schedule more**, and **remove** pending ones. Pairs with backend **PR #342**.

## UX
- A **"Manage schedule"** button sits on the existing **"Send Follow-up"** row (campaign analytics). Clicking it opens a modal.
- The modal lists each **connection-accepted lead** with a searchable list; per lead it shows scheduled (pending) follow-ups with their date + relative hint, and sent history.
- **Schedule more** offers *both* input styles (as requested): delay presets **+1d / +3d / +7d**, a custom **"in N hours"** field, and an **exact date/time** picker.
- **Remove** each pending follow-up with a trash button. Toasts confirm success/failure; the list refetches after each mutation.

## Files
- `components/campaigns/ScheduledFollowupsModal.tsx` — self-contained modal; fetches `/api/campaigns/:id/scheduled-followups`, schedules via POST, removes via DELETE.
- Next.js proxy routes → backend:
  - `GET  /api/campaigns/[id]/scheduled-followups`
  - `POST /api/campaigns/[id]/leads/[leadId]/scheduled-followups`
  - `DELETE /api/campaigns/[id]/leads/[leadId]/scheduled-followups/[followupId]`
- `campaigns/[id]/analytics/page.tsx` — "Manage schedule" button + modal wiring.

## Notes
- Reuses existing shadcn `Dialog`/`Button`/`Input`, `useToast`, and the `proxyGet/Post/Delete` API helpers; matches the navy (`#0b1957`)/indigo Tailwind theme incl. dark mode.
- `tsc --noEmit` and `eslint` are clean on the new/changed files (the 27 pre-existing `store.backup/**` tsc errors are untouched and unrelated).
- **QA recommendation:** authed click-through in a running env (schedule via preset + exact time, remove, empty/loading/error states) — the app has no FE test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)