### PR TITLE
feat(overview): channel-aware dashboard + interactive Sales Funnel

### DIFF
--- a/web/src/components/overview/DashboardGrid.tsx
+++ b/web/src/components/overview/DashboardGrid.tsx
@@ -32,7 +32,7 @@ import {
 } from '@dnd-kit/sortable';
 
 import { useDashboardStore } from '@/store/dashboardStore';
-import { getWidgetTypeFromId, WidgetLayoutItem } from '@/types/dashboard';
+import { getWidgetTypeFromId, WidgetLayoutItem, WidgetType } from '@/types/dashboard';
 
 // Widget components
 import { StatWidget } from './widgets/StatWidget';
@@ -47,8 +47,51 @@ import { BroadcastPerformanceWidget } from './widgets/BroadcastPerformanceWidget
 import { ConversationFunnelWidget } from './widgets/ConversationFunnelWidget';
 import { ReengageTopicsWidget } from './widgets/ReengageTopicsWidget';
 import { LeadJourneyWidget } from './widgets/LeadJourneyWidget';
+import { LinkedInFunnelWidget } from './widgets/LinkedInFunnelWidget';
+import { EmailActivityWidget } from './widgets/EmailActivityWidget';
+import { InstagramActivityWidget } from './widgets/InstagramActivityWidget';
+import { CombinedFunnelWidget } from './widgets/CombinedFunnelWidget';
+import { useConnectedChannels, type ChannelId, type ChannelStatus } from '@/hooks/useConnectedChannels';
 // Utilities
 import { cn } from '@/lib/utils';
