### PR TITLE
fix(linkedin-chat): render {{vars}} + carry media on chat-toolbar template insert

### DIFF
--- a/web/src/components/conversations/LinkedInChatToolbar.tsx
+++ b/web/src/components/conversations/LinkedInChatToolbar.tsx
@@ -36,13 +36,33 @@ interface LinkedInTemplate {
   // content, so callers must guard before using it.
   content: string | null;
   category?: string | null;
+  // Media (image / video / voice note / document) lives in the template's
+  // metadata JSONB. A media-only template can have null content but still carry
+  // an attachment, so it must ride along with the inserted text.
+  metadata?: {
+    media_url?: string | null;
+    media_type?: string | null;
+    media_filename?: string | null;
+  } | null;
+}
+
+/**
+ * Payload handed to the composer when a template is inserted: the body text plus
+ * any attachment carried on the template, so a media template visibly stages its
+ * video/image before sending (fixes templates that dropped their media).
+ */
+export interface InsertTemplatePayload {
+  text: string;
+  mediaUrl?: string | null;
+  mediaType?: string | null;
+  mediaFilename?: string | null;
 }
 
 interface Props {
   contextPanelOpen: boolean;
   onToggleContextPanel: () => void;
-  /** Insert template text into the chat input */
-  onInsertTemplate: (text: string) => void;
+  /** Insert a template (text + optional media) into the chat composer */
+  onInsertTemplate: (payload: InsertTemplatePayload) => void;
   /** Disabled when chat is locked (pending / accepted-awaiting-followup) */
   chatEnabled: boolean;
 }
@@ -214,16 +234,30 @@ export function LinkedInChatToolbar({
                   No templates configured
                 </DropdownMenuItem>
               )}
