### PR TITLE
feat(campaigns): AI Media canvas node — generate brand media and attach to outreach

### DIFF
--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -1453,11 +1453,26 @@ export default function AdvancedSearchAIPage() {
                     const curCfg = deriveConfig(useOnboardingStore.getState().workflowPreview as unknown as SyncStep[]);
                     const hydChannels = Array.isArray(cs.next_channels) ? [...cs.next_channels] : [...curCfg.nextChannels];
                     if (liActions.length && !hydChannels.includes('linkedin')) hydChannels.unshift('linkedin');
-                    setWorkflowPreview(applyConfig(
+                    const hydrated = applyConfig(
                         useOnboardingStore.getState().workflowPreview as unknown as SyncStep[],
                         { actions: liActions, nextChannels: hydChannels, triggerCondition: cs.trigger_condition ?? cfg.trigger_condition ?? '' },
                         { includeLeadSource: includeLeadSourceRef.current },
-                    ) as any);
+                    ) as any[];
+                    // Restore the AI Media node (preserved type — survives later
+                    // toggle reconciles). Source: checkpoint_selections.media_step,
+                    // else a persisted media_generation step row.
+                    const ms = cs.media_step
+                        || (camp?.steps || []).find((s: any) => (s.type || s.step_type) === 'media_generation')?.config;
+                    if (ms && !hydrated.some((s: any) => s.type === 'media_generation')) {
+                        hydrated.push({
+                            id: 'media-gen', type: 'media_generation', title: 'AI Media', channel: 'media',
+                            description: 'Generate brand media to attach to outreach',
+                            mediaUrl: ms.media_url || '', mediaType: ms.media_type || '',
+                            mediaFilename: ms.media_filename || '', mimeType: ms.mime_type || '',
+                            mediaPrompt: ms.prompt || '',
+                        });
+                    }
+                    setWorkflowPreview(hydrated as any);
                 }
                 if (cs.campaign_days != null) setCpDays(String(cs.campaign_days));
                 setCpName(cs.campaign_name ?? camp?.name ?? '');
@@ -7843,6 +7858,33 @@ function CheckpointFormInline({
                     if (ch === 'voice_call') actionSteps.push({ type: 'voice_agent_call', title: 'AI Voice Call', channel: 'voice', order_index: orderIdx++, config: { agent_id: selectedAgentId || undefined, voice_id: selectedVoiceId || undefined, from_number: selectedFromNumber || undefined, ...chDelayConfig } });
                 }
             }
+
+            // ── AI Media step (media_generation) ──────────────────────────────
+            // The canvas node carries the accepted asset (permanent GCS quadruple,
+            // set via StepEditor → import-generated). Emit it as a real first step
+            // and stamp the asset onto every downstream send step that can carry
+            // media (LinkedIn message / WhatsApp / Email). The backend executor
+            // for media_generation is a fast no-op — sends read their own config.
+            const wfMediaNode = (useOnboardingStore.getState().workflowPreview || [])
+                .find((s: any) => s.type === 'media_generation') as any;
+            if (wfMediaNode?.mediaUrl) {
+                const mediaCfg = {
+                    media_url: wfMediaNode.mediaUrl,
+                    media_type: wfMediaNode.mediaType || 'image',
+                    media_filename: wfMediaNode.mediaFilename || undefined,
+                    mime_type: wfMediaNode.mimeType || undefined,
+                };
+                const MEDIA_CAPABLE = ['linkedin_message', 'whatsapp_send', 'email_send'];
+                for (const s of actionSteps) {
+                    if (MEDIA_CAPABLE.includes(s.type)) s.config = { ...s.config, ...mediaCfg };
+                }
+                actionSteps.unshift({
+                    type: 'media_generation', title: wfMediaNode.title || 'AI Media', channel: 'media',
+                    order_index: 0, config: { ...mediaCfg, prompt: wfMediaNode.mediaPrompt || undefined },
+                });
+                actionSteps.forEach((s, i) => { s.order_index = i + 1; });
+            }
+
             const t = targeting || { keywords: [], industries: [], locations: [], job_titles: [], profile_language: [] };
             const icpMin = parseInt(icpThreshold) || 0;
             // Build lead feedback summary for campaign config
