### PR TITLE
feat(chat-settings): Generate with AI button on the create-new-prompt form

### DIFF
--- a/web/src/components/settings/ChatSettings.tsx
+++ b/web/src/components/settings/ChatSettings.tsx
@@ -1414,6 +1414,18 @@ export function ChatSettings() {
                 onChange={(e) => setNewPromptText(e.target.value)}
                 className="w-full h-32 px-3 py-2 text-sm font-mono border border-gray-200 rounded-md resize-y focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400"
               />
+              {/* LinkedIn-only: draft a fresh prompt from the business profile & ICP into the fields above */}
+              {activeChannel === 'linkedin' && (
+                <button
+                  onClick={() => runGenerate(null)}
+                  disabled={generatingPrompt === '__new__'}
+                  className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-blue-700 border border-blue-200 rounded-md hover:bg-blue-50 disabled:opacity-40"
+                  title="Generate a prompt from your business profile & ICP"
+                >
+                  {generatingPrompt === '__new__' ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
+                  Generate with AI
+                </button>
+              )}
               <div className="flex items-center gap-2">
                 <button
                   onClick={handleCreatePrompt}


### PR DESCRIPTION
## Problem
The "Generate with AI" LinkedIn prompt generator (PR #635) only renders in two places in `web/src/components/settings/ChatSettings.tsx`:
- the channel **empty state** (`runGenerate(null)`), shown only when `filteredPrompts.length === 0`, and
- each **expanded existing prompt card** (`runGenerate(prompt.name)`).

There was **no** Generate button on the **"Add New Prompt"** form. So a tenant that already has LinkedIn prompts (e.g. "Linkedin Connection Template" + "Linkedin Followup Template") had no visible way to AI-generate a *new* prompt — the empty-state button is hidden and the create form lacked one. (Real user report, 2026-07-08.)

## Change (FE only)
Add a "Generate with AI" button to the create-new-prompt form, between the prompt-text textarea and the "+ Create Prompt" button. It is wired to the **existing** `runGenerate(null)` handler (the `'__new__'` path), which drafts a prompt and prefills the new-prompt name/text fields for review before Save.

- Gated to `activeChannel === 'linkedin'`, matching the two existing generate buttons (generation is LinkedIn-only for now).
- Loading/disabled state mirrors the empty-state button: disabled while `generatingPrompt === '__new__'`; shows a spinning `Loader2` while generating, else `Sparkles` + "Generate with AI".
- Reuses the same Tailwind classes (blue border / `text-blue-700` / `hover:bg-blue-50`) and the shared `title` "Generate a prompt from your business profile & ICP".
- **No** new handler, endpoint, state, or import — `Sparkles`, `Loader2`, `generatingPrompt`, and `runGenerate` were already present. `runGenerate` logic, the missing-fields modal, and the empty-state/card buttons are untouched.

## Verification
- `npm run build --workspace=web` → **Compiled successfully**, all 122 static pages generated (Node 20).
- `tsc --noEmit` (web): no new errors introduced by this file — the only `ChatSettings.tsx` diagnostic is the pre-existing baseline error at line 562 (`campaign_frequency` typing), far above the additive edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)