### PR TITLE
fix(fe): clean stage rebuild for proxyGet crash + report-only tsc type-check gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,83 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+  # ---------------------------------------------------------------------------
+  # Type-check gate (tsc --noEmit).
+  #
+  # Motivation: twice in one day a *missing export* reached users as a runtime
+  # crash because `next build` never type-checks — next.config.mjs sets
+  # `typescript.ignoreBuildErrors: true`. Examples:
+  #   • ScheduledFollowupsModal imported `proxyGet` from '@/lib/api' →
+  #     "(0 , et.proxyGet) is not a function" on stage.
+  #   • community-roi DataImportModal imported a non-existent '../hooks/useDataImport'.
+  # `tsc --noEmit` catches exactly this class ("X is not exported / Cannot find
+  # module") at PR time.
+  #
+  # PHASE 1 (this PR): REPORT-ONLY. develop currently has ~363 pre-existing type
+  # errors (masked until now by an invalid `ignoreDeprecations` value that made
+  # tsc short-circuit). We do NOT block merges on that debt — the job surfaces
+  # the count + full error list in the PR summary and warns on regressions above
+  # the baseline, but always exits 0.
+  #
+  # PHASE 2 (follow-up, after the baseline is burned down to 0): make this
+  # blocking (delete the `exit 0` / `|| true`) AND remove
+  # `typescript.ignoreBuildErrors` from next.config.mjs so `next build` enforces
+  # types too. Do them together.
+  # ---------------------------------------------------------------------------
+  type-check:
+    name: type-check (tsc --noEmit) [report-only]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          # Monorepo uses npm workspaces — the only lockfile is at the repo root.
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: .
+
+      - name: Type-check (report-only)
+        shell: bash
+        run: |
+          set -uo pipefail
+          # Known pre-existing error count on develop when this gate was added.
+          # Burn this down over time; when it reaches 0, flip the gate to blocking
+          # (see PHASE 2 note above).
+          BASELINE=363
+          npx tsc --noEmit > /tmp/tsc.log 2>&1 || true
+          COUNT=$(grep -cE ': error TS' /tmp/tsc.log || true)
+          {
+            echo "## TypeScript type-check (report-only)"
+            echo ""
+            echo "- Errors on this branch: **$COUNT**"
+            echo "- Known develop baseline: **$BASELINE**"
+            echo ""
+            if [ "$COUNT" -gt "$BASELINE" ]; then
+              echo "> ⚠️ **$((COUNT - BASELINE))** more type error(s) than baseline — likely a new missing export/import or type regression. Please fix before merge."
+            elif [ "$COUNT" -lt "$BASELINE" ]; then
+              echo "> ✅ **$((BASELINE - COUNT))** fewer than baseline — lower \`BASELINE\` in ci.yml to lock in the win."
+            else
+              echo "> No change vs baseline."
+            fi
+            echo ""
+            echo "<details><summary>Full tsc output</summary>"
+            echo ""
+            echo '```'
+            grep -E ': error TS' /tmp/tsc.log || echo '(no type errors)'
+            echo '```'
+            echo "</details>"
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ "$COUNT" -gt "$BASELINE" ]; then
+            echo "::warning::type-check found $COUNT errors ($((COUNT - BASELINE)) above baseline $BASELINE). Report-only for now; will block once the baseline is burned down."
+          fi
+          # PHASE 1 is report-only — never fail the build. Remove this line in PHASE 2.
+          exit 0

--- a/cloudbuild-stage.yaml
+++ b/cloudbuild-stage.yaml
@@ -22,16 +22,25 @@ steps:
         echo "Environment: STAGING"
         echo "=== End Debug ==="
 