@@ -7870,6 +7912,14 @@ function CheckpointFormInline({
                 ai_value_prop: aiMsgValueProp || '',
                 ai_tone: aiMsgTone || 'professional',
                 ai_goal: aiMsgGoal || 'get_meeting',
+                // AI Media node (edit-mode round-trip: hydration re-creates the canvas node)
+                media_step: wfMediaNode ? {
+                    media_url: wfMediaNode.mediaUrl || '',
+                    media_type: wfMediaNode.mediaType || '',
+                    media_filename: wfMediaNode.mediaFilename || '',
+                    mime_type: wfMediaNode.mimeType || '',
+                    prompt: wfMediaNode.mediaPrompt || '',
+                } : null,
             };
 
             // Get original ICP input (first user message in chat)

--- a/web/src/components/onboarding/WorkflowPreviewPanel.tsx
+++ b/web/src/components/onboarding/WorkflowPreviewPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useMemo, useState, useEffect } from 'react';
-import { Workflow, Play, GitBranch, Zap, ArrowRightLeft, ArrowUpDown, Plus, X, ChevronRight, ChevronLeft, Linkedin, Mail, MessageCircle, Phone, UserPlus, Send, Eye } from 'lucide-react';
+import { Workflow, Play, GitBranch, Zap, ArrowRightLeft, ArrowUpDown, Plus, X, ChevronRight, ChevronLeft, Linkedin, Mail, MessageCircle, Phone, UserPlus, Send, Eye, Wand2 } from 'lucide-react';
 import { useOnboardingStore, WorkflowPreviewStep } from '@/store/onboardingStore';
 import { StepType } from '@/types/campaign';
 import ReactFlow, {
@@ -39,6 +39,7 @@ const PLATFORMS: any[] = [
   { id: 'email',    label: 'Email',    icon: <Mail className="w-4 h-4" />,     color: '#ea4335', desc: 'Direct mailing' },
   { id: 'whatsapp', label: 'WhatsApp', icon: <MessageCircle className="w-4 h-4" />, color: '#25d366', desc: 'Instant messaging' },
   { id: 'voice',    label: 'Voice',    icon: <Phone className="w-4 h-4" />,    color: '#8b5cf6', desc: 'AI Phone calls' },
+  { id: 'media',    label: 'AI Media', icon: <Wand2 className="w-4 h-4" />,    color: '#d946ef', desc: 'Generate brand media' },
 ];
 
 const PLATFORM_ACTIONS: Record<string, any[]> = {
@@ -55,6 +56,9 @@ const PLATFORM_ACTIONS: Record<string, any[]> = {
   ],
   voice: [
     { type: 'voice_agent_call', title: 'AI Call', icon: <Phone className="w-4 h-4" />, desc: 'AI voice interaction' },
+  ],
+  media: [
+    { type: 'media_generation', title: 'Generate Media', icon: <Wand2 className="w-4 h-4" />, desc: 'Brand image/video for outreach' },
   ],
 };
 
@@ -214,10 +218,11 @@ export default function WorkflowPreviewPanel({
           <div style={{ display: 'flex', gap: 6, marginTop: 10, flexWrap: 'wrap' }}>
             {workflowPreview.map((step) => {
               const color = step.type.includes('linkedin') || step.type === 'lead_generation' ? '#0a66c2'
-                : step.type.includes('email') ? '#ea4335'
-                  : step.type.includes('whatsapp') ? '#25d366'
-                    : step.type.includes('voice') ? '#8b5cf6'
-                      : step.type === 'delay' ? '#6b7280' : '#6366f1';
+                : step.type === 'media_generation' ? '#d946ef'
+                  : step.type.includes('email') ? '#ea4335'
+                    : step.type.includes('whatsapp') ? '#25d366'
+                      : step.type.includes('voice') ? '#8b5cf6'
+                        : step.type === 'delay' ? '#6b7280' : '#6366f1';
               return (
                 <div key={step.id} style={{
                   display: 'flex', alignItems: 'center', gap: 5,

--- a/web/src/components/onboarding/workflow/CustomWorkflowNode.tsx
+++ b/web/src/components/onboarding/workflow/CustomWorkflowNode.tsx
@@ -12,6 +12,7 @@ function getBrandConfig(type: string) {
   if (type === 'start')            return { bg: '#22c55e', border: '#16a34a', glow: 'rgba(34,197,94,0.25)' };
   if (type === 'end')              return { bg: '#ef4444', border: '#dc2626', glow: 'rgba(239,68,68,0.25)' };
   if (type === 'lead_generation')  return { bg: '#f59e0b', border: '#d97706', glow: 'rgba(245,158,11,0.25)' };
+  if (type === 'media_generation') return { bg: '#d946ef', border: '#c026d3', glow: 'rgba(217,70,239,0.25)' };
   if (type === 'linkedin_connect') return { bg: '#3b82f6', border: '#2563eb', glow: 'rgba(59,130,246,0.25)' };
   if (type === 'linkedin_message') return { bg: '#8b5cf6', border: '#7c3aed', glow: 'rgba(139,92,246,0.25)' };
   if (type === 'linkedin_visit')   return { bg: '#0ea5e9', border: '#0284c7', glow: 'rgba(14,165,233,0.25)' };

--- a/web/src/components/onboarding/workflow/StepEditor.tsx
+++ b/web/src/components/onboarding/workflow/StepEditor.tsx
@@ -1,7 +1,9 @@
 'use client';
 import React, { useState, useEffect } from 'react';
 import { useOnboardingStore, WorkflowPreviewStep } from '@/store/onboardingStore';
-import { X, Save, Linkedin, Mail, MessageCircle, Phone, Users, Clock, CheckCircle } from 'lucide-react';
+import { X, Save, Linkedin, Mail, MessageCircle, Phone, Users, Clock, CheckCircle, Wand2, Loader2, Film, FileImage } from 'lucide-react';
+import { MediaGenerationModal } from '@/components/voice-agent/MediaGenerationModal';
+import { useMediaBuilder } from '@/hooks/voice-agent/useMediaBuilder';
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || '';
 const headers = () => ({
@@ -59,13 +61,67 @@ export default function StepEditor({ step, onClose, campaignId }: StepEditorProp
     delayDays: parsedDelay.days,
     delayHours: parsedDelay.hours,
     leadLimit: step.leadLimit || 10,
+    // AI Media step — permanent quadruple set after import-generated
+    mediaPrompt: step.mediaPrompt || '',
+    mediaUrl: step.mediaUrl || '',
+    mediaType: step.mediaType || '',
+    mediaFilename: step.mediaFilename || '',
+    mimeType: step.mimeType || '',
   });
+
+  // ── AI Media step state (media_generation only) ──────────────────────────
+  const [showMediaStudio, setShowMediaStudio] = useState(false);
+  const [showGallery, setShowGallery] = useState(false);
+  const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState('');
+  const [pasteUrl, setPasteUrl] = useState('');
+  const mediaBuilder = useMediaBuilder();
+
+  /** Coarse media category from a filename/URL extension. */
+  const mediaTypeFromName = (name: string): string => {
+    const ext = (name.split('?')[0].split('.').pop() || '').toLowerCase();
+    if (['mp4', 'webm', 'mov', '3gp'].includes(ext)) return 'video';
+    if (['pdf', 'doc', 'docx'].includes(ext)) return 'document';
+    return 'image';
+  };
+
+  /** Re-home a generated asset (7-day signed URL) to the permanent campaign bucket. */
+  const importGenerated = async (sourceUrl: string) => {
+    if (!sourceUrl) return;
+    setImporting(true);
+    setImportError('');
+    try {
+      const filename = decodeURIComponent(sourceUrl.split('?')[0].split('/').pop() || 'generated-media');
+      const res = await fetch(`${API_BASE}/api/campaigns/media/import-generated`, {
+        method: 'POST',
+        headers: headers(),
+        body: JSON.stringify({ source_url: sourceUrl, media_type: mediaTypeFromName(filename), filename }),
+      });
+      const d = await res.json();
+      if (!res.ok || !d?.url) throw new Error(d?.error || `Import failed (${res.status})`);
+      setFormData(prev => ({
+        ...prev,
+        mediaUrl: d.url,
+        mediaType: d.media_type || mediaTypeFromName(d.filename || filename),
+        mediaFilename: d.filename || filename,
+        mimeType: d.mime_type || '',
+        description: prev.description || `Attach ${d.media_type || 'media'} to outreach`,
+      }));
+      setShowGallery(false);
+      setPasteUrl('');
+    } catch (e: any) {
+      setImportError(e?.message || 'Failed to import media');
+    } finally {
+      setImporting(false);
+    }
+  };
   const getStepIcon = () => {
     if (step.type.startsWith('linkedin_')) return <Linkedin className="w-5 h-5" />;
     if (step.type.startsWith('whatsapp_')) return <MessageCircle className="w-5 h-5" />;
     if (step.type.startsWith('email_')) return <Mail className="w-5 h-5" />;
     if (step.type.startsWith('voice_')) return <Phone className="w-5 h-5" />;
     if (step.type === 'lead_generation') return <Users className="w-5 h-5" />;
+    if (step.type === 'media_generation') return <Wand2 className="w-5 h-5" />;
     if (step.type === 'delay') return <Clock className="w-5 h-5" />;
     if (step.type === 'condition') return <CheckCircle className="w-5 h-5" />;
     return null;
@@ -76,6 +132,7 @@ export default function StepEditor({ step, onClose, campaignId }: StepEditorProp
     if (step.type.startsWith('email_')) return 'bg-[#F59E0B]';
     if (step.type.startsWith('voice_')) return 'bg-[#8B5CF6]';
     if (step.type === 'lead_generation') return 'bg-orange-500';
+    if (step.type === 'media_generation') return 'bg-[#D946EF]';
     if (step.type === 'delay') return 'bg-gray-500';
     return 'bg-blue-500';
   };
@@ -445,6 +502,113 @@ export default function StepEditor({ step, onClose, campaignId }: StepEditorProp
             </div>
           </div>
         );
+      case 'media_generation':
+        return (
+          <div className="space-y-4">
+            {/* Selected media preview */}
+            {formData.mediaUrl ? (
+              <div className="border border-fuchsia-200 bg-fuchsia-50 rounded-lg p-3">
+                <div className="flex items-center gap-2 mb-2 text-sm font-medium text-fuchsia-700">
+                  {formData.mediaType === 'video' ? <Film className="w-4 h-4" /> : <FileImage className="w-4 h-4" />}
+                  Attached {formData.mediaType || 'media'}
+                  <button
+                    onClick={() => setFormData({ ...formData, mediaUrl: '', mediaType: '', mediaFilename: '', mimeType: '' })}
+                    className="ml-auto text-xs text-gray-500 hover:text-red-500">Remove</button>
+                </div>
+                {formData.mediaType === 'video' ? (
+                  <video src={formData.mediaUrl} controls className="w-full max-h-48 rounded-md bg-black" />
+                ) : (
+                  // eslint-disable-next-line @next/next/no-img-element
+                  <img src={formData.mediaUrl} alt={formData.mediaFilename} className="w-full max-h-48 object-contain rounded-md" />
+                )}
+                <p className="mt-1 text-xs text-gray-500 truncate">{formData.mediaFilename}</p>
+              </div>
+            ) : (
+              <p className="text-sm text-gray-600">
+                Generate brand media in the AI Media Studio, then attach it here — it will be sent with this campaign&apos;s outreach messages.
+              </p>
+            )}
+
+            {/* Actions */}
+            <div className="flex gap-2">
+              <button
+                onClick={() => setShowMediaStudio(true)}
+                className="flex-1 flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg bg-[#D946EF] text-white text-sm font-semibold hover:opacity-90">
+                <Wand2 className="w-4 h-4" /> Open AI Media Studio
+              </button>
+              <button
+                onClick={() => { setShowGallery(!showGallery); if (!showGallery) mediaBuilder.fetchGallery(); }}
+                className="flex-1 px-3 py-2.5 rounded-lg border border-fuchsia-300 text-fuchsia-700 text-sm font-semibold hover:bg-fuchsia-50">
+                {showGallery ? 'Hide generated media' : 'Pick from generated media'}
+              </button>
+            </div>
+
+            {/* Gallery picker */}
+            {showGallery && (
+              <div className="border border-gray-200 rounded-lg p-2 max-h-56 overflow-y-auto">
+                {mediaBuilder.loadingGallery ? (
+                  <div className="flex items-center justify-center gap-2 py-6 text-sm text-gray-500">
+                    <Loader2 className="w-4 h-4 animate-spin" /> Loading your generated media…
+                  </div>
+                ) : (
+                  <>
+                    {(mediaBuilder.galleryImages?.length || 0) + (mediaBuilder.galleryVideos?.length || 0) === 0 ? (
+                      <p className="py-4 text-center text-sm text-gray-500">No generated media yet — use the AI Media Studio first.</p>
+                    ) : (
+                      <div className="grid grid-cols-3 gap-2">
+                        {(mediaBuilder.galleryImages || []).map((it: any, i: number) => {
+                          const u = it?.url || it?.signed_url || (typeof it === 'string' ? it : '');
+                          return u ? (
+                            // eslint-disable-next-line @next/next/no-img-element
+                            <img key={`gi-${i}`} src={u} alt="generated" onClick={() => importGenerated(u)}
+                              className="w-full h-20 object-cover rounded-md cursor-pointer border-2 border-transparent hover:border-fuchsia-400" />
+                          ) : null;
+                        })}
+                        {(mediaBuilder.galleryVideos || []).map((it: any, i: number) => {
+                          const u = it?.url || it?.signed_url || (typeof it === 'string' ? it : '');
+                          return u ? (
+                            <video key={`gv-${i}`} src={u} onClick={() => importGenerated(u)} muted
+                              className="w-full h-20 object-cover rounded-md cursor-pointer border-2 border-transparent hover:border-fuchsia-400" />
+                          ) : null;
+                        })}
+                      </div>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+
+            {/* Manual URL fallback (asset URL copied from the studio) */}
+            <div className="flex gap-2">
+              <input
+                type="url"
+                value={pasteUrl}
+                onChange={(e) => setPasteUrl(e.target.value)}
+                className="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500"
+                placeholder="…or paste a generated asset URL"
+              />
+              <button
+                onClick={() => importGenerated(pasteUrl)}
+                disabled={importing || !pasteUrl}
+                className="px-4 py-2 rounded-lg bg-gray-900 text-white text-sm font-semibold disabled:opacity-50">
+                {importing ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Attach'}
+              </button>
+            </div>
+            {importing && <p className="text-xs text-gray-500">Saving a permanent copy of the asset…</p>}
+            {importError && <p className="text-xs text-red-500">{importError}</p>}
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Notes / creative brief (optional)</label>
+              <textarea
+                value={formData.mediaPrompt}
+                onChange={(e) => setFormData({ ...formData, mediaPrompt: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-fuchsia-500 focus:border-fuchsia-500 resize-none"
+                rows={2}
+                placeholder="e.g. Product hero image with brand colors, no text overlay"
+              />
+            </div>
+          </div>
+        );
       case 'delay':
         return (
           <div className="space-y-4">
@@ -529,6 +693,11 @@ export default function StepEditor({ step, onClose, campaignId }: StepEditorProp
           </button>
         </div>
       </div>
+
+      {/* Full AI Media Studio wizard (media_generation step only) */}
+      {step.type === 'media_generation' && (
+        <MediaGenerationModal isOpen={showMediaStudio} onClose={() => setShowMediaStudio(false)} />
+      )}
     </div>
   );
 }

--- a/web/src/components/onboarding/workflow/configStepsSync.ts
+++ b/web/src/components/onboarding/workflow/configStepsSync.ts
@@ -62,6 +62,14 @@ const TYPE_BY_CHANNEL: Record<string, string> = {
   voice_call: 'voice_agent_call',
 };
 
+/**
+ * Step types that are NOT modeled by the guided-config toggles but must SURVIVE
+ * a rebuild. buildStepsFromConfig re-derives the array from the toggle config,
+ * so any type it doesn't know is silently dropped the moment a toggle changes —
+ * preserved types are re-inserted at (approximately) their original position.
+ */
+const PRESERVED_TYPES = new Set(['media_generation']);
+
 const COND_LABELS: Record<string, string> = {
   connection_accepted: 'Wait for Connection Accepted',
   message_replied: 'Wait for Message Reply',
@@ -112,6 +120,8 @@ function makeStep(kind: string, existing?: SyncStep): SyncStep {
       return { id: 'ch-whatsapp', type: 'whatsapp_send', title: 'Send WhatsApp Message', description: 'Follow up via whatsapp', channel: 'whatsapp' };
     case 'voice_agent_call':
       return { id: 'ch-voice_call', type: 'voice_agent_call', title: 'AI Voice Call', description: 'Follow up via voice_call', channel: 'voice' };
+    case 'media_generation':
+      return { id: 'media-gen', type: 'media_generation', title: 'AI Media', description: 'Generate brand media to attach to outreach', channel: 'media' };
     default:
       return { id: `${kind}-${Math.random().toString(36).slice(2, 8)}`, type: kind, title: kind };
   }
@@ -181,6 +191,13 @@ export function buildStepsFromConfig(
     if (type) out.push(take(type));
   }
 
+  // Re-insert preserved (toggle-agnostic) steps — e.g. the AI Media node — at
+  // their original position, clamped to the rebuilt array. Without this they
+  // would vanish from the canvas on the next guided-toggle change.
+  existing.forEach((s, i) => {
+    if (PRESERVED_TYPES.has(s.type)) out.splice(Math.min(i, out.length), 0, s);
+  });
+
   return out;
 }
 
@@ -194,4 +211,4 @@ export function applyConfig(
   return buildStepsFromConfig(merged, steps, opts);
 }
 
-export const _internal = { LI_ACTION_BY_TYPE, CHANNEL_BY_TYPE, TYPE_BY_CHANNEL, COND_LABELS };
+export const _internal = { LI_ACTION_BY_TYPE, CHANNEL_BY_TYPE, TYPE_BY_CHANNEL, COND_LABELS, PRESERVED_TYPES };

--- a/web/src/components/onboarding/workflow/workflowNodeUtils.tsx
+++ b/web/src/components/onboarding/workflow/workflowNodeUtils.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Linkedin, Mail, MessageCircle, Phone, ArrowRight, Clock, Filter, Play, Square, Users, Search, Send, UserPlus, Eye, Zap } from 'lucide-react';
+import { Linkedin, Mail, MessageCircle, Phone, ArrowRight, Clock, Filter, Play, Square, Users, Search, Send, UserPlus, Eye, Zap, Wand2 } from 'lucide-react';
 import { StepType } from '@/types/campaign';
 
 export interface NodeClasses {
@@ -39,6 +39,15 @@ export function getNodeClasses(type: StepType): NodeClasses {
     ring: 'ring-amber-400/30',
     bg: 'bg-amber-500',
     text: 'text-amber-400',
+  };
+  if (type === 'media_generation') return {
+    gradient: 'from-fuchsia-400 to-fuchsia-600',
+    icon: 'bg-fuchsia-500',
+    shadow: 'shadow-fuchsia-500/40',
+    glow: 'hover:shadow-fuchsia-400/60',
+    ring: 'ring-fuchsia-400/30',
+    bg: 'bg-fuchsia-500',
+    text: 'text-fuchsia-400',
   };
   if (type.includes('linkedin')) return {
     gradient: 'from-blue-500 to-blue-700',
@@ -109,6 +118,7 @@ export function getNodeIcon(type: StepType, size: string = 'w-5 h-5'): React.Rea
   if (type === 'start') return <Play className={size} />;
   if (type === 'end') return <Square className={size} />;
   if (type === 'lead_generation') return <Search className={size} />;
+  if (type === 'media_generation') return <Wand2 className={size} />;
   if (type === 'linkedin_connect') return <UserPlus className={size} />;
   if (type === 'linkedin_message') return <Send className={size} />;
   if (type === 'linkedin_visit') return <Eye className={size} />;

--- a/web/src/store/onboardingStore.ts
+++ b/web/src/store/onboardingStore.ts
@@ -180,7 +180,7 @@ export interface WorkflowPreviewStep {
   title: string;
   description?: string;
   icon?: string;
-  channel?: 'linkedin' | 'email' | 'whatsapp' | 'voice' | 'instagram';
+  channel?: 'linkedin' | 'email' | 'whatsapp' | 'voice' | 'instagram' | 'media' | 'system';
   // Additional fields for step configuration
   message?: string;
   subject?: string;
@@ -189,6 +189,14 @@ export interface WorkflowPreviewStep {
   delayDays?: number;
   delayHours?: number;
   leadLimit?: number; // Number of leads to generate per day
+  // AI Media step (media_generation) — set when the user accepts a generated
+  // asset in the StepEditor; consumed by downstream send steps at launch.
+  // Persisted workflowPreview may predate these fields — all optional.
+  mediaPrompt?: string;
+  mediaUrl?: string;      // permanent GCS URL (post import-generated)
+  mediaType?: string;     // 'image' | 'video' | 'document'
+  mediaFilename?: string; // real extension — MIME normalization depends on it
+  mimeType?: string;
 }
 export interface AIMessage {
   role: 'ai' | 'user';

--- a/web/src/types/campaign.ts
+++ b/web/src/types/campaign.ts
@@ -19,9 +19,10 @@ export type StepType =
   | 'instagram_comment_reply'
   | 'instagram_story_view'
   | 'lead_generation'
-  | 'delay' 
-  | 'condition' 
-  | 'start' 
+  | 'media_generation'
+  | 'delay'
+  | 'condition'
+  | 'start'
   | 'end';
 export type ConditionType = 
   | 'connected'           // LinkedIn: if connected


### PR DESCRIPTION
Frontend half of the **AI Media campaign step** (see `MEDIA_GENERATION_CAMPAIGN_STEP_PLAN.md`, Phase 2). Pairs with **LAD-Backend #379** — merge that first (this UI calls its `POST /api/campaigns/media/import-generated`).

## What it does
A new **AI Media** node in the campaign Workflow Builder: generate brand-grounded images/videos in the existing MediaBuilder wizard (VOAG playground / MAGe), attach the accepted asset to the node, and at launch the asset is stamped onto every downstream LinkedIn-message / WhatsApp / Email send step.

## The 7 registrations (the silent-drop trap)
`configStepsSync.buildStepsFromConfig` rebuilds the steps array from the guided toggles — any unmodeled type is dropped on the next toggle. This PR adds a `PRESERVED_TYPES` pass-through (re-inserted at original index) so the node survives, plus the other 6 registries: StepType union, store fields, Add-Step picker, node visuals (×2 registries + pills), StepEditor panel, launch payload + `checkpoint_selections` + edit-mode hydration.

## StepEditor media panel
- **Open AI Media Studio** → full `MediaGenerationModal`/`MediaBuilder` wizard (unchanged reuse)
- **Pick from generated media** → tenant gallery via `useMediaBuilder.fetchGallery`
- Paste-URL fallback → all paths call `import-generated` (permanence bridge: generated assets sit behind **7-day signed URLs**; campaigns run longer) → inline preview on the node

## Verification
- 10/10 deterministic preservation tests (survives reconciles, no duplication, delete stays deleted, prior round-trip identities intact)
- `tsc`: **zero new errors** vs develop baseline (verified by signature diff)
- `next build` green (Node 20)

## QA (needs an authed session)
1. Workflow tab → Add Step → AI Media → Generate Media; node appears (fuchsia, wand icon)
2. Click node → generate/pick asset → preview shows → Save
3. Toggle channels in the guided config → node must persist
4. Launch → campaign steps include `media_generation` + sends carry `config.media_url`
5. Edit Workflow on the saved campaign → node restored with its asset

Requires a reachable media-builder worker (`NEXT_PUBLIC` worker URL / `PLAYGROUND_MODE=true`) for generation; attach-by-URL works regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)