### PR TITLE
fix(lint): clear 4 blocking ESLint errors failing CI on develop

### DIFF
--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -7,7 +7,7 @@ import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import { useSelector } from 'react-redux';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRouter } from 'next/navigation';
-import { Sparkles, Gem, Upload, FileSpreadsheet, Download, CheckCircle2, Pencil, Trash2, ChevronDown, ChevronLeft, ChevronRight, X, MessageSquare, Users, Zap, Plus, Image as ImageIcon, Video, Loader2, Mic, Globe, Newspaper, UserPlus, Check, History } from 'lucide-react';
+import { Sparkles, Gem, Upload, FileSpreadsheet, Download, CheckCircle2, Pencil, Trash2, ChevronDown, ChevronLeft, ChevronRight, X, MessageSquare, Users, Zap, Plus, Image as ImageIcon, Video, Loader2, Mic, Globe, Newspaper, UserPlus, Check, History, Volume2, ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { ProfileSummaryDialog } from '@/components/campaigns';
 import AgentVisualizer from '@/components/ui/AgentVisualizer';
@@ -2518,7 +2518,7 @@ export default function AdvancedSearchAIPage() {
         if (!mediaMode || !mediaInputWrapRef.current) return;
 
         const observer = new ResizeObserver((entries) => {
-            for (let entry of entries) {
+            for (const entry of entries) {
                 setMediaInputWrapHeight(entry.target.clientHeight);
             }
         });

--- a/web/src/hooks/useConnectedChannels.ts
+++ b/web/src/hooks/useConnectedChannels.ts
@@ -129,6 +129,7 @@ export function useConnectedChannels() {
       const next = { waba, personal_whatsapp: personal, linkedin, gmail, instagram, voice };
       // Visible in devtools so "why is this tab shown/hidden?" is answerable.
       // 'unknown' = probe failed transiently → treated as visible (fail-open).
+      // eslint-disable-next-line no-console -- intentional diagnostic (see comment above)
       console.debug('[useConnectedChannels] statuses', next);
       setStatuses(next);
       setLoaded(true);


### PR DESCRIPTION
## Why
The `ci / lint (Next.js web)` check runs `npm run lint` (eslint over the whole `web/` project) and has been **red on every PR targeting `develop`** due to 4 pre-existing errors. This unblocks all of them at once (e.g. #574, #581, #582, #586).

## The 4 errors fixed
| File | Error | Rule | Fix |
|---|---|---|---|
| `advanced-search-ai/page.tsx:2363` | `'Volume2' is not defined` | react/jsx-no-undef | added to lucide-react import |
| `advanced-search-ai/page.tsx:2374` | `'ArrowLeft' is not defined` | react/jsx-no-undef | added to lucide-react import |
| `advanced-search-ai/page.tsx:2521` | `'entry'` never reassigned | prefer-const | `let` → `const` |
| `useConnectedChannels.ts:132` | `console.debug` | no-console | kept intentional diagnostic with `eslint-disable-next-line` |

The two missing icon imports were also a **real runtime bug** — `Volume2`/`ArrowLeft` are rendered in the media-generation UI but were never imported, so that path would throw `ReferenceError`.

## Verification
`eslint src` now exits **0** (0 errors; 2466 pre-existing warnings remain, which are non-blocking). No behavior change beyond the icons now rendering instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)