### PR TITLE
feat(conversations): show exact date & time on LinkedIn message bubbles

### DIFF
--- a/web/src/components/conversations/LinkedInConversationView.tsx
+++ b/web/src/components/conversations/LinkedInConversationView.tsx
@@ -211,6 +211,25 @@ function relativeTime(isoString: string): string {
   }
 }
 
+// Exact, absolute date + time for message bubbles (e.g. "Jul 7, 2026, 3:42 PM").
+// Used instead of relative "Xm ago" so the precise send time is always visible.
+function exactDateTime(isoString: string): string {
+  if (!isoString) return '';
+  try {
+    const d = new Date(isoString);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleString(undefined, {
+      year:   'numeric',
+      month:  'short',
+      day:    'numeric',
+      hour:   'numeric',
+      minute: '2-digit',
+    });
+  } catch {
+    return '';
+  }
+}
+
 // ─── Conversation list item ───────────────────────────────────────────────────
 
 function ConvListItem({
@@ -315,7 +334,7 @@ function MessageBubble({ msg }: { msg: LinkedInMessage }) {
       >
         <p className="whitespace-pre-wrap break-words">{msg.content}</p>
         <p className={cn('text-[10px] mt-1 text-right', isOut ? 'text-blue-200' : 'text-slate-400')}>
-          {relativeTime(msg.created_at)}
+          {exactDateTime(msg.created_at)}
         </p>
       </div>
     </div>


### PR DESCRIPTION
LinkedIn conversation message bubbles showed **relative** timestamps ("26m ago", "11m ago", "10m ago"). This switches them to the **exact absolute date & time** (e.g. *"Jul 7, 2026, 3:42 PM"*) so the precise send time is always visible.

## Change
- New `exactDateTime()` helper (locale-aware `toLocaleString` with month/day/year + hour/minute).
- The message bubble timestamp now renders `exactDateTime(msg.created_at)` instead of `relativeTime(...)`.
- The **sidebar conversation list keeps relative time** ("Xm ago") — it's the compact, conventional density there; only the open thread's messages change, which is what was requested.

Single file, +20/-1. `tsc --noEmit` and `eslint` clean on the change (pre-existing `store.backup/**` type errors untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)