### PR TITLE
feat(advanced-search): credit-gate campaign launch + auto-unlock results

### DIFF
--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -1626,6 +1626,16 @@ export default function AdvancedSearchAIPage() {
         }
     }, [billing.wallet, billing.error]);
 
+    // Auto-unlock search results when the tenant has any credit balance. Unlocking is a
+    // pure client-side flag flip (locked = CSS blur only — no data withheld, no charge).
+    // The leads.some(locked) guard prevents re-render loops and also covers late-arriving
+    // "Get More Leads" pages, which are constructed with locked: idx >= 5.
+    useEffect(() => {
+        if (creditBalance !== null && creditBalance >= 1 && leads.some(l => l.locked)) {
+            setLeads(prev => prev.map(l => ({ ...l, locked: false })));
+        }
+    }, [creditBalance, leads]);
+
     // Sync voice agent hook data → cpVoiceAgents/cpVoiceNumbers state
     // so CheckpointFormInline receives them as pre-populated props
     useEffect(() => {
@@ -4988,6 +4998,8 @@ export default function AdvancedSearchAIPage() {
                                     leads={leads}
                                     leadFeedback={leadFeedback}
                                     selectedLeadIds={selectedLeadIds}
+                                    creditBalance={creditBalance}
+                                    onOpenRecharge={() => setShowRechargeModal(true)}
                                     searchSessions={searchSessions}
                                     chatMessages={messages}
                                     pendingContact={pendingContact}
@@ -7468,7 +7480,7 @@ function CheckpointFormInline({
     step, setStep, icpThreshold, setIcpThreshold, actions, setActions, connMsg, setConnMsg, followMsg, setFollowMsg,
     nextChannels, setNextChannels, triggerCondition, setTriggerCondition,
     days, setDays, channelConfigStep, setChannelConfigStep, channelDelays, setChannelDelays, name, setName, genLoading, setGenLoading, launching, setLaunching, targeting, leads,
-    leadFeedback, selectedLeadIds, searchSessions, chatMessages,
+    leadFeedback, selectedLeadIds, creditBalance, onOpenRecharge, searchSessions, chatMessages,
     voiceAgents, setVoiceAgents, voiceNumbers, setVoiceNumbers,
     selectedAgentId, setSelectedAgentId, selectedVoiceId, setSelectedVoiceId,
     selectedFromNumber, setSelectedFromNumber,
@@ -7506,6 +7518,8 @@ function CheckpointFormInline({
     leads: LeadProfile[];
     leadFeedback: Record<string, 'good' | 'bad'>;
     selectedLeadIds: Set<string>;
+    creditBalance: number | null;
+    onOpenRecharge: () => void;
     searchSessions: { query: string; targeting: LeadTargeting | null; icp_description: string; timestamp: string }[];
     chatMessages: ChatMsg[];
     voiceAgents: any[]; setVoiceAgents: (v: any[]) => void;
@@ -7884,6 +7898,13 @@ function CheckpointFormInline({
     const LINKEDIN_DAILY_LIMIT = 40; // safe daily connection request limit
     const LINKEDIN_WEEKLY_LIMIT = 190; // safe weekly limit
 
+    // Minimum credit ESTIMATE per enrolled lead, matching the default personalized-connect
+    // flow (featureCreditConfig: personalized connect = 5 flat). Real billing is PER-ACTION
+    // at execution time — launch itself charges 0; connect=1, personalized connect=5,
+    // template msg=5, enrichment=2, phone=10 — so this gate is a deliberate minimum
+    // estimate, NOT the actual charge.
+    const CREDIT_COST_PER_LEAD = 5;
+
     // Compute qualified leads count based on ICP threshold
     const qualifiedLeadCount = leads.filter(l => (l.icp_score ?? 0) >= (parseInt(icpThreshold) || 0)).length;
 
@@ -7901,6 +7922,14 @@ function CheckpointFormInline({
     // across the campaign duration and made subsequent scheduled runs fetch only 1 lead/day.)
     const safeLeadsPerDay = Math.min(LINKEDIN_DAILY_LIMIT, Math.max(1, qualifiedLeadCount));
     const exceedsLinkedInLimits = qualifiedLeadCount > LINKEDIN_DAILY_LIMIT;
+
+    // Credit gate for launch. Enrolled = CHECKED leads minus thumbs-down — mirrors
+    // launchCampaign's goodMatchLeads filter, not raw selectedLeadIds.size.
+    // creditBalance === null (billing fetch failed) fails OPEN — never block launch
+    // on a billing-fetch error.
+    const enrolledCount = leads.filter(l => selectedLeadIds.has(l.id)).filter(l => leadFeedback[l.id] !== 'bad').length;
+    const requiredCredits = enrolledCount * CREDIT_COST_PER_LEAD;
+    const creditsOk = creditBalance == null || creditBalance >= requiredCredits;
 
     const toggleAction = (a: string) => {
         const newActions = actions.includes(a) ? actions.filter(x => x !== a) : [...actions, a];
@@ -9561,6 +9590,28 @@ function CheckpointFormInline({
                                     transition: 'all 0.15s',
                                 }}>✨ Suggest</button>
                             </div>
+                            {!creditsOk && (
+                                <div style={{
+                                    padding: '10px 14px', borderRadius: '10px', fontSize: '12px', lineHeight: 1.5,
+                                    background: '#fef3c7', border: '1px solid #f59e0b', color: '#92400e',
+                                    display: 'flex', flexDirection: 'column', gap: '8px', alignItems: 'flex-start',
+                                }}>
+                                    <div>
+                                        <strong>Not enough credits:</strong> You need {requiredCredits} credits to launch this
+                                        campaign ({enrolledCount} leads × {CREDIT_COST_PER_LEAD}). You have {creditBalance}.
+                                    </div>
+                                    <button onClick={onOpenRecharge} style={{
+                                        padding: '6px 14px', borderRadius: '8px', border: 'none',
+                                        background: '#0b1957', color: '#fff', fontSize: '12px', fontWeight: 700,
+                                        cursor: 'pointer', transition: 'all 0.15s',
+                                    }}>Add credits</button>
+                                </div>
+                            )}
+                            {creditsOk && creditBalance !== null && enrolledCount > 0 && (
+                                <div style={{ fontSize: '12px', color: '#9ca3af' }}>
+                                    ≈{requiredCredits} credits will be used as this campaign runs
+                                </div>
+                            )}
                         </div>
                     )}
                 </div>
@@ -9602,13 +9653,13 @@ function CheckpointFormInline({
                                     </button>
                                 ) : (
                                     <button
-                                        disabled={!canNext() || launching}
+                                        disabled={!canNext() || launching || !creditsOk}
                                         onClick={launchCampaign}
                                         style={{
                                             padding: '8px 20px', borderRadius: '10px', border: 'none',
-                                            background: canNext() && !launching ? '#10b981' : '#e5e7eb',
-                                            color: canNext() && !launching ? '#fff' : '#9ca3af',
-                                            fontSize: '13px', fontWeight: 700, cursor: canNext() && !launching ? 'pointer' : 'default',
+                                            background: canNext() && !launching && creditsOk ? '#10b981' : '#e5e7eb',
+                                            color: canNext() && !launching && creditsOk ? '#fff' : '#9ca3af',
+                                            fontSize: '13px', fontWeight: 700, cursor: canNext() && !launching && creditsOk ? 'pointer' : 'default',
                                             display: 'flex', alignItems: 'center', gap: '6px', transition: 'all 0.15s',
                                         }}
                                     >


### PR DESCRIPTION
## What

Adds credit-gating to the advanced-search-ai campaign builder (`web/src/app/onboarding/advanced-search-ai/page.tsx`, single file). Three behaviors:

### A. Auto-unlock search results when balance ≥ 1
A new `useEffect` (right after the existing credit-sync effect) flips `locked: false` on all leads whenever `creditBalance >= 1` and any lead is locked. Unlock is a pure client-side flag flip — `locked` is CSS blur only, no data withheld, no API call, no credit deduction — so this is free. The `leads.some(l => l.locked)` guard prevents render loops and also auto-unlocks late-arriving "Get More Leads" pages (constructed with `locked: idx >= 5`). The manual "Unlock Results" button is untouched: with balance ≥ 1 it self-hides (nothing locked); with balance ≤ 0 it keeps opening the recharge modal as before.

### B. Launch button credit gate
`CheckpointFormInline` now receives `creditBalance` and `onOpenRecharge` props. Beside the existing derived values:

- `enrolledCount` = **checked leads minus thumbs-down** — mirrors `launchCampaign`'s own `goodMatchLeads` filter, not raw `selectedLeadIds.size`
- `requiredCredits = enrolledCount × 5`
- `creditsOk = creditBalance == null || creditBalance >= requiredCredits`

"Launch Campaign" is disabled (and greyed via all three style ternaries) when `!creditsOk`.

**Why ×5:** real billing is PER-ACTION at execution time (launch itself charges 0; connect=1, personalized connect=5 flat, template msg=5, enrichment=2, phone=10). The ×5 gate is a deliberate **minimum estimate** matching the default personalized-connect flow — documented in a code comment so nobody mistakes it for the actual charge.

**Fail-open on null balance:** if the billing fetch fails (`creditBalance === null`), the gate passes — a billing-fetch error must never block launch.

### C. On-screen notice + "Add credits"
On the campaign-name step (the launch step), when `!creditsOk`, an amber notice (same styling as the page's LinkedIn safe-limit warning) shows: *"You need {requiredCredits} credits to launch this campaign ({enrolledCount} leads × 5). You have {creditBalance}."* with an **Add credits** button that opens the page's existing credits-plan modal (`showRechargeModal`) in place — no navigation; the modal's own plan buttons already route to `/settings?tab=credits&action=add` (Stripe-backed Add Credits). When the gate passes and balance is known, a subtle one-liner shows the ≈ estimate instead.

## Verification

- `npm run build --workspace=web` passes (Node 20).
- `tsc --noEmit` error set for this file is **byte-identical** before/after the change (known pre-existing baseline; zero new errors).
- No test harness exists for `web/` pages (repo has no FE test files), so manual steps:
  1. Balance ≥ 1 → previously-blurred leads (beyond first 5) auto-unlock, including after "Get More Leads".
  2. Balance < enrolled × 5 → Launch disabled + amber notice on the name step; "Add credits" opens the plan modal in place.
  3. Balance ≥ enrolled × 5 → Launch enabled, subtle "≈N credits will be used" line shows.
  4. Billing fetch failure (null balance) → launch not blocked.
  5. Unchecking leads / thumbs-down reduces the required amount live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)