### PR TITLE
fix(community-roi): always show 1-2-1 Verification Claims panel

### DIFF
--- a/web/src/features/community-roi/components/VerificationClaimsPanel.tsx
+++ b/web/src/features/community-roi/components/VerificationClaimsPanel.tsx
@@ -14,8 +14,9 @@
  *   POST /api/community-roi/1to1-claims/:id/approve
  *   POST /api/community-roi/1to1-claims/:id/reject
  *
- * Self-hides until the first claim exists, so tenants not using verification never
- * see an empty panel.
+ * Always rendered (like an inbox): shows the status tabs and a "no claims" empty
+ * state even at zero, so admins can discover the queue and see it fill up as
+ * members reply to the verification message.
  */
 'use client';
 
@@ -63,7 +64,6 @@ export function VerificationClaimsPanel() {
   const [error, setError] = useState<string | null>(null);
   const [acting, setActing] = useState<Record<string, boolean>>({});
   const [note, setNote] = useState<string | null>(null);
-  const [loadedOnce, setLoadedOnce] = useState(false);
 
   const fetchData = (status: StatusFilter) => {
     setLoading(true);
@@ -78,7 +78,6 @@ export function VerificationClaimsPanel() {
       .catch((e) => setError(e?.message || 'Failed to load claims'))
       .finally(() => {
         setLoading(false);
-        setLoadedOnce(true);
       });
   };
 
@@ -121,11 +120,6 @@ export function VerificationClaimsPanel() {
       setActing((s) => ({ ...s, [claim.id]: false }));
     }
   };
-
-  const total = (counts.pending || 0) + (counts.approved || 0) + (counts.rejected || 0);
-
-  // Self-hide until at least one claim exists in any status.
-  if (loadedOnce && total === 0 && !loading && !error) return null;
 
   return (
     <Card className="rounded-[1.5rem] border-slate-100 shadow-sm">


### PR DESCRIPTION
## Why
The panel self-hid at zero claims. Once the backend "Failed to list claims" race was fixed, the panel returned success with 0 claims → **disappeared entirely** from `/community-roi`, so there was no way to discover the review queue or confirm it works until a claim happened to land.

## Change
Render it **unconditionally**, like an inbox — the Pending/Approved/Rejected tabs and a "no claims" empty state show even at zero, and the queue fills in as members reply to the verification message. Removes the self-hide guard and the now-unused `loadedOnce` / `total`.

## Notes
- Follow-up to #655 (merged).
- `tsc --noEmit`: 0 errors in the changed file.
- Deploy: this needs the FE redeployed to wherever `web.mrlads.com` serves from for the panel to reappear there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)