### PR TITLE
fix(conversations): LinkedIn chat Templates button crash (reading 'trim' of undefined)

### DIFF
--- a/web/src/components/conversations/LinkedInChatToolbar.tsx
+++ b/web/src/components/conversations/LinkedInChatToolbar.tsx
@@ -31,7 +31,10 @@ import {
 interface LinkedInTemplate {
   id: string;
   name: string;
-  message_text: string;
+  // The API (/api/campaigns/linkedin-message-templates) returns the body in the
+  // `content` column. A connection-only template can legitimately have a null
+  // content, so callers must guard before using it.
+  content: string | null;
   category?: string | null;
 }
 
@@ -215,10 +218,10 @@ export function LinkedInChatToolbar({
                 <DropdownMenuItem
                   key={t.id}
                   className="text-xs flex flex-col items-start gap-0.5 py-1.5"
-                  onClick={() => onInsertTemplate(t.message_text)}
+                  onClick={() => onInsertTemplate(t.content || '')}
                 >
                   <span className="font-medium text-slate-800 truncate w-full">{t.name}</span>
-                  <span className="text-[10px] text-slate-500 truncate w-full">{t.message_text}</span>
+                  <span className="text-[10px] text-slate-500 truncate w-full">{t.content || ''}</span>
                 </DropdownMenuItem>
               ))}
             </DropdownMenuContent>

--- a/web/src/components/conversations/LinkedInConversationView.tsx
+++ b/web/src/components/conversations/LinkedInConversationView.tsx
@@ -888,7 +888,12 @@ export function LinkedInConversationView({
               contextPanelOpen={contextPanelOpen}
               onToggleContextPanel={() => setContextPanelOpen(o => !o)}
               onInsertTemplate={(text) => {
-                setMessageText(prev => prev ? `${prev}\n${text}` : text);
+                // Coerce to a string so the input's value never becomes undefined
+                // (a null/empty template body would otherwise crash the next
+                // `messageText.trim()` render with "reading 'trim' of undefined").
+                const insert = text ?? '';
+                if (!insert) return;
+                setMessageText(prev => prev ? `${prev}\n${insert}` : insert);
               }}
               chatEnabled={chatEnabled}
             />


### PR DESCRIPTION
## Problem

Clicking the **Templates** button (and selecting a template) in the LinkedIn **chat window** toolbar throws and blanks the view:

```
TypeError: Cannot read properties of undefined (reading 'trim')
    at ed (page-….js)  ← LinkedInConversationView render
```

## Root cause — field-name mismatch

The list endpoint `GET /api/campaigns/linkedin-message-templates` returns each row's body in the **`content`** column (the `communication_templates.content` DB column). Both the backend repository and the sibling `advanced-search-ai` page read `content`.

But `LinkedInChatToolbar` declared the row shape as `{ message_text }` and read `t.message_text` — a field the API never sends, so it is always `undefined`:

1. Click a template → `onInsertTemplate(t.message_text)` = `onInsertTemplate(undefined)`.
2. Parent handler: `setMessageText(prev => prev ? \`${prev}\n${text}\` : text)` → with an empty input, `messageText` becomes **`undefined`**.
3. Next render reads `messageText.trim()` → **crash**.

## Fix (frontend only)

- `LinkedInChatToolbar` now reads the correct **`content`** field (typed `string | null` — a connection-only template can legitimately have null content), guarded with `|| ''` at both the insert and the preview render.
- Hardened the parent `onInsertTemplate` handler in `LinkedInConversationView` to coerce to a string and skip empty inserts, so a null/empty body can never poison the input value again (defense-in-depth at the exact crash site).

No backend change is needed — `content` is the canonical API/DB field; the toolbar was the lone outlier. The `LinkedInTemplate` interface is local to the toolbar (not exported), so no other consumers are affected.

## Verification

- Confirmed the API contract: backend inline route (`features/campaigns/routes/index.js`) `SELECT … content …`; repository stores/returns `content`; `advanced-search-ai/page.tsx` reads `d.data.content`.
- `tsc --noEmit` on the two changed files introduces **no new type errors** (only pre-existing baseline implicit-`any` noise on untouched lines remains).
- Traced the crash path end-to-end: wrong field → `undefined` → `setMessageText(undefined)` → `messageText.trim()`. Both the source (field) and the sink (coercion) are now fixed.

## Context

Surfaced now that the Templates → LinkedIn tab is unblocked (backend LAD-Backend #351, the camelCase JWT-claim fix), which lets tenants create LinkedIn templates that this toolbar then lists. Related route-duplication debt (slash vs hyphen template paths) is tracked in that backend PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)