### PR TITLE
feat(advanced-search): smarter Suggest campaign name (title + industry + location)

### DIFF
--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -8055,11 +8055,34 @@ function CheckpointFormInline({
     };
 
     const suggestName = () => {
-        const titlePart = targeting?.job_titles?.length ? targeting.job_titles[0] + 's' : 'Leads';
-        const locPart = targeting?.locations?.length ? ` in ${targeting.locations[0].split(',')[0]}` : '';
-        const indPart = targeting?.industries?.length && !locPart ? ` (${targeting.industries[0]})` : '';
+        const t = targeting;
         const datePart = new Date().toLocaleDateString('en-US', { month: 'short', year: 'numeric' });
-        setName(`${titlePart}${locPart}${indPart} - ${datePart}`);
+        // Simple pluralize: append "s" unless the word already ends in one.
+        const pluralize = (s: string) => (s.endsWith('s') ? s : `${s}s`);
+        // " +N" suffix when the targeting has more than one value for a facet.
+        const more = (arr?: string[]) => (arr && arr.length > 1 ? ` +${arr.length - 1}` : '');
+
+        // Title/role: first job title (pluralized), else first keyword, else "Leads".
+        let titlePart = 'Leads';
+        if (t?.job_titles?.length) {
+            titlePart = pluralize(t.job_titles[0].trim()) + more(t.job_titles);
+        } else if (t?.keywords?.length) {
+            titlePart = t.keywords[0].trim();
+        }
+
+        // Industry: always included when present (previously dropped whenever a location existed).
+        const indPart = t?.industries?.length
+            ? ` — ${t.industries[0].trim()}${more(t.industries)}`
+            : '';
+
+        // Location: city (part before the comma) of the first location.
+        const locPart = t?.locations?.length
+            ? ` in ${t.locations[0].split(',')[0].trim()}${more(t.locations)}`
+            : '';
+
+        // title + industry + location is the headline; date is a subtle suffix for uniqueness.
+        const composed = `${titlePart}${indPart}${locPart} · ${datePart}`.replace(/\s{2,}/g, ' ').trim();
+        setName(composed || `Leads · ${datePart}`);
     };
 
     // AI-generate a LinkedIn message for the given type


### PR DESCRIPTION
## What

Improves the **✨ Suggest** campaign-name generator in the advanced-search-ai builder (`web/src/app/onboarding/advanced-search-ai/page.tsx`, `suggestName`) so the suggested name is relatable to the campaign's actual targeting — **title + industry + location** — instead of dropping the industry.

Pure client-side, synchronous function — **no LLM, no endpoint**. Stays instant and free.

## The bug it fixes

The old implementation gated the industry behind `&& !locPart`:

```js
const indPart = targeting?.industries?.length && !locPart ? ` (${targeting.industries[0]})` : '';
```

So the **industry was included only when there was no location** — i.e. dropped for the normal title+industry+location case. It also only ever used the *first* title/industry/location.

Example: Property Manager / Real Estate / Dubai →
- **Before:** `Property Managers in Dubai - Jul 2026` ← industry missing
- **After:** `Property Managers — Real Estate in Dubai · Jul 2026`

## New behavior

- **Title/role** — first job title, pluralized (append `s` unless it already ends in `s`); `+N` when there are more titles. Falls back to the first `keywords` entry, then `Leads`.
- **Industry** — ` — {industry}` whenever present (with `+N` if multiple). **Included regardless of location** (the fix).
- **Location** — ` in {city}` (part before the comma) of the first location, `+N` if multiple.
- **Date** — subtle ` · {Mon YYYY}` suffix for uniqueness; title+industry+location is the headline.
- Trims, collapses double spaces, and falls back to `Leads · {Mon YYYY}` when nothing is targeted.

## Manual verification (no test harness for this page)

Logic verified against a standalone reproduction of the function:

| Targeting | Output |
|---|---|
| Property Manager / Real Estate / Dubai, UAE | `Property Managers — Real Estate in Dubai · Jul 2026` |
| Property Manager / — / Dubai (no industry) | `Property Managers in Dubai · Jul 2026` |
| Marketing Manager +1 / Banking / Riyadh, Saudi Arabia | `Marketing Managers +1 — Banking in Riyadh · Jul 2026` |
| Property Manager / Real Estate +2 / Dubai +1 | `Property Managers — Real Estate +2 in Dubai +1 · Jul 2026` |
| no titles, keyword "founders" / Real Estate / Dubai | `founders — Real Estate in Dubai · Jul 2026` |
| nothing targeted | `Leads · Jul 2026` |

## Build

`npm run build --workspace=web` → **✓ Compiled successfully**, static pages generated (122/122), exit 0 (Node 20).

Scoped `tsc --noEmit` confirms the change adds **no new type errors** — the target file's pre-existing errors are all outside `suggestName` (the repo has a known ~363-error tsc baseline and `ignoreBuildErrors: true`).

## Scope

FE only — this one function plus two tiny inline helpers (`pluralize`, `more`). No changes to the credit-estimate line, launch handler, or anything else.
