### PR TITLE
fix(campaigns): gate + relabel the LinkedIn Lead Search node (canvas ⇄ launch)

### DIFF
--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -586,9 +586,16 @@ export default function AdvancedSearchAIPage() {
     const cpNextChannels = _cpCfg.nextChannels;           // ['email','whatsapp','voice_call'] subset
     const cpTriggerCondition = _cpCfg.triggerCondition;   // '' | 'connection_accepted' | …
 
+    // The lead-search node is the campaign's lead SOURCE, only relevant when leads
+    // are discovered via LinkedIn search. For direct-contact / inbound-import
+    // campaigns (leads provided directly) it must be omitted from the canvas so it
+    // matches what actually launches. Kept in a ref (updated each render below,
+    // once inboundMode/pendingContact are in scope) so the reconcile callbacks read
+    // the latest value without a stale closure or a temporal-dead-zone reference.
+    const includeLeadSourceRef = useRef(true);
     const _applyCpCfg = useCallback((patch: Partial<{ actions: string[]; nextChannels: string[]; triggerCondition: string }>) => {
         const cur = useOnboardingStore.getState().workflowPreview as unknown as SyncStep[];
-        setWorkflowPreview(applyConfig(cur, patch) as any);
+        setWorkflowPreview(applyConfig(cur, patch, { includeLeadSource: includeLeadSourceRef.current }) as any);
     }, [setWorkflowPreview]);
 
     // These keep the exact React.Dispatch<SetStateAction<string[]>> shape the
@@ -611,7 +618,7 @@ export default function AdvancedSearchAIPage() {
     // hydration or a persisted session) is left untouched.
     useEffect(() => {
         const cur = useOnboardingStore.getState().workflowPreview as unknown as SyncStep[];
-        if (!cur || cur.length === 0) setWorkflowPreview(applyConfig([], {}) as any);
+        if (!cur || cur.length === 0) setWorkflowPreview(applyConfig([], {}, { includeLeadSource: includeLeadSourceRef.current }) as any);
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
     const [cpDays, setCpDays] = useState('30');
@@ -748,6 +755,11 @@ export default function AdvancedSearchAIPage() {
 
     // Inbound CSV upload state
     const [inboundMode, setInboundMode] = useState(false);
+    // Keep the lead-source gate current (read by the reconcile callbacks above via
+    // includeLeadSourceRef). Direct-contact (a pending contact with no LinkedIn
+    // URL) and inbound-import campaigns provide leads directly, so they omit the
+    // LinkedIn lead-search node — matching the launch builder.
+    includeLeadSourceRef.current = !inboundMode && !(pendingContact && !pendingContact.linkedin_url);
     const [inboundLeads, setInboundLeads] = useState<ParsedInboundLead[]>([]);
     const [inboundLeadIds, setInboundLeadIds] = useState<string[]>([]); // Real UUIDs from leads table (CSV/image)
     const [directContactLeadIds, setDirectContactLeadIds] = useState<string[]>([]); // Real UUIDs for chat-entered direct contacts
@@ -1324,6 +1336,7 @@ export default function AdvancedSearchAIPage() {
                     setWorkflowPreview(applyConfig(
                         useOnboardingStore.getState().workflowPreview as unknown as SyncStep[],
                         { actions: liActions, nextChannels: hydChannels, triggerCondition: cs.trigger_condition ?? cfg.trigger_condition ?? '' },
+                        { includeLeadSource: includeLeadSourceRef.current },
                     ) as any);
                 }
                 if (cs.campaign_days != null) setCpDays(String(cs.campaign_days));

--- a/web/src/components/onboarding/workflow/configStepsSync.ts
+++ b/web/src/components/onboarding/workflow/configStepsSync.ts
@@ -127,19 +127,40 @@ function makeStep(kind: string, existing?: SyncStep): SyncStep {
  * Canonical order: lead_generation → LinkedIn actions (connect, message,
  * profile_view) → wait_for_condition (if trigger) → follow-up channels.
  */
-export function buildStepsFromConfig(cfg: DerivedConfig, existing: SyncStep[] = []): SyncStep[] {
+export function buildStepsFromConfig(
+  cfg: DerivedConfig,
+  existing: SyncStep[] = [],
+  opts: { includeLeadSource?: boolean } = {},
+): SyncStep[] {
   const byType = new Map<string, SyncStep>();
   for (const s of existing) if (!byType.has(s.type)) byType.set(s.type, s);
   const take = (type: string) => makeStep(type, byType.get(type));
 
+  const liSelected = cfg.nextChannels.includes('linkedin');
+
   const out: SyncStep[] = [];
-  // Lead search is always the entry step (preserve an existing one if present).
-  out.push(take('lead_generation'));
+  // The lead-search node is the campaign's lead SOURCE, not an outreach channel.
+  // It's included by default (this page discovers leads via LinkedIn search), but
+  // OMITTED for direct-contact / inbound-import campaigns where leads are provided
+  // directly (initial_leads) — mirroring the launch builder, which gates the same
+  // node on `!isDirectContact && !inboundMode`. Without this the canvas showed a
+  // "LinkedIn Lead Search" node those campaigns never actually run.
+  if (opts.includeLeadSource !== false) {
+    const leadGen = take('lead_generation');
+    // When LinkedIn isn't a selected OUTREACH channel, don't title the source
+    // node as if it were a LinkedIn action — it reads as "why is LinkedIn here
+    // when I picked Email + Voice". Relabel it neutrally (leads are still sourced
+    // via LinkedIn search — see the description).
+    if (!liSelected) {
+      leadGen.title = 'Find Leads';
+      leadGen.description = 'Discover target leads via LinkedIn search';
+    }
+    out.push(leadGen);
+  }
 
   // LinkedIn outreach steps materialise only when the LinkedIn channel is
   // selected. If it's selected with no explicit action, default to a profile
   // visit (mirrors the launch builder's `liChannelActions.length === 0` default).
-  const liSelected = cfg.nextChannels.includes('linkedin');
   const liActions = !liSelected ? [] : (cfg.actions.length > 0 ? cfg.actions : ['profile_view']);
   // Emit in execution order (visit → connect → message) so the canvas matches
   // how the launch builder actually runs the sequence.
@@ -164,9 +185,13 @@ export function buildStepsFromConfig(cfg: DerivedConfig, existing: SyncStep[] = 
 }
 
 /** Merge a partial structural change and rebuild the steps. */
-export function applyConfig(steps: SyncStep[], patch: Partial<DerivedConfig>): SyncStep[] {
+export function applyConfig(
+  steps: SyncStep[],
+  patch: Partial<DerivedConfig>,
+  opts: { includeLeadSource?: boolean } = {},
+): SyncStep[] {
   const merged = { ...deriveConfig(steps), ...patch };
-  return buildStepsFromConfig(merged, steps);
+  return buildStepsFromConfig(merged, steps, opts);
 }
 
 export const _internal = { LI_ACTION_BY_TYPE, CHANNEL_BY_TYPE, TYPE_BY_CHANNEL, COND_LABELS };


### PR DESCRIPTION
## Bug
Selecting only **Email + Voice Call** still auto-adds a **"LinkedIn Lead Search"** node to the workflow, even though LinkedIn wasn't selected.

## Root cause
`configStepsSync.buildStepsFromConfig` **unconditionally** pushed the `lead_generation` node ([configStepsSync.ts:137](web/src/components/onboarding/workflow/configStepsSync.ts:137)), hard-labelled "LinkedIn Lead Search" / `channel: linkedin` ([:99](web/src/components/onboarding/workflow/configStepsSync.ts:99)). Two issues:
1. **Canvas ⇄ launch divergence**: the launch builder gates the same node on `!isDirectContact && !inboundMode` ([page.tsx:7174](web/src/app/onboarding/advanced-search-ai/page.tsx:7174)) — for direct-contact / CSV-inbound campaigns leads come from `initial_leads`, so launch omits it. The canvas showed it regardless → it displayed a node those campaigns never run.
2. **Mislabel**: for an Email/Voice-only campaign (leads still sourced via LinkedIn search) the node read like a LinkedIn *outreach* action.

## Important nuance
The node is the campaign's lead **source**, not an outreach channel — this page discovers leads via LinkedIn Sales Navigator search, then reaches out over the selected channels. So for a normal search-based Email/Voice campaign it's genuinely needed (and launch includes it). We do **not** gate it on channel selection (that would leave the campaign with no lead source).

## Fix (frontend, self-contained)
- `buildStepsFromConfig` / `applyConfig` take an optional `includeLeadSource` (default `true` — no behavior change). The page threads it as `!inboundMode && !isDirectContact` via a ref (kept current each render — avoids a stale closure / temporal-dead-zone, since `inboundMode` is declared after the reconcile callbacks), so the canvas now matches the launch payload for direct-contact / inbound campaigns.
- When LinkedIn isn't a selected outreach channel, the source node is **relabeled** neutrally ("Find Leads" / "Discover target leads via LinkedIn search") so it no longer masquerades as a LinkedIn action.

## Verification
- `tsc`: **358 errors before and after** — zero introduced by this change.
- `eslint`: clean on the changed files.
- No FE test runner exists in this repo (zero-tests), so this relies on typecheck + lint + review.

Part of the campaign-execution batch (with #359 email dispatch, #360 voice status).

🤖 Generated with [Claude Code](https://claude.com/claude-code)