-  # Build the Docker image with buildkit for better caching
+  # Build the Docker image.
+  #
+  # --no-cache is REQUIRED here (do NOT reintroduce --cache-from / inline cache).
+  # Reusing the cached `RUN npm run build` layer shipped a STALE Next.js bundle to
+  # stage where a newly-added component (ScheduledFollowupsModal) imported
+  # `proxyGet` from '@/lib/api' but the bundled module lacked that export, crashing
+  # at runtime with "(0 , et.proxyGet) is not a function" even though the source
+  # was correct. A clean build guarantees `next build` re-runs from scratch and the
+  # emitted client chunks always match current source. Stage deploys are infrequent,
+  # so paying for a full rebuild each time is an acceptable trade for correctness.
+  # (The web/cloudbuild-stage.yaml sibling already builds with --no-cache.)
   - name: 'gcr.io/cloud-builders/docker'
     args: [
       'build',
+      '--no-cache',
       '-t', 'gcr.io/$PROJECT_ID/lad-frontend-stage:$COMMIT_SHA',
       '-t', 'gcr.io/$PROJECT_ID/lad-frontend-stage:$SHORT_SHA',
       '-t', 'gcr.io/$PROJECT_ID/lad-frontend-stage:$BRANCH_NAME',
       '-t', 'gcr.io/$PROJECT_ID/lad-frontend-stage:latest',
-      '--cache-from', 'gcr.io/$PROJECT_ID/lad-frontend-stage:latest',
-      '--build-arg', 'BUILDKIT_INLINE_CACHE=1',
       '--build-arg', 'NEXT_PUBLIC_BACKEND_URL=$_API_URL',
       '--build-arg', 'NEXT_PUBLIC_ICP_BACKEND_URL=$_API_URL',
       '--build-arg', 'NEXT_PUBLIC_SOCKET_URL=$_NEXT_PUBLIC_SOCKET_URL',

--- a/web/next.config.mjs
+++ b/web/next.config.mjs
@@ -152,6 +152,16 @@ const nextConfig = {
     ];
   },
 
+  // ⚠️ TEMPORARY — not permanent.
+  // While this is true, `next build` skips type-checking entirely, which is how
+  // two missing-export runtime crashes shipped to users in one day (proxyGet
+  // from '@/lib/api'; community-roi's useDataImport). It stays true only because
+  // develop currently carries ~363 pre-existing type errors — flipping it now
+  // would fail every Docker / Cloud Run build.
+  // A report-only `tsc --noEmit` CI gate now surfaces these on every PR
+  // (.github/workflows/ci.yml → type-check job). PHASE 2: once that baseline is
+  // burned down to 0, DELETE this block and make the CI gate blocking so
+  // `next build` enforces types too.
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --webpack",
     "build": "next build --webpack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -17,7 +17,7 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "incremental": true,
-    "ignoreDeprecations": "6.0",
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".",
     "plugins": [
       {
@@ -59,6 +59,8 @@
     "../sdk/**/*.tsx"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "**/*.backup",
+    "**/*.backup/**"
   ]
 }


### PR DESCRIPTION
## Summary

Two-part fix for the **missing-export → runtime crash** class of bug that slipped past the build **twice in one day** (the stage `proxyGet` crash and the community-roi `useDataImport` crash). `next build` never type-checks because `next.config.mjs` sets `typescript.ignoreBuildErrors: true`, so a missing/renamed export ships to users instead of failing the build.

---

## Part A — stage crash `"(0 , et.proxyGet) is not a function"`

The **Scheduled Follow-ups / Manage schedule** modal (`web/src/components/campaigns/ScheduledFollowupsModal.tsx`) imports `{ proxyGet, proxyPost, proxyDelete }` from `@/lib/api` and calls `proxyGet('/api/campaigns/:id/scheduled-followups')` on open.

