### PR TITLE
fix(advanced-search): show AI summary for thin LinkedIn profiles (No summary available)

### DIFF
--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -1422,6 +1422,10 @@ export default function AdvancedSearchAIPage() {
                     forceRefresh ? null : (typeof data.data_age_days === 'number' ? data.data_age_days : null)
                 );
 
+                // Tracks whether we actually produced usable summary text — drives
+                // the AI-preview fallback below.
+                let summaryText = '';
+
                 // ── 1. Build rich text summary ─────────────────────────────────
                 if (data.profile_summary) {
                     const ps = data.profile_summary as any;
@@ -1455,13 +1459,14 @@ export default function AdvancedSearchAIPage() {
                         if (names) parts.push(`\n🌐 Languages: ${names}`);
                     }
                     const richSummary = parts.join('\n').trim();
-                    if (richSummary) setProfileSummary(richSummary);
+                    if (richSummary) { setProfileSummary(richSummary); summaryText = richSummary; }
                 } else if (data.company_profile) {
-                    setProfileSummary(
+                    const companyText = (
                         data.company_profile.overview ||
                         data.company_profile.description ||
-                        `${lead.current_company || 'Company'} — ${data.company_profile.industry || ''} ${data.company_profile.company_size_range ? `· ${data.company_profile.company_size_range} employees` : ''}`.trim()
-                    );
+                        `${lead.current_company || 'Company'} — ${data.company_profile.industry || ''} ${data.company_profile.company_size_range ? `· ${data.company_profile.company_size_range} employees` : ''}`
+                    ).trim();
+                    if (companyText) { setProfileSummary(companyText); summaryText = companyText; }
                 }
 
                 // ── 2. Web presence ────────────────────────────────────────────
@@ -1471,7 +1476,10 @@ export default function AdvancedSearchAIPage() {
                 if (data.recent_posts?.length) setProfileRecentPosts(data.recent_posts);
 
                 // ── 4. Fallback ────────────────────────────────────────────────
-                if (!data.profile_summary && !data.company_profile) {
+                // Run the AI preview whenever no usable summary text was produced —
+                // including a thin LinkedIn profile object (name/headline only, no
+                // about/experience), which previously rendered blank AND skipped this.
+                if (!summaryText) {
                     const fallback = await campaignCreation.fetchLeadSummaryPreview({
                         profileData: { name: lead.name, title: lead.headline || '', company: lead.current_company || '', linkedin_url: lead.profile_url || '' }
                     });


### PR DESCRIPTION
## Problem

On the advanced-search lead dialog, leads whose Unipile profile comes back **thin** (name + headline + location only — no about/experience/skills; common for 3rd-degree or classic-account results) show **"No summary available"** with a blank body, even though research ran.

Confirmed from a live stage response — `POST /api/campaigns/search-prospects/generate-summary` returned:
```json
"profile_summary": { "id": "ACoAAA…", "name": "Deepak Kotwani",
  "headline": "Managing Director @ Repografix …", "location": "United Arab Emirates",
  "profile_url": "…" }   // no about / experience / skills
```

## Root cause

`_loadSummary` builds the rich summary from `data.profile_summary` (the **raw Unipile profile object**). When that object has no usable text, the built summary is empty — **and because `data.profile_summary` is still a truthy object, the AI-preview fallback (`!data.profile_summary && !data.company_profile`) is skipped.** So the dialog renders blank and never falls back.

## Fix

Track whether usable summary text was actually produced (`summaryText`) and run the AI preview whenever it wasn't (`if (!summaryText)`), instead of gating on the mere presence of the profile object. Thin profiles now fall through to `POST /api/campaigns/preview/lead-summary`, which generates a real summary from name + title + company (ICP-grounded now that #339 is merged).

## Notes

- Frontend-only, isolated to `_loadSummary` (13 insertions / 5 deletions). Typecheck clean (no new errors).
- Follow-up to #623 — this fix was pushed *after* #623 merged, so it needs its own PR to reach `develop`/stage.
- The Campaigns → Leads dialog (different endpoint, `/leads/:id/summary`) was already covered by #339's graceful path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)