-              {templates.map(t => (
-                <DropdownMenuItem
-                  key={t.id}
-                  className="text-xs flex flex-col items-start gap-0.5 py-1.5"
-                  onClick={() => onInsertTemplate(t.content || '')}
-                >
-                  <span className="font-medium text-slate-800 truncate w-full">{t.name}</span>
-                  <span className="text-[10px] text-slate-500 truncate w-full">{t.content || ''}</span>
-                </DropdownMenuItem>
-              ))}
+              {templates.map(t => {
+                const media = t.metadata || {};
+                const hasMedia = !!media.media_url;
+                return (
+                  <DropdownMenuItem
+                    key={t.id}
+                    className="text-xs flex flex-col items-start gap-0.5 py-1.5"
+                    onClick={() => onInsertTemplate({
+                      text: t.content || '',
+                      mediaUrl: media.media_url ?? null,
+                      mediaType: media.media_type ?? null,
+                      mediaFilename: media.media_filename ?? null,
+                    })}
+                  >
+                    <span className="font-medium text-slate-800 truncate w-full flex items-center gap-1">
+                      {hasMedia && <Paperclip className="w-3 h-3 flex-shrink-0 text-slate-400" />}
+                      <span className="truncate">{t.name}</span>
+                    </span>
+                    <span className="text-[10px] text-slate-500 truncate w-full">
+                      {t.content || (hasMedia ? (media.media_filename || 'Attachment') : '')}
+                    </span>
+                  </DropdownMenuItem>
+                );
+              })}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/web/src/components/conversations/LinkedInConversationView.tsx
+++ b/web/src/components/conversations/LinkedInConversationView.tsx
@@ -13,7 +13,7 @@
  *   active   → automated follow-up sent     → chat enabled
  */
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Send, RefreshCw, Loader2, MessageSquare, Linkedin, Clock, CheckCircle, Zap, Lock, ChevronLeft, Search, MoreVertical, Trash2 } from 'lucide-react';
+import { Send, RefreshCw, Loader2, MessageSquare, Linkedin, Clock, CheckCircle, Zap, Lock, ChevronLeft, Search, MoreVertical, Trash2, X, Film, Music, FileText, Image as ImageIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -29,6 +29,7 @@ import { fetchWithTenant } from '@/lib/fetch-with-tenant';
 import { LinkedInFollowupComposer } from './LinkedInFollowupComposer';
 import { LinkedInContextPanel } from './LinkedInContextPanel';
 import { LinkedInChatToolbar } from './LinkedInChatToolbar';
+import type { InsertTemplatePayload } from './LinkedInChatToolbar';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -39,6 +40,16 @@ interface LinkedInContact {
   name: string;
   avatar?: string | null;
   headline?: string | null;
+  // Surfaced by the backend merge so the chat-toolbar template insert can
+  // substitute {{company}} client-side (backend fills it as a backstop).
+  company?: string | null;
+}
+
+/** A template attachment staged in the composer before send. */
+interface PendingMedia {
+  url: string;
+  type?: string | null;
+  filename?: string | null;
 }
 
 interface LinkedInConversation {
@@ -71,6 +82,45 @@ const API_BASE = '/api/whatsapp-conversations';
 // Add ?channel=linkedin to any URL
 function li(url: string) {
   return `${url}${url.includes('?') ? '&' : '?'}channel=linkedin`;
+}
+
+/**
+ * Substitute {{var}} placeholders in a template body with the open
+ * conversation's lead data, so inserting a template shows the FINAL text (not a
+ * literal `{{first_name}}`). Only the vars we can resolve from the contact are
+ * filled; anything else is left intact for the backend's substitution backstop
+ * to fill on send (so we never guess and never clobber a value the server knows).
+ */
+function substituteLeadVars(text: string, contact?: LinkedInContact | null): string {
+  if (!text || !contact) return text;
+  const full = (contact.name || '').trim();
+  const first = full.split(/\s+/)[0] || '';
+  const last = full.split(/\s+/).slice(1).join(' ') || '';
+  const title = (contact.headline || '').trim();
+  const company = (contact.company || '').trim();
+
+  const sub = (src: string, key: string, value: string): string =>
+    value ? src.replace(new RegExp(`\\{\\{?\\s*${key}\\s*\\}\\}?`, 'gi'), value) : src;
+
+  let out = text;
+  out = sub(out, 'first_name', first);
+  out = sub(out, 'last_name', last);
+  out = sub(out, 'name', full);
+  out = sub(out, 'title', title);
+  out = sub(out, 'headline', title);
+  out = sub(out, 'company(?:_name)?', company);
+  return out;
+}
+
+/** Icon for a staged attachment chip, chosen from the media type / filename. */
+function MediaChipIcon({ type, filename }: { type?: string | null; url?: string; filename?: string | null }) {
+  const t = (type || '').toLowerCase();
+  const ext = (filename || '').split('.').pop()?.toLowerCase() || '';
+  const isImage = t.startsWith('image') || ['png', 'jpg', 'jpeg', 'gif', 'webp'].includes(ext);
+  const isVideo = t.startsWith('video') || ['mp4', 'mov', 'webm', 'm4v'].includes(ext);
+  const isAudio = t.startsWith('audio') || ['mp3', 'm4a', 'wav', 'ogg', 'oga'].includes(ext);
+  const Icon = isImage ? ImageIcon : isVideo ? Film : isAudio ? Music : FileText;
+  return <Icon className="w-4 h-4 flex-shrink-0 text-blue-600" />;
 }
 
 // ─── Status badge config ──────────────────────────────────────────────────────
@@ -389,6 +439,8 @@ export function LinkedInConversationView({
     return window.innerWidth >= 1280;
   });
   const [messageText, setMessageText]     = useState('');
+  // Attachment staged from a template insert, shown as a removable composer chip.
+  const [pendingMedia, setPendingMedia]   = useState<PendingMedia | null>(null);
   const [loadingConvs, setLoadingConvs]   = useState(true);
   const [loadingMsgs, setLoadingMsgs]     = useState(false);
   const [sending, setSending]             = useState(false);
@@ -487,6 +539,9 @@ export function LinkedInConversationView({
   }, []);
 
   useEffect(() => {
+    // Drop any staged attachment when switching threads so it can't ride into
+    // the wrong conversation.
+    setPendingMedia(null);
     if (selectedId) {
       loadMessages(selectedId);
     } else {
@@ -501,18 +556,22 @@ export function LinkedInConversationView({
 
   // ── Send message ────────────────────────────────────────────────────────────
   const handleSend = useCallback(async () => {
-    if (!selectedId || !messageText.trim() || sending) return;
+    // A media-only send (attachment, no text) is valid.
+    if (!selectedId || (!messageText.trim() && !pendingMedia) || sending) return;
     const selectedConv = conversations.find(c => c.id === selectedId);
     if (!selectedConv?.chat_enabled) return;
 
     const text = messageText.trim();
+    const media = pendingMedia;
     setMessageText('');
+    setPendingMedia(null);
     setSending(true);
 
     const tempMsg: LinkedInMessage = {
       id:         `temp-${Date.now()}`,
       role:       'assistant',
-      content:    text,
+      // Show something for a media-only optimistic bubble so it isn't blank.
+      content:    text || `📎 ${media?.filename || 'Attachment'}`,
       created_at: new Date().toISOString(),
       is_sender:  true,
     };
@@ -523,13 +582,18 @@ export function LinkedInConversationView({
       // CONTACTED in campaign_analytics on a successful send. That marker
       // cancels the workflow scheduler's automated follow-up so the lead
       // never gets a duplicate auto-message after the user has already
-      // engaged in chat manually.
+      // engaged in chat manually. Media (from a template) rides along as
+      // media_url/type/filename — the backend re-downloads the bytes and
+      // sends a real LinkedIn attachment.
       const res  = await fetchWithTenant(li(`${API_BASE}/conversations/${selectedId}/messages`), {
         method: 'POST',
         body:   JSON.stringify({
           content: text,
           campaign_id: selectedConv.campaign_id || undefined,
           lead_id:     selectedConv.lead_id     || undefined,
+          media_url:      media?.url      || undefined,
+          media_type:     media?.type     || undefined,
+          media_filename: media?.filename || undefined,
         }),
       });
       const json = await res.json();
@@ -540,17 +604,24 @@ export function LinkedInConversationView({
         setConversations(prev =>
           prev.map(c =>
             c.id === selectedId
-              ? { ...c, last_message: text, last_message_time: new Date().toISOString() }
+              ? { ...c, last_message: text || `📎 ${media?.filename || 'Attachment'}`, last_message_time: new Date().toISOString() }
               : c
           )
         );
+      } else {
+        // Non-success response — drop the optimistic bubble and restore the draft.
+        setMessages(prev => prev.filter(m => m.id !== tempMsg.id));
+        setMessageText(text);
+        if (media) setPendingMedia(media);
       }
     } catch {
       setMessages(prev => prev.filter(m => m.id !== tempMsg.id));
+      setMessageText(text);
+      if (media) setPendingMedia(media);
     } finally {
       setSending(false);
     }
-  }, [selectedId, messageText, sending, conversations]);
+  }, [selectedId, messageText, pendingMedia, sending, conversations]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -887,13 +958,24 @@ export function LinkedInConversationView({
             <LinkedInChatToolbar
               contextPanelOpen={contextPanelOpen}
               onToggleContextPanel={() => setContextPanelOpen(o => !o)}
-              onInsertTemplate={(text) => {
-                // Coerce to a string so the input's value never becomes undefined
-                // (a null/empty template body would otherwise crash the next
-                // `messageText.trim()` render with "reading 'trim' of undefined").
-                const insert = text ?? '';
-                if (!insert) return;
-                setMessageText(prev => prev ? `${prev}\n${insert}` : insert);
+              onInsertTemplate={(payload: InsertTemplatePayload) => {
+                // Substitute {{first_name}} / {{company}} / {{title}} with the
+                // open lead's data so the composer shows the FINAL text (the
+                // literal-placeholder bug). Unresolved vars stay for the backend
+                // backstop. Coerce to string so the input value is never
+                // undefined (would crash the next `messageText.trim()` render).
+                const resolved = substituteLeadVars(payload.text ?? '', selectedConv?.contact);
+                if (resolved) {
+                  setMessageText(prev => prev ? `${prev}\n${resolved}` : resolved);
+                }
+                // Stage the template's attachment as a removable composer chip.
+                if (payload.mediaUrl) {
+                  setPendingMedia({
+                    url: payload.mediaUrl,
+                    type: payload.mediaType ?? null,
+                    filename: payload.mediaFilename ?? null,
+                  });
+                }
               }}
               chatEnabled={chatEnabled}
             />
@@ -911,6 +993,24 @@ export function LinkedInConversationView({
                       ? 'Chat unlocks after connection is accepted and follow-up is sent'
                       : 'Chat unlocks after the automated follow-up is sent'}
                   </span>
+                </div>
+              )}
+              {/* Staged attachment from a template — removable before send */}
+              {pendingMedia && (
+                <div className="mb-2 inline-flex items-center gap-2 max-w-full rounded-lg border border-blue-200 bg-blue-50 px-2.5 py-1.5">
+                  <MediaChipIcon type={pendingMedia.type} url={pendingMedia.url} filename={pendingMedia.filename} />
+                  <span className="text-xs text-slate-700 truncate max-w-[220px]">
+                    {pendingMedia.filename || 'Attachment'}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setPendingMedia(null)}
+                    className="flex-shrink-0 text-slate-400 hover:text-slate-700"
+                    title="Remove attachment"
+                    aria-label="Remove attachment"
+                  >
+                    <X className="w-3.5 h-3.5" />
+                  </button>
                 </div>
               )}
               <div className="flex items-end gap-2">
@@ -939,7 +1039,7 @@ export function LinkedInConversationView({
                       : 'bg-slate-200 text-slate-400 cursor-not-allowed',
                   )}
                   onClick={chatEnabled ? handleSend : undefined}
-                  disabled={!chatEnabled || !messageText.trim() || sending}
+                  disabled={!chatEnabled || (!messageText.trim() && !pendingMedia) || sending}
                 >
                   {sending ? (
                     <Loader2 className="h-4 w-4 animate-spin" />

--- a/web/src/components/templates/CreateLinkedInTemplateModal.tsx
+++ b/web/src/components/templates/CreateLinkedInTemplateModal.tsx
@@ -119,8 +119,9 @@ export default function CreateLinkedInTemplateModal({
   const validate = (): boolean => {
     const e: Record<string, string> = {};
     if (!name.trim()) e.name = 'Template name is required';
-    if (!connectionMessage.trim() && !followupMessage.trim()) {
-      e.messages = 'Provide at least a connection or a follow-up message';
+    // A media-only template is valid — the attachment rides the follow-up DM.
+    if (!connectionMessage.trim() && !followupMessage.trim() && !mediaUrl) {
+      e.messages = 'Provide a connection message, a follow-up message, or an attachment';
     }
     if (connectionMessage.length > LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH) {
       e.connection = `Connection message must be ${LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH} characters or less`;
@@ -297,7 +298,8 @@ export default function CreateLinkedInTemplateModal({
               </Button>
             )}
             <p className="text-[11px] text-muted-foreground">
-              Sent alongside the connection request / follow-up. Max 25MB.
+              Sent with the follow-up message — the connection invite is text-only,
+              so a media-only template needs a follow-up leg to deliver. Max 25MB.
             </p>
             {errors.media && (
               <p className="text-xs text-red-600 flex items-center gap-1">


### PR DESCRIPTION
## Problem
Inserting a LinkedIn template from the **chat toolbar** dropped the template's media and put the **RAW body** (literal `{{first_name}}`) into the composer, which then sent verbatim. Pairs with LAD-Backend #357 on the same send path.

## Fix (frontend)
- **`LinkedInChatToolbar`**: carry the **full template** (text + `metadata.media_url`/`media_type`/`media_filename`) through `onInsertTemplate` instead of just text; the list API already returns `content` + `metadata`. Shows a 📎 on template items that have an attachment.
- **`LinkedInConversationView`**:
  - Substitute `{{first_name}}`/`{{last_name}}`/`{{name}}`/`{{title}}`/`{{company}}` **at insert time** from the open lead's `contact` so the composer shows the **final text** (unresolved vars are left for the backend backstop, so we never guess/clobber).
  - Stage the template's media as a **removable composer chip**; include `media_url`/`type`/`filename` in the send body; **allow a media-only send** (empty text); restore the draft + chip if the send fails; drop the staged attachment when switching threads.
  - Added `contact.company` to the type (surfaced by the backend merge).
- **`CreateLinkedInTemplateModal`** (bonus, develop-merged file): allow a **media-only** template (`... && !mediaUrl`); narrow the helper copy to *"Sent with the follow-up message — the connection invite is text-only…"* (media only rides the follow-up DM, not the connection invite).

## Verification
- `tsc --noEmit`: **no new errors** in the changed files; total **358** (below the 363 report-only baseline).
- `eslint`: **0 errors** on the changed files.

## Companion PR
LAD-Backend #357 — accepts `media_url`, substitutes server-side as a backstop, routes through `sendAttachment` with correct MIME, allows media-only, relaxes the media-only template validator.

## Deploy note
Depends on LAD-Backend #357 + `GCP_BUCKET_NAME` set in the LinkedIn env (media re-download-by-path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)