### Diagnosis (verified against `origin/*`, not the working tree)
- `origin/stage` **already ships** `proxyGet`/`proxyPost`/`proxyDelete` in `web/src/lib/api.ts` **and** the modal referencing them — internally consistent. `proxyGet` has existed since **2026-05-19**; `api.ts` is **identical** on stage and develop.
- `origin/stage` is **`develop` + 20 commits** (it merged develop this morning via #627); develop has **0** commits stage lacks.
- ⇒ **This is not a source mismatch. No develop→stage merge is needed. The modal is NOT deleted.** It's scenario #3 from the brief: a **stale build** — the deployed stage bundle's `@/lib/api` chunk lacked `proxyGet` even though the source has it.

### Fix
Root `cloudbuild-stage.yaml` (the config the stage trigger uses) reused the Docker `RUN npm run build` layer via `--cache-from …:latest` + `BUILDKIT_INLINE_CACHE=1`. Switched the stage image build to **`--no-cache`** (and dropped the now-dead cache flags) so `next build` always re-runs from scratch and emitted client chunks match current source. The `web/cloudbuild-stage.yaml` sibling already builds with `--no-cache`; this aligns the live root config with it.

### All modal calls confirmed to resolve
| call | route handler (exists on develop) |
|---|---|
| `proxyGet` `…/scheduled-followups` | `web/src/app/api/campaigns/[id]/scheduled-followups/route.ts` |
| `proxyPost` `…/leads/[leadId]/scheduled-followups` | `web/src/app/api/campaigns/[id]/leads/[leadId]/scheduled-followups/route.ts` |
| `proxyDelete` `…/scheduled-followups/[followupId]` | `web/src/app/api/campaigns/[id]/leads/[leadId]/scheduled-followups/[followupId]/route.ts` |

> [!IMPORTANT]
> **Operational step after merge:** the stage FE must be **rebuilt + redeployed** for the crash fix to take effect (source is already correct on stage; the running bundle is stale). This PR guarantees that rebuild is clean.

---

## Part B — stop this class from shipping (root cause)

`next build` doesn't type-check (`typescript.ignoreBuildErrors: true`), so "X is not exported from '@/lib/api'" only surfaces at runtime. This PR adds a `tsc --noEmit` gate.

### Changes
- **`web/package.json`** — add `"typecheck": "tsc --noEmit"`.
- **`web/tsconfig.json`** — **fix a latent footgun**: `ignoreDeprecations: "6.0"` is **invalid** for TypeScript 5.9, which made `tsc` short-circuit (`error TS5103`, exit 2) and **type-check nothing — masking every real error**. Changed to the valid `"5.0"`. Also excluded the dead `**/*.backup` dir (27 syntax errors in the unreferenced `deals-pipeline/store.backup/`, which sits next to the real `store/`).
- **`.github/workflows/ci.yml`** — new `type-check` job (Node 20, workspace `npm ci`, `npm run typecheck`).
- **`web/next.config.mjs`** — `ignoreBuildErrors` **kept for now** (see phasing), with a comment documenting why and the Phase-2 removal plan.

### ⚠️ Baseline: 363 pre-existing type errors → gate is REPORT-ONLY (phase 1)
Once the mask (`ignoreDeprecations`) is fixed, `tsc --noEmit` reveals **363 real, pre-existing type errors** on develop (reproduced deterministically; repo pins TS 5.9.3 so CI matches). Breakdown:

| bucket | count |
|---|---|
| `TS2339` property-does-not-exist | 112 |
| `TS2322` type-not-assignable | 97 |
| `TS7006` implicit-any | 27 |
| **`TS2307`/`TS2305`/`TS2614` cannot-find-module / no-exported-member** | **~30** |
| other | ~97 |

Those `TS2307` "Cannot find module" errors **are exactly this bug class** — including `components/community-roi/DataImportModal.tsx → '../hooks/useDataImport'` (**the other crash today**), `@clerk/nextjs/server`, `react-hook-form`, `xlsx`, etc.

Per the brief's pragmatic guidance, the gate ships **report-only / non-blocking**: it runs `tsc --noEmit`, prints the count + full error list to the PR's **job summary**, and warns on any regression **above** the 363 baseline — but **always exits 0**. This does **not** block FE PRs on the pre-existing type-debt, and `ignoreBuildErrors` stays so Docker/Cloud Run builds keep succeeding.

### Phase 2 (separate follow-up, after baseline burndown)
When the baseline reaches 0: delete the `exit 0` in the CI job (make it **blocking**) **and** remove the `typescript.ignoreBuildErrors` block in `next.config.mjs` so `next build` enforces types too. Both are one-line changes flagged in-code.

> Note: `eslint.ignoreDuringBuilds` is **not** present in `next.config.mjs` — nothing to remove; lint is already gated in `ci.yml`.

---

## Why now
This is the **second** missing-export runtime crash to reach users **today** (community-roi's `useDataImport` was the first). Both were invisible to the build because it never type-checks. The report-only gate makes them visible on every PR immediately, and sets up enforcement once the debt is burned down.

## Test plan
- [x] Verified stage/develop `api.ts` + modal state via `git show origin/<branch>:<path>` (source consistent; no merge needed).
- [x] `npm run typecheck` runs `tsc --noEmit`, exits 2 on errors, **363** errors, **no** TS5103 (short-circuit fixed).
- [x] `**/*.backup` exclude removes the 27 dead syntax errors.
- [x] `ci.yml` + `cloudbuild-stage.yaml` parse as valid YAML; `tsconfig.json`/`package.json` valid JSON.
- [ ] **After merge:** trigger a clean stage build and redeploy `lad-frontend-stage`; confirm the modal opens without the `proxyGet` crash.