+
+// ── Channel gating ───────────────────────────────────────────────────────────
+// Which channel a widget's metrics belong to. Widgets NOT listed here are
+// channel-agnostic (credits, calendar, ai-insights, quick-actions, the
+// cross-channel funnel) and always show. A gated widget is hidden only when its
+// channel is positively disconnected — 'unknown'/loading stays visible
+// (fail-open), so a transient probe failure never blanks the dashboard.
+type ChannelGate = 'voice' | 'whatsapp' | 'linkedin' | 'email' | 'instagram';
+const WIDGET_CHANNEL: Partial<Record<WidgetType, ChannelGate>> = {
+  'calls-today': 'voice',
+  'answer-rate': 'voice',
+  'calls-monthly': 'voice',
+  'calls-chart': 'voice',
+  'voice-agents': 'voice',
+  'latest-calls': 'voice',
+  'broadcast-performance': 'whatsapp',
+  'reengage-topics': 'whatsapp',
+  'lead-journey': 'linkedin',
+  'linkedin-funnel': 'linkedin',
+  'email-activity': 'email',
+  'instagram-activity': 'instagram',
+};
+function gateConnected(statuses: Record<ChannelId, ChannelStatus>, gate: ChannelGate): boolean {
+  const notDisc = (id: ChannelId) => statuses[id] !== 'disconnected';
+  switch (gate) {
+    case 'whatsapp': return notDisc('waba') || notDisc('personal_whatsapp');
+    case 'email':    return notDisc('gmail');
+    case 'voice':    return notDisc('voice');
+    case 'linkedin': return notDisc('linkedin');
+    case 'instagram':return notDisc('instagram');
+    default:         return true;
+  }
+}
+function widgetVisibleForChannels(type: WidgetType | null, statuses: Record<ChannelId, ChannelStatus>): boolean {
+  if (!type) return true;
+  const gate = WIDGET_CHANNEL[type];
+  return gate ? gateConnected(statuses, gate) : true;
+}
 import {
   useDashboardCalls,
   useWalletStats,
@@ -97,6 +140,12 @@ const DAYS_RANGE = 30;
 
 export const DashboardGrid: React.FC<DashboardGridProps> = ({ className, onLoadingChange }) => {
   const { layout, setLayout, isEditMode } = useDashboardStore();
+  // Channel-aware gating: hide widgets whose channel isn't connected. In edit
+  // mode we show everything so users can still manage/reorder gated widgets.
+  const { statuses } = useConnectedChannels();
+  const visibleLayout = isEditMode
+    ? layout
+    : layout.filter((item) => widgetVisibleForChannels(getWidgetTypeFromId(item.i), statuses));
   const [activeId, setActiveId] = React.useState<string | null>(null);
   const isMobile = useIsMobile();
 
@@ -486,6 +535,14 @@ export const DashboardGrid: React.FC<DashboardGridProps> = ({ className, onLoadi
         return <ReengageTopicsWidget id={widgetId} />;
       case 'lead-journey':
         return <LeadJourneyWidget id={widgetId} />;
+      case 'linkedin-funnel':
+        return <LinkedInFunnelWidget id={widgetId} />;
+      case 'email-activity':
+        return <EmailActivityWidget id={widgetId} />;
+      case 'instagram-activity':
+        return <InstagramActivityWidget id={widgetId} />;
+      case 'combined-funnel':
+        return <CombinedFunnelWidget id={widgetId} />;
       default:
         return <div className="widget-card h-full flex items-center justify-center text-muted-foreground">Unknown widget</div>;
     }
@@ -519,7 +576,7 @@ export const DashboardGrid: React.FC<DashboardGridProps> = ({ className, onLoadi
     return getGridStyle(item);
   };
 
-  const sortableItems = layout.map(item => item.i);
+  const sortableItems = visibleLayout.map(item => item.i);
 
   return (
     <div className={cn('dashboard-grid', className)}>
@@ -531,7 +588,7 @@ export const DashboardGrid: React.FC<DashboardGridProps> = ({ className, onLoadi
       >
         <SortableContext items={sortableItems} strategy={rectSortingStrategy}>
           <div className="grid grid-cols-12 gap-3 md:gap-6 auto-rows-min">
-            {layout.map((item) => (
+            {visibleLayout.map((item) => (
               <div
                 key={item.i}
                 style={getResponsiveGridStyle(item)}

--- a/web/src/components/overview/widgets/CombinedFunnelWidget.tsx
+++ b/web/src/components/overview/widgets/CombinedFunnelWidget.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+/**
+ * CombinedFunnelWidget — one cross-channel lead funnel, with a time filter and
+ * drill-down.
+ *
+ * Stages: New Leads (connection requests sent) → Accepted → Responded →
+ * Meeting Booked (SAH), with overall + per-stage conversion and drop-off. A
+ * Week / Month / Quarter / Year selector (default Week) date-windows every
+ * stage. Clicking a stage opens a modal listing that stage's leads (name,
+ * company, campaign, LinkedIn) for the selected window.
+ *
+ * Data: GET /api/campaigns/lead-journey?from=&to= — returns counts + the lead
+ * lists per stage. Channel-agnostic → always shown.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { RefreshCw, Filter, Linkedin, X, Download } from 'lucide-react';
+import { WidgetWrapper } from '../WidgetWrapper';
+import { fetchWithTenant } from '@/lib/fetch-with-tenant';
+
+interface LeadRow {
+  lead_id: string;
+  name: string;
+  company_name: string | null;
+  industry: string | null;
+  linkedin_url: string | null;
+  campaign_name: string | null;
+  next_followup_at: string | null;
+}
+type StageKey = 'sent' | 'accepted' | 'responded' | 'sah';
+interface FunnelData {
+  counts: Record<StageKey, number>;
+  lists: Record<StageKey, LeadRow[]>;
+}
+
+type PeriodKey = 'week' | 'month' | 'quarter' | 'year';
+const PERIODS: { key: PeriodKey; label: string; days: number }[] = [
+  { key: 'week', label: 'Week', days: 7 },
+  { key: 'month', label: 'Month', days: 30 },
+  { key: 'quarter', label: 'Quarter', days: 90 },
+  { key: 'year', label: 'Year', days: 365 },
+];
+const STAGES: { key: StageKey; label: string; color: string }[] = [
+  { key: 'sent', label: 'New Leads', color: '#0F6E56' },
+  { key: 'accepted', label: 'Accepted', color: '#1D9E75' },
+  { key: 'responded', label: 'Responded', color: '#5DCAA5' },
+  { key: 'sah', label: 'Meeting Booked', color: '#639922' },
+];
+const DAY_MS = 24 * 60 * 60 * 1000;
+const num = (n: number) => n.toLocaleString();
+const rate = (a: number, b: number) => (b > 0 ? Math.round((a / b) * 100) : 0);
+
+export const CombinedFunnelWidget: React.FC<{ id: string }> = ({ id }) => {
+  const [period, setPeriod] = useState<PeriodKey>('week');
+  const [data, setData] = useState<FunnelData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [openStage, setOpenStage] = useState<StageKey | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const days = PERIODS.find((p) => p.key === period)?.days ?? 7;
+      const to = new Date();
+      const from = new Date(to.getTime() - days * DAY_MS);
+      const qs = `?from=${encodeURIComponent(from.toISOString())}&to=${encodeURIComponent(to.toISOString())}`;
+      const res = await fetchWithTenant(`/api/campaigns/lead-journey${qs}`);
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok || json?.success === false) throw new Error(json?.error || `Request failed (${res.status})`);
+      const c = json?.counts || {};
+      setData({
+        counts: {
+          sent: Number(c.sent) || 0,
+          accepted: Number(c.accepted) || 0,
+          responded: Number(c.responded) || 0,
+          sah: Number(c.sah) || 0,
+        },
+        lists: {
+          sent: Array.isArray(json.sent) ? json.sent : [],
+          accepted: Array.isArray(json.accepted) ? json.accepted : [],
+          responded: Array.isArray(json.responded) ? json.responded : [],
+          sah: Array.isArray(json.sah) ? json.sah : [],
+        },
+      });
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load funnel');
+    } finally {
+      setLoading(false);
+    }
+  }, [period]);
+
+  useEffect(() => { load(); }, [load]);
+  useEffect(() => { setOpenStage(null); }, [period]);
+
+  const header = (
+    <button onClick={load} title="Refresh" className="p-1 rounded hover:bg-black/5 dark:hover:bg-white/10 text-muted-foreground dark:text-[#E0E0E0]">
+      <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+    </button>
+  );
+
+  const first = data?.counts.sent ?? 0;
+  const last = data?.counts.sah ?? 0;
+  const overall = rate(last, first);
+  const maxCount = Math.max(1, ...STAGES.map((s) => data?.counts[s.key] ?? 0));
+  const periodLabel = PERIODS.find((p) => p.key === period)?.label ?? '';
+
+  return (
+    <WidgetWrapper id={id} title="Sales funnel" icon={<Filter className="h-4 w-4" />} headerActions={header}>
+      <div className="flex items-center gap-1 mb-4">
+        {PERIODS.map((p) => {
+          const active = period === p.key;
+          return (
+            <button
+              key={p.key}
+              onClick={() => setPeriod(p.key)}
+              className={`px-2.5 py-1 rounded-md text-xs font-medium border transition-colors ${
+                active ? 'border-transparent bg-[#0F6E56] text-white' : 'border-border text-muted-foreground hover:bg-muted/50 dark:text-[#E0E0E0]/70'
+              }`}
+            >
+              {p.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {error && !data ? (
+        <div className="h-full flex flex-col items-center justify-center text-center gap-1 py-8">
+          <p className="text-sm text-muted-foreground">Couldn&apos;t load funnel</p>
+          <p className="text-[11px] text-muted-foreground/70 max-w-[240px]">{error}</p>
+          <button onClick={load} className="mt-2 text-xs text-blue-600 hover:underline">Try again</button>
+        </div>
+      ) : loading && !data ? (
+        <div className="space-y-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-9 rounded-lg bg-muted/50 dark:bg-white/5 animate-pulse" style={{ width: `${100 - i * 18}%`, margin: '0 auto' }} />
+          ))}
+        </div>
+      ) : data && first === 0 && last === 0 && data.counts.accepted === 0 ? (
+        <div className="flex flex-col items-center justify-center py-10 text-center">
+          <p className="text-sm font-medium dark:text-[#E0E0E0]">No activity in this period</p>
+          <p className="text-xs text-muted-foreground mt-1 max-w-[260px]">Try a wider time range, or wait for your campaigns to send connection requests.</p>
+        </div>
+      ) : data ? (
+        <div className="flex flex-col gap-5">
+          <div className="flex items-center justify-center gap-4 sm:gap-6">
+            <div className="text-center rounded-lg border border-border px-3 py-2 min-w-[84px]">
+              <p className="text-[11px] text-muted-foreground">New Leads</p>
+              <p className="text-lg font-medium dark:text-[#E0E0E0]">{num(first)}</p>
+            </div>
+            <div className="text-center">
+              <p className="text-[11px] uppercase tracking-wide text-muted-foreground">Overall conversion</p>
+              <p className="text-3xl font-bold font-display dark:text-[#E0E0E0]">{overall}%</p>
+            </div>
+            <div className="text-center rounded-lg border border-emerald-200 dark:border-emerald-500/30 px-3 py-2 min-w-[84px]">
+              <p className="text-[11px] text-muted-foreground">Won (SAH)</p>
+              <p className="text-lg font-medium text-emerald-700 dark:text-emerald-400">{num(last)}</p>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            {STAGES.map((s, i) => {
+              const count = data.counts[s.key];
+              const w = Math.max(14, Math.round((count / maxCount) * 100));
+              const prev = i > 0 ? data.counts[STAGES[i - 1].key] : null;
+              const conv = prev != null && prev > 0 ? rate(count, prev) : null;
+              const dropped = prev != null ? Math.max(0, prev - count) : 0;
+              return (
+                <div key={s.key}>
+                  {i > 0 && (
+                    <div className="flex items-center justify-center gap-2 py-0.5">
+                      <span className="text-[11px] font-medium text-muted-foreground bg-muted/60 dark:bg-white/5 rounded-full px-2 py-0.5">{conv != null ? `${conv}%` : '—'}</span>
+                      {dropped > 0 && <span className="text-[10px] text-muted-foreground/70">{num(dropped)} dropped</span>}
+                    </div>
+                  )}
+                  <div className="flex items-center gap-3">
+                    <div className="w-28 shrink-0 text-xs font-medium dark:text-[#E0E0E0]">{s.label}</div>
+                    <div className="flex-1 flex justify-center">
+                      <button
+                        type="button"
+                        onClick={() => setOpenStage(s.key)}
+                        title={`View ${s.label} leads`}
+                        className="flex items-center justify-center text-white text-sm font-medium rounded-md h-9 transition-all hover:opacity-90 cursor-pointer"
+                        style={{ width: `${w}%`, background: s.color }}
+                      >
+                        {num(count)}
+                      </button>
+                    </div>
+                    <div className="w-10 shrink-0" />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <p className="text-[10px] text-muted-foreground text-center">Click any stage to see its leads.</p>
+        </div>
+      ) : null}
+
+      {openStage && data && (
+        <StageLeadsModal
+          title={STAGES.find((s) => s.key === openStage)!.label}
+          subtitle={`${periodLabel} · ${num(data.counts[openStage])} lead${data.counts[openStage] === 1 ? '' : 's'}`}
+          fileLabel={`${STAGES.find((s) => s.key === openStage)!.label.replace(/\s+/g, '-').toLowerCase()}-${period}`}
+          leads={data.lists[openStage]}
+          onClose={() => setOpenStage(null)}
+        />
+      )}
+    </WidgetWrapper>
+  );
+};
+
+const fmtFollowup = (iso: string | null): string => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (isNaN(d.getTime())) return '—';
+  return d.toLocaleString(undefined, { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
+};
+
+function downloadLeadsCsv(leads: LeadRow[], fileLabel: string) {
+  const esc = (v: unknown) => `"${String(v ?? '').replace(/"/g, '""')}"`;
+  const headers = ['Name', 'Company', 'Industry', 'Campaign', 'LinkedIn URL', 'Next follow-up'];
+  const lines = [headers.join(',')];
+  for (const l of leads) {
+    lines.push([
+      esc(l.name),
+      esc(l.company_name),
+      esc(l.industry),
+      esc(l.campaign_name),
+      esc(l.linkedin_url),
+      esc(l.next_followup_at ? new Date(l.next_followup_at).toISOString() : ''),
+    ].join(','));
+  }
+  const blob = new Blob(['﻿' + lines.join('\r\n')], { type: 'text/csv;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `leads-${fileLabel}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
+// Rendered via createPortal(document.body): WidgetWrapper carries a dnd-kit
+// `transform`, and a transformed ancestor becomes the containing block for
+// position:fixed — so without the portal this modal positions/dims against the
+// widget CARD instead of the viewport (headers pushed off-screen on long lists).
+const StageLeadsModal: React.FC<{ title: string; subtitle: string; fileLabel: string; leads: LeadRow[]; onClose: () => void }> = ({ title, subtitle, fileLabel, leads, onClose }) => {
+  if (typeof document === 'undefined') return null;
+  return createPortal(
+  <div
+    className="fixed inset-0 z-[120] bg-black/40"
+    style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '16px' }}
+    onClick={onClose}
+  >
+    <div
+      onClick={(e) => e.stopPropagation()}
+      className="w-full max-w-3xl rounded-xl bg-white dark:bg-[#1A2A43] border border-gray-200 dark:border-[#2B7CFF]/20 shadow-2xl"
+      style={{ maxHeight: '85vh', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+    >
+      <div className="flex items-center justify-between gap-3 px-5 py-4 border-b border-gray-200 dark:border-[#2B7CFF]/20" style={{ flexShrink: 0 }}>
+        <div className="min-w-0">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-[#E0E0E0]">{title}</h3>
+          <p className="text-xs text-muted-foreground">{subtitle}</p>
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <button
+            onClick={() => downloadLeadsCsv(leads, fileLabel)}
+            disabled={leads.length === 0}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md border border-border hover:bg-muted/50 disabled:opacity-40 disabled:cursor-not-allowed dark:text-[#E0E0E0]"
+          >
+            <Download className="h-3.5 w-3.5" /> Download CSV
+          </button>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-white" aria-label="Close">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+      <div style={{ flex: '1 1 auto', minHeight: 0, overflowY: 'auto' }}>
+        {leads.length === 0 ? (
+          <p className="text-sm text-muted-foreground text-center py-10">No leads in this stage for the selected period.</p>
+        ) : (
+          <table className="w-full text-sm" style={{ tableLayout: 'fixed' }}>
+            {/* Sticky must be on <th>, not <thead> — browsers ignore sticky on
+                thead, so with long (scrolling) lists the header would scroll away
+                and overlap rows. */}
+            <thead>
+              <tr className="text-left text-[11px] uppercase tracking-wide text-muted-foreground">
+                <th className="sticky top-0 z-10 bg-white dark:bg-[#1A2A43] border-b border-gray-200 dark:border-[#2B7CFF]/20 px-4 py-2 font-medium" style={{ width: '30%' }}>Name</th>
+                <th className="sticky top-0 z-10 bg-white dark:bg-[#1A2A43] border-b border-gray-200 dark:border-[#2B7CFF]/20 px-4 py-2 font-medium" style={{ width: '26%' }}>Company</th>
+                <th className="sticky top-0 z-10 bg-white dark:bg-[#1A2A43] border-b border-gray-200 dark:border-[#2B7CFF]/20 px-4 py-2 font-medium" style={{ width: '26%' }}>Campaign</th>
+                <th className="sticky top-0 z-10 bg-white dark:bg-[#1A2A43] border-b border-gray-200 dark:border-[#2B7CFF]/20 px-4 py-2 font-medium" style={{ width: '18%' }}>Next follow-up</th>
+              </tr>
+            </thead>
+            <tbody>
+              {leads.map((l) => (
+                <tr key={`${l.lead_id}-${l.campaign_name}`} className="border-b border-gray-100 dark:border-white/5 hover:bg-muted/40 dark:hover:bg-white/5">
+                  <td className="px-4 py-2.5">
+                    <div className="flex items-center gap-1.5 min-w-0">
+                      <span className="font-medium truncate dark:text-[#E0E0E0]" title={l.name}>{l.name || 'Unknown'}</span>
+                      {l.linkedin_url && (
+                        <a href={l.linkedin_url} target="_blank" rel="noopener noreferrer" title="Open LinkedIn profile" className="text-[#2B7CFF] hover:opacity-80 shrink-0">
+                          <Linkedin className="h-3.5 w-3.5" />
+                        </a>
+                      )}
+                    </div>
+                  </td>
+                  <td className="px-4 py-2.5 text-muted-foreground truncate" title={l.company_name || ''}>{l.company_name || '—'}</td>
+                  <td className="px-4 py-2.5 text-muted-foreground truncate" title={l.campaign_name || ''}>{l.campaign_name || '—'}</td>
+                  <td className="px-4 py-2.5 text-muted-foreground whitespace-nowrap" title={l.next_followup_at || ''}>{fmtFollowup(l.next_followup_at)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  </div>,
+  document.body
+  );
+};

--- a/web/src/components/overview/widgets/EmailActivityWidget.tsx
+++ b/web/src/components/overview/widgets/EmailActivityWidget.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+/**
+ * EmailActivityWidget — email channel activity.
+ *
+ * Connected senders + broadcast send/fail totals across recent runs, plus the
+ * latest few broadcasts. Data: GET /api/campaigns/email/connected-senders and
+ * GET /api/email-comms/broadcast/runs. Gated to the email channel by
+ * DashboardGrid. (Open/reply rates aren't surfaced by the API yet.)
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { RefreshCw, Mail } from 'lucide-react';
+import { WidgetWrapper } from '../WidgetWrapper';
+import { fetchWithTenant } from '@/lib/fetch-with-tenant';
+
+interface Run {
+  subject?: string;
+  status?: string;
+  recipient_count?: number;
+  sent_count?: number;
+  failed_count?: number;
+}
+interface EmailData {
+  senders: number;
+  runs: Run[];
+  sent: number;
+  failed: number;
+}
+
+const num = (n: number) => n.toLocaleString();
+
+export const EmailActivityWidget: React.FC<{ id: string }> = ({ id }) => {
+  const [data, setData] = useState<EmailData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [sRes, rRes] = await Promise.all([
+        fetchWithTenant('/api/campaigns/email/connected-senders'),
+        fetchWithTenant('/api/email-comms/broadcast/runs?limit=100'),
+      ]);
+      const sJson = await sRes.json().catch(() => ({}));
+      const rJson = await rRes.json().catch(() => ({}));
+      const senders = Array.isArray(sJson?.data) ? sJson.data.length : (Array.isArray(sJson) ? sJson.length : 0);
+      const runs: Run[] = Array.isArray(rJson?.runs) ? rJson.runs : (Array.isArray(rJson) ? rJson : []);
+      const sent = runs.reduce((a, r) => a + (r.sent_count || 0), 0);
+      const failed = runs.reduce((a, r) => a + (r.failed_count || 0), 0);
+      setData({ senders, runs, sent, failed });
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load email activity');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const header = (
+    <button onClick={load} title="Refresh" className="p-1 rounded hover:bg-black/5 dark:hover:bg-white/10 text-muted-foreground dark:text-[#E0E0E0]">
+      <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+    </button>
+  );
+
+  const tiles = data
+    ? [
+        { label: 'Senders', value: data.senders },
+        { label: 'Broadcasts', value: data.runs.length },
+        { label: 'Sent', value: data.sent },
+        { label: 'Failed', value: data.failed },
+      ]
+    : [];
+
+  return (
+    <WidgetWrapper id={id} title="Email activity" icon={<Mail className="h-4 w-4" />} headerActions={header}>
+      {error && !data ? (
+        <div className="h-full flex flex-col items-center justify-center text-center gap-1 py-8">
+          <p className="text-sm text-muted-foreground">Couldn&apos;t load email activity</p>
+          <p className="text-[11px] text-muted-foreground/70 max-w-[240px]">{error}</p>
+          <button onClick={load} className="mt-2 text-xs text-blue-600 hover:underline">Try again</button>
+        </div>
+      ) : loading && !data ? (
+        <div className="grid grid-cols-2 gap-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="h-14 rounded-lg bg-muted/50 dark:bg-white/5 animate-pulse" />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <div className="grid grid-cols-2 gap-2">
+            {tiles.map((t) => (
+              <div key={t.label} className="bg-muted/40 dark:bg-white/5 rounded-lg px-3 py-2">
+                <p className="text-[11px] text-muted-foreground">{t.label}</p>
+                <p className="text-lg font-medium dark:text-[#E0E0E0]">{num(t.value)}</p>
+              </div>
+            ))}
+          </div>
+          {data && data.runs.length > 0 && (
+            <div>
+              <p className="text-[11px] text-muted-foreground mb-1.5">Recent broadcasts</p>
+              <div className="space-y-1.5">
+                {data.runs.slice(0, 3).map((r, i) => (
+                  <div key={i} className="flex items-center justify-between gap-2 text-xs">
+                    <span className="truncate dark:text-[#E0E0E0]/90">{r.subject || '(no subject)'}</span>
+                    <span className="shrink-0 text-muted-foreground">
+                      {num(r.sent_count || 0)} sent{r.failed_count ? ` · ${num(r.failed_count)} failed` : ''}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </WidgetWrapper>
+  );
+};

--- a/web/src/components/overview/widgets/InstagramActivityWidget.tsx
+++ b/web/src/components/overview/widgets/InstagramActivityWidget.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+/**
+ * InstagramActivityWidget — Instagram DM activity.
+ *
+ * DM thread counts (total / unread) and active connected accounts, derived from
+ * GET /api/instagram-conversations/conversations and /accounts (no dedicated
+ * analytics endpoint exists). Gated to the instagram channel by DashboardGrid.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { RefreshCw, Instagram } from 'lucide-react';
+import { WidgetWrapper } from '../WidgetWrapper';
+import { fetchWithTenant } from '@/lib/fetch-with-tenant';
+
+interface IgData {
+  threads: number;
+  unread: number;
+  accounts: number;
+}
+
+const num = (n: number) => n.toLocaleString();
+const unreadOf = (c: any): number =>
+  Number(c?.unread_count ?? c?.unreadCount ?? c?.unread ?? 0) || 0;
+
+export const InstagramActivityWidget: React.FC<{ id: string }> = ({ id }) => {
+  const [data, setData] = useState<IgData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [cRes, aRes] = await Promise.all([
+        fetchWithTenant('/api/instagram-conversations/conversations'),
+        fetchWithTenant('/api/instagram-conversations/accounts'),
+      ]);
+      const cJson = await cRes.json().catch(() => ({}));
+      const aJson = await aRes.json().catch(() => ({}));
+      const rows: any[] = Array.isArray(cJson?.data) ? cJson.data : (Array.isArray(cJson?.conversations) ? cJson.conversations : (Array.isArray(cJson) ? cJson : []));
+      const accts: any[] = Array.isArray(aJson?.accounts) ? aJson.accounts : (Array.isArray(aJson) ? aJson : []);
+      const activeAccts = accts.filter((a) => (a?.status ?? 'active') !== 'inactive' && !a?.is_deleted).length;
+      setData({
+        threads: rows.length,
+        unread: rows.filter((r) => unreadOf(r) > 0).length,
+        accounts: activeAccts,
+      });
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load Instagram activity');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const header = (
+    <button onClick={load} title="Refresh" className="p-1 rounded hover:bg-black/5 dark:hover:bg-white/10 text-muted-foreground dark:text-[#E0E0E0]">
+      <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+    </button>
+  );
+
+  const tiles = data
+    ? [
+        { label: 'DM threads', value: data.threads },
+        { label: 'Unread', value: data.unread },
+        { label: 'Accounts', value: data.accounts },
+      ]
+    : [];
+
+  return (
+    <WidgetWrapper id={id} title="Instagram activity" icon={<Instagram className="h-4 w-4" />} headerActions={header}>
+      {error && !data ? (
+        <div className="h-full flex flex-col items-center justify-center text-center gap-1 py-8">
+          <p className="text-sm text-muted-foreground">Couldn&apos;t load Instagram activity</p>
+          <p className="text-[11px] text-muted-foreground/70 max-w-[240px]">{error}</p>
+          <button onClick={load} className="mt-2 text-xs text-blue-600 hover:underline">Try again</button>
+        </div>
+      ) : loading && !data ? (
+        <div className="grid grid-cols-3 gap-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-16 rounded-lg bg-muted/50 dark:bg-white/5 animate-pulse" />
+          ))}
+        </div>
+      ) : data && data.threads === 0 && data.accounts === 0 ? (
+        <div className="flex flex-col items-center justify-center py-10 text-center">
+          <p className="text-sm font-medium dark:text-[#E0E0E0]">No Instagram activity yet</p>
+          <p className="text-xs text-muted-foreground mt-1 max-w-[240px]">DM threads will show up here once your Instagram account starts receiving messages.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-3 gap-2">
+          {tiles.map((t) => (
+            <div key={t.label} className="bg-muted/40 dark:bg-white/5 rounded-lg px-3 py-2.5">
+              <p className="text-[11px] text-muted-foreground">{t.label}</p>
+              <p className="text-xl font-medium dark:text-[#E0E0E0]">{num(t.value)}</p>
+            </div>
+          ))}
+        </div>
+      )}
+    </WidgetWrapper>
+  );
+};

--- a/web/src/components/overview/widgets/LinkedInFunnelWidget.tsx
+++ b/web/src/components/overview/widgets/LinkedInFunnelWidget.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+/**
+ * LinkedInFunnelWidget — the outbound LinkedIn funnel.
+ *
+ * Sent → Accepted → Replied across all campaigns, with accept/reply rates and
+ * the account's weekly connection-limit usage. Data: LAD backend
+ * GET /api/campaigns/stats (CampaignStats). Gated to the LinkedIn channel by
+ * DashboardGrid, so it only renders when a LinkedIn account is connected.
+ */
+import React, { useCallback, useEffect, useState } from 'react';
+import { RefreshCw, Linkedin } from 'lucide-react';
+import { WidgetWrapper } from '../WidgetWrapper';
+import { fetchWithTenant } from '@/lib/fetch-with-tenant';
+
+interface Stats {
+  total_sent?: number;
+  total_connected?: number;
+  total_replied?: number;
+  avg_connection_rate?: number;
+  avg_reply_rate?: number;
+  linkedin_network_size?: number | null;
+  linkedin_rate_limits?: {
+    weekly?: { max?: number; total?: number };
+    usage?: { weekly_percentage?: number | string };
+  };
+}
+
+const pct = (n: number | undefined) => (n == null ? 0 : Math.round(n));
+const num = (n: number | undefined) => (n == null ? 0 : n).toLocaleString();
+
+export const LinkedInFunnelWidget: React.FC<{ id: string }> = ({ id }) => {
+  const [data, setData] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetchWithTenant('/api/campaigns/stats');
+      const json = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(json?.error || json?.message || `Request failed (${res.status})`);
+      setData((json?.data ?? json) as Stats);
+    } catch (e: any) {
+      setError(e?.message || 'Failed to load LinkedIn stats');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const header = (
+    <button
+      onClick={load}
+      title="Refresh"
+      className="p-1 rounded hover:bg-black/5 dark:hover:bg-white/10 text-muted-foreground dark:text-[#E0E0E0]"
+    >
+      <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+    </button>
+  );
+
+  const sent = data?.total_sent ?? 0;
+  const accepted = data?.total_connected ?? 0;
+  const replied = data?.total_replied ?? 0;
+  const acceptRate = pct(data?.avg_connection_rate);
+  const replyRate = pct(data?.avg_reply_rate);
+  const weeklyUsed = data?.linkedin_rate_limits?.weekly?.total ?? null;
+  const weeklyMax = data?.linkedin_rate_limits?.weekly?.max ?? null;
+  const weeklyPctRaw = data?.linkedin_rate_limits?.usage?.weekly_percentage;
+  const weeklyPct = weeklyPctRaw == null ? (weeklyMax ? Math.round(((weeklyUsed ?? 0) / weeklyMax) * 100) : null) : Math.round(Number(weeklyPctRaw));
+
+  const steps = [
+    { label: 'Sent', value: sent, sub: null as string | null },
+    { label: 'Accepted', value: accepted, sub: `${acceptRate}%` },
+    { label: 'Replied', value: replied, sub: `${replyRate}%` },
+  ];
+  const maxVal = Math.max(1, sent, accepted, replied);
+
+  return (
+    <WidgetWrapper id={id} title="LinkedIn funnel" icon={<Linkedin className="h-4 w-4" />} headerActions={header}>
+      {error && !data ? (
+        <div className="h-full flex flex-col items-center justify-center text-center gap-1 py-8">
+          <p className="text-sm text-muted-foreground">Couldn&apos;t load LinkedIn stats</p>
+          <p className="text-[11px] text-muted-foreground/70 max-w-[240px]">{error}</p>
+          <button onClick={load} className="mt-2 text-xs text-blue-600 hover:underline">Try again</button>
+        </div>
+      ) : loading && !data ? (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-8 rounded-lg bg-muted/50 dark:bg-white/5 animate-pulse" />
+          ))}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2.5">
+            {steps.map((s) => (
+              <div key={s.label}>
+                <div className="flex items-baseline justify-between mb-1">
+                  <span className="text-xs text-muted-foreground dark:text-[#E0E0E0]/70">{s.label}</span>
+                  <span className="text-sm font-medium dark:text-[#E0E0E0]">
+                    {num(s.value)}
+                    {s.sub && <span className="ml-1.5 text-[11px] text-muted-foreground">{s.sub}</span>}
+                  </span>
+                </div>
+                <div className="h-1.5 rounded-full bg-muted dark:bg-white/5 overflow-hidden">
+                  <span className="block h-full bg-[#2B7CFF]" style={{ width: `${Math.round((s.value / maxVal) * 100)}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-2 gap-2">
+            <div className="bg-muted/40 dark:bg-white/5 rounded-lg px-3 py-2">
+              <p className="text-[11px] text-muted-foreground">Accept rate</p>
+              <p className="text-lg font-medium dark:text-[#E0E0E0]">{acceptRate}%</p>
+            </div>
+            <div className="bg-muted/40 dark:bg-white/5 rounded-lg px-3 py-2">
+              <p className="text-[11px] text-muted-foreground">Network size</p>
+              <p className="text-lg font-medium dark:text-[#E0E0E0]">
+                {data?.linkedin_network_size != null ? num(data.linkedin_network_size) : '—'}
+              </p>
+            </div>
+          </div>
+
+          {weeklyPct != null && (
+            <div>
+              <div className="flex items-baseline justify-between mb-1">
+                <span className="text-[11px] text-muted-foreground">Weekly connection limit</span>
+                <span className="text-[11px] text-muted-foreground">
+                  {weeklyUsed != null && weeklyMax != null ? `${num(weeklyUsed)} / ${num(weeklyMax)}` : `${weeklyPct}%`}
+                </span>
+              </div>
+              <div className="h-1.5 rounded-full bg-muted dark:bg-white/5 overflow-hidden">
+                <span
+                  className={`block h-full ${weeklyPct >= 90 ? 'bg-red-500' : weeklyPct >= 70 ? 'bg-amber-500' : 'bg-emerald-500'}`}
+                  style={{ width: `${Math.min(100, weeklyPct)}%` }}
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </WidgetWrapper>
+  );
+};

--- a/web/src/hooks/useConnectedChannels.ts
+++ b/web/src/hooks/useConnectedChannels.ts
@@ -20,7 +20,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { fetchWithTenant } from '@/lib/fetch-with-tenant';
 
-export type ChannelId = 'waba' | 'personal_whatsapp' | 'linkedin' | 'gmail' | 'instagram';
+export type ChannelId = 'waba' | 'personal_whatsapp' | 'linkedin' | 'gmail' | 'instagram' | 'voice';
 export type ChannelStatus = 'connected' | 'disconnected' | 'unknown';
 
 const INITIAL: Record<ChannelId, ChannelStatus> = {
@@ -29,6 +29,7 @@ const INITIAL: Record<ChannelId, ChannelStatus> = {
   linkedin: 'unknown',
   gmail: 'unknown',
   instagram: 'unknown',
+  voice: 'unknown',
 };
 
 type ProbeResult =
@@ -100,6 +101,14 @@ async function probeInstagram(): Promise<ChannelStatus> {
   });
 }
 
+/** Voice is "connected" when the tenant has at least one usable voice agent. */
+async function probeVoice(): Promise<ChannelStatus> {
+  return toStatus(await probe('/api/voice-agent/user/available-agents'), (data) => {
+    const agents = Array.isArray(data) ? data : (Array.isArray(data?.data) ? data.data : []);
+    return agents.length > 0;
+  });
+}
+
 export function useConnectedChannels() {
   const [statuses, setStatuses] = useState<Record<ChannelId, ChannelStatus>>(INITIAL);
   const [loaded, setLoaded] = useState(false);
@@ -109,14 +118,15 @@ export function useConnectedChannels() {
     if (inFlight.current) return;
     inFlight.current = true;
     try {
-      const [waba, personal, linkedin, gmail, instagram] = await Promise.all([
+      const [waba, personal, linkedin, gmail, instagram, voice] = await Promise.all([
         probeWaba(),
         probePersonalWhatsapp(),
         probeLinkedin(),
         probeEmail(),
         probeInstagram(),
+        probeVoice(),
       ]);
-      const next = { waba, personal_whatsapp: personal, linkedin, gmail, instagram };
+      const next = { waba, personal_whatsapp: personal, linkedin, gmail, instagram, voice };
       // Visible in devtools so "why is this tab shown/hidden?" is answerable.
       // 'unknown' = probe failed transiently → treated as visible (fail-open).
       console.debug('[useConnectedChannels] statuses', next);

--- a/web/src/store/dashboardStore.ts
+++ b/web/src/store/dashboardStore.ts
@@ -201,7 +201,17 @@ export const useDashboardStore = create<DashboardState>()(
       //     Re-engage by Topic) at their intended slot under the stat cards.
       // v4: hard-reset to DEFAULT_LAYOUT so existing users get the new
       //     Lead Journey widget (accepted / responded / SAH) under the stats.
-      version: 4,
+      // v5: hard-reset to DEFAULT_LAYOUT for the channel-aware redesign — adds
+      //     the LinkedIn Funnel widget; widgets are now hidden when their
+      //     channel isn't connected (DashboardGrid gating).
+      // v6: hard-reset to DEFAULT_LAYOUT — adds the Email Activity and
+      //     Instagram Activity widgets (channel-gated like the rest).
+      // v7: hard-reset to DEFAULT_LAYOUT — adds the combined Sales Funnel
+      //     widget (cross-channel: new leads → accepted → responded → SAH).
+      // v8: Sales Funnel is now interactive (click a stage → drill into its
+      //     leads), which supersedes the separate Lead Journey widget — removed
+      //     from the default layout (still available in the widget library).
+      version: 8,
       migrate: (persistedState: Record<string, unknown>) => {
         if (!persistedState) return persistedState;
         return { ...persistedState, layout: DEFAULT_LAYOUT };

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -13,14 +13,21 @@ export type WidgetType =
   | 'broadcast-performance'
   | 'conversation-funnel'
   | 'reengage-topics'
-  | 'lead-journey';
+  | 'lead-journey'
+  | 'linkedin-funnel'
+  | 'email-activity'
+  | 'instagram-activity'
+  | 'combined-funnel';
 export type WidgetCategory =
   | 'analytics'
   | 'voice-agent'
   | 'credits'
   | 'calendar'
   | 'ai-insights'
-  | 'whatsapp';
+  | 'whatsapp'
+  | 'linkedin'
+  | 'email'
+  | 'instagram';
 export interface WidgetConfig {
   id: string;
   type: WidgetType;
@@ -214,6 +221,50 @@ export const WIDGET_CATALOG: Record<WidgetType, WidgetConfig> = {
     minSize: { w: 4, h: 3 },
     maxSize: { w: 12, h: 8 },
   },
+  'linkedin-funnel': {
+    id: 'linkedin-funnel',
+    type: 'linkedin-funnel',
+    title: 'LinkedIn Funnel',
+    description: 'Outbound LinkedIn funnel — sent, accepted, replied, accept/reply rates and weekly connection-limit usage',
+    category: 'linkedin',
+    icon: 'TrendingUp',
+    defaultSize: { w: 6, h: 4 },
+    minSize: { w: 4, h: 3 },
+    maxSize: { w: 12, h: 6 },
+  },
+  'email-activity': {
+    id: 'email-activity',
+    type: 'email-activity',
+    title: 'Email Activity',
+    description: 'Connected senders, broadcast send / fail totals and your most recent email broadcasts',
+    category: 'email',
+    icon: 'Mail',
+    defaultSize: { w: 6, h: 4 },
+    minSize: { w: 4, h: 3 },
+    maxSize: { w: 12, h: 6 },
+  },
+  'instagram-activity': {
+    id: 'instagram-activity',
+    type: 'instagram-activity',
+    title: 'Instagram Activity',
+    description: 'Instagram DM threads, unread count and active connected accounts',
+    category: 'instagram',
+    icon: 'Instagram',
+    defaultSize: { w: 6, h: 3 },
+    minSize: { w: 4, h: 3 },
+    maxSize: { w: 12, h: 5 },
+  },
+  'combined-funnel': {
+    id: 'combined-funnel',
+    type: 'combined-funnel',
+    title: 'Sales Funnel',
+    description: 'One cross-channel lead funnel — new leads to booked meeting (SAH) with overall + per-stage conversion',
+    category: 'analytics',
+    icon: 'Filter',
+    defaultSize: { w: 12, h: 5 },
+    minSize: { w: 6, h: 4 },
+    maxSize: { w: 12, h: 7 },
+  },
 };
 // Widget categories for the library
 export const WIDGET_CATEGORIES: { id: WidgetCategory; label: string; icon: string }[] = [
@@ -223,15 +274,21 @@ export const WIDGET_CATEGORIES: { id: WidgetCategory; label: string; icon: strin
   { id: 'calendar', label: 'Calendar & Scheduling', icon: 'Calendar' },
   { id: 'ai-insights', label: 'AI Insights', icon: 'Brain' },
   { id: 'whatsapp', label: 'WhatsApp', icon: 'MessageSquare' },
+  { id: 'linkedin', label: 'LinkedIn', icon: 'TrendingUp' },
+  { id: 'email', label: 'Email', icon: 'Mail' },
+  { id: 'instagram', label: 'Instagram', icon: 'Instagram' },
 ];
 // Default dashboard layout
 export const DEFAULT_LAYOUT: WidgetLayoutItem[] = [
   { i: 'calls-today-1', x: 0, y: 0, w: 4, h: 2, minW: 3, minH: 2 },
   { i: 'answer-rate-1', x: 4, y: 0, w: 4, h: 2, minW: 3, minH: 2 },
   { i: 'calls-monthly-1', x: 8, y: 0, w: 4, h: 2, minW: 3, minH: 2 },
-  { i: 'lead-journey-1', x: 0, y: 2, w: 6, h: 4, minW: 4, minH: 3 },
-  { i: 'conversation-funnel-1', x: 6, y: 2, w: 6, h: 4, minW: 4, minH: 3 },
+  { i: 'combined-funnel-1', x: 0, y: 2, w: 12, h: 5, minW: 6, minH: 4 },
+  { i: 'linkedin-funnel-1', x: 0, y: 7, w: 6, h: 4, minW: 4, minH: 3 },
+  { i: 'conversation-funnel-1', x: 6, y: 7, w: 6, h: 4, minW: 4, minH: 3 },
   { i: 'reengage-topics-1', x: 6, y: 2, w: 6, h: 4, minW: 4, minH: 3 },
+  { i: 'email-activity-1', x: 0, y: 6, w: 6, h: 4, minW: 4, minH: 3 },
+  { i: 'instagram-activity-1', x: 6, y: 6, w: 6, h: 3, minW: 4, minH: 3 },
   { i: 'broadcast-performance-1', x: 0, y: 6, w: 12, h: 3, minW: 6, minH: 3 },
   { i: 'calls-chart-1', x: 0, y: 5, w: 6, h: 4, minW: 4, minH: 3 },
   { i: 'voice-agents-1', x: 6, y: 5, w: 6, h: 4, minW: 4, minH: 3 },


### PR DESCRIPTION
## What & why
Follow-up to the merged #647 — redesigns `/overview` to show **metrics per integrated channel** and adds a cross-channel **Sales Funnel** with drill-down. Fixes the voice bias (6 of 12 default widgets were Voice and showed for LinkedIn-only tenants).

### Channel gating
- `DashboardGrid`: `WIDGET_CHANNEL` map — widgets hide when their channel is positively **disconnected** (fail-open on unknown/loading; edit mode shows everything so gated widgets stay manageable).
- `useConnectedChannels`: added the missing **voice** probe.

### New widgets
- **Sales Funnel** (`CombinedFunnelWidget`, always-on, full-width): New Leads (connection requests sent) → Accepted → Responded → Meeting Booked (SAH); overall + per-stage conversion + drop-off; **Week/Month/Quarter/Year** filter (default Week) driving `?from=&to=`; **click a stage → drill-down table** (Name+LinkedIn / Company / Campaign / Next follow-up) with **CSV download**. Modal renders via `createPortal(document.body)` — the dnd-kit `transform` on `WidgetWrapper` made the card the containing block for `position:fixed`, pushing the modal header off-screen on long lists; sticky headers on `<th>` (browsers ignore sticky `<thead>`); inline `minHeight:0` flex scroll body.
- **LinkedIn Funnel**: sent/accepted/replied + accept rate, network size, weekly connection-limit bar (`/api/campaigns/stats`).
- **Email Activity**: senders + broadcast sent/failed + recent runs (API exposes no open/reply rates yet).
- **Instagram Activity**: DM threads / unread / active accounts.

### Layout
Sales Funnel on top; **Lead Journey removed from the default layout** (superseded by the funnel drill-down; still in the widget library). Store version **4 → 8**.

## ⚠️ Layout reset
The store version bump hard-resets every user's customized dashboard layout to default (existing `migrate` behavior) — the agreed cost of shipping the new default.

## Depends on
LAD-Backend PR from `feat/lead-journey-overview` (date window + `sent` + `next_followup_at`). Without it the funnel renders but the time filter/drill-down extras degrade.

## Verification
`tsc --noEmit` clean on all changed files; endpoint E2E-verified against a stage tenant; modal fix visually confirmed (portal was the root cause across three debugging rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)