### PR TITLE
feat(templates): single-body LinkedIn template editor with Type dropdown

### DIFF
--- a/sdk/features/campaigns/index.ts
+++ b/sdk/features/campaigns/index.ts
@@ -96,10 +96,13 @@ export {
   type TemplateFilters as LinkedInTemplateFilters,
   type PersonalizedTemplate as PersonalizedLinkedInTemplate,
   type TemplateCategory as LinkedInTemplateCategory,
+  type TemplateType as LinkedInTemplateType,
   type TemplateMedia as LinkedInTemplateMedia,
   type TemplateMediaType as LinkedInTemplateMediaType,
   type TemplateMediaUploadResult as LinkedInTemplateMediaUploadResult,
   TEMPLATE_CATEGORIES as LINKEDIN_TEMPLATE_CATEGORIES,
+  TEMPLATE_TYPES as LINKEDIN_TEMPLATE_TYPES,
+  templateTypeLabel as linkedinTemplateTypeLabel,
   MESSAGE_VARIABLES as LINKEDIN_MESSAGE_VARIABLES,
   CONNECTION_MESSAGE_MAX_LENGTH as LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH,
   // Hooks

--- a/sdk/features/campaigns/linkedin-message-templates/index.ts
+++ b/sdk/features/campaigns/linkedin-message-templates/index.ts
@@ -12,6 +12,7 @@ export type {
   TemplateFilters,
   PersonalizedTemplate,
   TemplateCategory,
+  TemplateType,
   TemplateMedia,
   TemplateMediaType,
   TemplateMediaUploadResult,
@@ -19,6 +20,8 @@ export type {
 
 export {
   TEMPLATE_CATEGORIES,
+  TEMPLATE_TYPES,
+  templateTypeLabel,
   MESSAGE_VARIABLES,
   CONNECTION_MESSAGE_MAX_LENGTH,
 } from './types';

--- a/sdk/features/campaigns/linkedin-message-templates/types.ts
+++ b/sdk/features/campaigns/linkedin-message-templates/types.ts
@@ -10,8 +10,13 @@ export interface LinkedInMessageTemplate {
   tenant_id: string;
   name: string;
   description: string | null;
+  /** Single message body (canonical). */
+  content?: string | null;
+  /** Alias of `content` (kept for back-compat with older consumers). */
+  message?: string | null;
   connection_message: string | null;
   followup_message: string | null;
+  /** Template type: 'linkedin_connection' | 'linkedin_followup'. */
   category: string | null;
   tags: string[] | null;
   is_default: boolean;
@@ -58,9 +63,14 @@ export interface TemplateMediaUploadResult {
 export interface CreateTemplateRequest {
   name: string;
   description?: string;
-  connection_message?: string;
-  followup_message?: string;
+  /** Single message body (canonical). */
+  content?: string;
+  /** Template type. Defaults to 'linkedin_connection' server-side. */
   category?: string;
+  /** @deprecated use `content` — still accepted server-side as the body. */
+  connection_message?: string;
+  /** @deprecated use `content` — still accepted server-side as the body. */
+  followup_message?: string;
   tags?: string[];
   is_default?: boolean;
   is_active?: boolean;
@@ -76,9 +86,14 @@ export interface CreateTemplateRequest {
 export interface UpdateTemplateRequest {
   name?: string;
   description?: string;
-  connection_message?: string;
-  followup_message?: string;
+  /** Single message body (canonical). */
+  content?: string;
+  /** Template type. */
   category?: string;
+  /** @deprecated use `content` — still accepted server-side as the body. */
+  connection_message?: string;
+  /** @deprecated use `content` — still accepted server-side as the body. */
+  followup_message?: string;
   tags?: string[];
   is_default?: boolean;
   is_active?: boolean;
@@ -116,6 +131,24 @@ export const TEMPLATE_CATEGORIES = [
 ] as const;
 
 export type TemplateCategory = typeof TEMPLATE_CATEGORIES[number];
+
+/**
+ * Template type (what the single body is used for). The connection request note
+ * is text-only and 300-char capped; the follow-up message allows media and any
+ * length.
+ */
+export const TEMPLATE_TYPES = [
+  { value: 'linkedin_connection', label: 'Connection request' },
+  { value: 'linkedin_followup', label: 'Follow-up message' },
+] as const;
+
+export type TemplateType = typeof TEMPLATE_TYPES[number]['value'];
+
+/** Friendly label for a template's type (`category`). */
+export function templateTypeLabel(category?: string | null): string {
+  const match = TEMPLATE_TYPES.find((t) => t.value === category);
+  return match ? match.label : (category || '');
+}
 
 /**
  * Variable placeholders for personalization

--- a/web/src/app/conversations/templates/page.tsx
+++ b/web/src/app/conversations/templates/page.tsx
@@ -14,6 +14,7 @@ import {
   useDeleteLinkedInMessageTemplate,
   useInstagramMessageTemplates,
   useDeleteInstagramMessageTemplate,
+  linkedinTemplateTypeLabel,
 } from '@lad/frontend-features/campaigns';
 import type {
   LinkedInMessageTemplate,
@@ -641,9 +642,9 @@ export default function TemplatesPage() {
                     gradient="bg-gradient-to-r from-[#0A66C2] via-[#0e76d6] to-[#378fe9]"
                     icon={<Linkedin className="w-3.5 h-3.5 text-white/80" />}
                     name={t.name}
-                    preview={t.connection_message || t.followup_message || t.description || ''}
+                    preview={t.content || t.connection_message || t.followup_message || t.description || ''}
                     isDefault={t.is_default}
-                    footerRight={t.category ? <span className="capitalize">{t.category}</span> : null}
+                    footerRight={t.category ? <span>{linkedinTemplateTypeLabel(t.category)}</span> : null}
                     onEdit={() => { setLiEditing(t); setLiModalOpen(true); }}
                     onDelete={() => handleDeleteLi(t)}
                   />

--- a/web/src/components/campaigns/linkedin-templates/TemplateManagerModal.tsx
+++ b/web/src/components/campaigns/linkedin-templates/TemplateManagerModal.tsx
@@ -17,6 +17,7 @@ import {
   useLinkedInMessageTemplates,
   useUpdateLinkedInMessageTemplate,
   useDeleteLinkedInMessageTemplate,
+  linkedinTemplateTypeLabel,
 } from '@lad/frontend-features/campaigns';
 import {
   Settings2,
@@ -127,7 +128,7 @@ export default function TemplateManagerModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+    <Dialog open={open} onOpenChange={(isOpen: boolean) => !isOpen && onClose()}>
       <DialogContent className="max-h-[80vh]">
         <DialogHeader>
           <div className="flex items-center gap-3">
@@ -184,7 +185,7 @@ export default function TemplateManagerModal({
                       )}
                       {template.category && (
                         <Badge variant="outline" className="text-[10px] font-bold text-gray-500 border-gray-200">
-                          {template.category}
+                          {linkedinTemplateTypeLabel(template.category)}
                         </Badge>
                       )}
                       {!template.is_active && (
@@ -256,28 +257,25 @@ export default function TemplateManagerModal({
                   </div>
                 </div>
 
-                {/* Expandable Messages Preview */}
+                {/* Expandable Message Preview (single body) */}
                 {expandedId === template.id && (
                   <div className="space-y-2 pt-2 border-t border-gray-50">
-                    {template.connection_message && (
+                    {(template.content ?? template.connection_message ?? template.followup_message) ? (
                       <div className="space-y-1">
                         <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">
-                          Connection Message ({template.connection_message.length}/300)
+                          Message{template.category === 'linkedin_connection'
+                            ? ` (${(template.content ?? template.connection_message ?? '').length}/300)`
+                            : ''}
                         </p>
-                        <p className="text-xs text-gray-700 bg-gray-50/50 p-3 rounded-xl border border-gray-100">
-                          {template.connection_message}
+                        <p className="text-xs text-gray-700 bg-gray-50/50 p-3 rounded-xl border border-gray-100 whitespace-pre-wrap">
+                          {template.content ?? template.connection_message ?? template.followup_message}
                         </p>
                       </div>
+                    ) : (
+                      <p className="text-xs text-gray-400 italic">No message text</p>
                     )}
-                    {template.followup_message && (
-                      <div className="space-y-1">
-                        <p className="text-[10px] font-bold text-gray-400 uppercase tracking-widest">
-                          Followup Message
-                        </p>
-                        <p className="text-xs text-gray-700 bg-gray-50/50 p-3 rounded-xl border border-gray-100">
-                          {template.followup_message}
-                        </p>
-                      </div>
+                    {(template.metadata as any)?.media_url && (
+                      <p className="text-[10px] font-medium text-gray-400">📎 Attachment included</p>
                     )}
                   </div>
                 )}

--- a/web/src/components/campaigns/linkedin-templates/TemplateSaveModal.tsx
+++ b/web/src/components/campaigns/linkedin-templates/TemplateSaveModal.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -15,9 +15,15 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/ui/app-toaster';
-import { useCreateLinkedInMessageTemplate } from '@lad/frontend-features/campaigns';
+import {
+  useCreateLinkedInMessageTemplate,
+  LINKEDIN_TEMPLATE_TYPES,
+  LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH,
+} from '@lad/frontend-features/campaigns';
 import { Loader2, Save, AlertCircle } from 'lucide-react';
 import type { CreateLinkedInTemplateRequest } from '@lad/frontend-features/campaigns';
+
+const CONNECTION_TYPE = 'linkedin_connection';
 
 interface TemplateSaveModalProps {
   open: boolean;
@@ -40,43 +46,58 @@ export default function TemplateSaveModal({
   const [formData, setFormData] = useState({
     name: '',
     description: '',
-    category: 'sales' as const,
+    templateType: CONNECTION_TYPE as string,
     is_default: false,
   });
 
   const [errors, setErrors] = useState<Record<string, string>>({});
 
+  const isConnection = formData.templateType === CONNECTION_TYPE;
+  // The single body saved is the composed message that matches the chosen type.
+  const body = isConnection ? connectionMessage : followupMessage;
+
+  // Preselect the type based on which message the builder actually has.
+  useEffect(() => {
+    if (!open) return;
+    const preferred = connectionMessage.trim()
+      ? CONNECTION_TYPE
+      : followupMessage.trim()
+        ? 'linkedin_followup'
+        : CONNECTION_TYPE;
+    setFormData((f) => ({ ...f, templateType: preferred }));
+  }, [open, connectionMessage, followupMessage]);
+
+  const reset = () => {
+    setFormData({ name: '', description: '', templateType: CONNECTION_TYPE, is_default: false });
+    setErrors({});
+  };
+
   const validateForm = (): boolean => {
     const newErrors: Record<string, string> = {};
-
     if (!formData.name.trim()) {
       newErrors.name = 'Template name is required';
     }
-
-    if (!connectionMessage.trim() && !followupMessage.trim()) {
-      newErrors.messages = 'At least one message (connection or followup) must be provided';
+    if (!body.trim()) {
+      newErrors.messages = isConnection
+        ? 'A connection request message is required'
+        : 'A follow-up message is required';
     }
-
-    if (connectionMessage.length > 300) {
-      newErrors.connection = 'Connection message must be 300 characters or less';
+    if (isConnection && body.length > LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH) {
+      newErrors.connection = `Connection request message must be ${LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH} characters or less`;
     }
-
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
   };
 
   const handleSave = async () => {
-    if (!validateForm()) {
-      return;
-    }
+    if (!validateForm()) return;
 
     try {
       const request: CreateLinkedInTemplateRequest = {
         name: formData.name.trim(),
         description: formData.description.trim() || undefined,
-        connection_message: connectionMessage.trim() || undefined,
-        followup_message: followupMessage.trim() || undefined,
-        category: formData.category,
+        category: formData.templateType,
+        content: body.trim() || undefined,
         is_default: formData.is_default,
         is_active: true,
       };
@@ -93,14 +114,7 @@ export default function TemplateSaveModal({
         onTemplateSaved(result.id);
       }
 
-      // Reset form
-      setFormData({
-        name: '',
-        description: '',
-        category: 'sales',
-        is_default: false,
-      });
-      setErrors({});
+      reset();
       onClose();
     } catch (error: any) {
       push({
@@ -112,18 +126,12 @@ export default function TemplateSaveModal({
   };
 
   const handleClose = () => {
-    setFormData({
-      name: '',
-      description: '',
-      category: 'sales',
-      is_default: false,
-    });
-    setErrors({});
+    reset();
     onClose();
   };
 
   return (
-    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
+    <Dialog open={open} onOpenChange={(isOpen: boolean) => !isOpen && handleClose()}>
       <DialogContent className="">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
@@ -131,7 +139,7 @@ export default function TemplateSaveModal({
             Save as Template
           </DialogTitle>
           <DialogDescription>
-            Save your LinkedIn messages as a reusable template
+            Save this LinkedIn message as a reusable template
           </DialogDescription>
         </DialogHeader>
 
@@ -168,46 +176,37 @@ export default function TemplateSaveModal({
             />
           </div>
 
-          {/* Category */}
+          {/* Template type */}
           <div className="space-y-2">
-            <Label htmlFor="template-category">Category</Label>
+            <Label htmlFor="template-type">Use this template for</Label>
             <select
-              id="template-category"
-              value={formData.category}
-              onChange={(e) => setFormData({ ...formData, category: e.target.value as any })}
+              id="template-type"
+              value={formData.templateType}
+              onChange={(e) => setFormData({ ...formData, templateType: e.target.value })}
               className="w-full h-9 px-3 py-2 text-sm border border-input rounded-md bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              <option value="sales">Sales</option>
-              <option value="recruiting">Recruiting</option>
-              <option value="networking">Networking</option>
-              <option value="partnership">Partnership</option>
-              <option value="custom">Custom</option>
+              {LINKEDIN_TEMPLATE_TYPES.map((t) => (
+                <option key={t.value} value={t.value}>{t.label}</option>
+              ))}
             </select>
           </div>
 
-          {/* Preview Messages */}
+          {/* Preview */}
           <div className="space-y-2 p-3 bg-gray-50 rounded-md border">
             <Label className="text-xs font-semibold text-gray-700">Template Preview:</Label>
-
-            {connectionMessage && (
+            {body ? (
               <div className="space-y-1">
-                <p className="text-xs font-medium text-gray-600">Connection Message:</p>
-                <p className="text-xs text-gray-800 bg-white p-2 rounded border">
-                  {connectionMessage}
-                </p>
-                <p className="text-xs text-gray-500">
-                  {connectionMessage.length}/300 characters
-                </p>
+                <p className="text-xs text-gray-800 bg-white p-2 rounded border whitespace-pre-wrap">{body}</p>
+                {isConnection && (
+                  <p className="text-xs text-gray-500">
+                    {body.length}/{LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH} characters
+                  </p>
+                )}
               </div>
-            )}
-
-            {followupMessage && (
-              <div className="space-y-1 mt-2">
-                <p className="text-xs font-medium text-gray-600">Followup Message:</p>
-                <p className="text-xs text-gray-800 bg-white p-2 rounded border">
-                  {followupMessage}
-                </p>
-              </div>
+            ) : (
+              <p className="text-xs text-gray-500 italic">
+                No {isConnection ? 'connection request' : 'follow-up'} message to save yet.
+              </p>
             )}
 
             {errors.messages && (
@@ -237,7 +236,7 @@ export default function TemplateSaveModal({
             <Switch
               id="is-default"
               checked={formData.is_default}
-              onCheckedChange={(checked) => setFormData({ ...formData, is_default: checked })}
+              onCheckedChange={(checked: boolean) => setFormData({ ...formData, is_default: checked })}
             />
           </div>
         </div>

--- a/web/src/components/templates/CreateLinkedInTemplateModal.tsx
+++ b/web/src/components/templates/CreateLinkedInTemplateModal.tsx
@@ -20,16 +20,31 @@ import {
   useUpdateLinkedInMessageTemplate,
   uploadLinkedInTemplateMedia,
   LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH,
+  LINKEDIN_TEMPLATE_TYPES,
+  LINKEDIN_MESSAGE_VARIABLES,
 } from '@lad/frontend-features/campaigns';
 import type {
   LinkedInMessageTemplate,
   CreateLinkedInTemplateRequest,
   LinkedInTemplateMediaType,
 } from '@lad/frontend-features/campaigns';
-import { Loader2, Save, AlertCircle, Linkedin, Paperclip, X, FileText, Film, Music } from 'lucide-react';
+import { Loader2, Save, AlertCircle, Linkedin, Paperclip, X, FileText, Film, Music, Plus } from 'lucide-react';
 
 const MEDIA_ACCEPT =
   'image/*,video/*,audio/*,.pdf,.doc,.docx,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+
+// Personalization tokens offered by the variable picker (label → placeholder).
+const VARIABLE_OPTIONS: Array<{ label: string; token: string }> = [
+  { label: 'First name', token: LINKEDIN_MESSAGE_VARIABLES.FIRST_NAME },
+  { label: 'Last name', token: LINKEDIN_MESSAGE_VARIABLES.LAST_NAME },
+  { label: 'Full name', token: LINKEDIN_MESSAGE_VARIABLES.FULL_NAME },
+  { label: 'Company', token: LINKEDIN_MESSAGE_VARIABLES.COMPANY },
+  { label: 'Title', token: LINKEDIN_MESSAGE_VARIABLES.TITLE },
+  { label: 'Location', token: LINKEDIN_MESSAGE_VARIABLES.LOCATION },
+];
+
+const CONNECTION_TYPE = 'linkedin_connection';
+const FOLLOWUP_TYPE = 'linkedin_followup';
 
 interface CreateLinkedInTemplateModalProps {
   open: boolean;
@@ -45,8 +60,6 @@ interface CreateLinkedInTemplateModalProps {
   onCreated?: (tpl: LinkedInMessageTemplate) => void;
 }
 
-const CATEGORIES = ['sales', 'recruiting', 'networking', 'partnership', 'custom'] as const;
-
 export default function CreateLinkedInTemplateModal({
   open,
   onClose,
@@ -59,9 +72,9 @@ export default function CreateLinkedInTemplateModal({
 
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [connectionMessage, setConnectionMessage] = useState('');
-  const [followupMessage, setFollowupMessage] = useState('');
-  const [category, setCategory] = useState<string>('sales');
+  // A template is ONE body used for a chosen type (connection request | follow-up).
+  const [templateType, setTemplateType] = useState<string>(CONNECTION_TYPE);
+  const [body, setBody] = useState('');
   const [isDefault, setIsDefault] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
 
@@ -72,14 +85,16 @@ export default function CreateLinkedInTemplateModal({
   const [uploadingMedia, setUploadingMedia] = useState(false);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
+  const isConnection = templateType === CONNECTION_TYPE;
+
   // Hydrate form when opening (create = blank, edit = existing values)
   useEffect(() => {
     if (!open) return;
     setName(editing?.name ?? '');
     setDescription(editing?.description ?? '');
-    setConnectionMessage(editing?.connection_message ?? '');
-    setFollowupMessage(editing?.followup_message ?? '');
-    setCategory(editing?.category ?? 'sales');
+    setTemplateType(editing?.category === FOLLOWUP_TYPE ? FOLLOWUP_TYPE : CONNECTION_TYPE);
+    // Backend now returns the single `content`; fall back to the legacy aliases.
+    setBody(editing?.content ?? editing?.connection_message ?? editing?.followup_message ?? '');
     setIsDefault(editing?.is_default ?? false);
     const meta = (editing?.metadata ?? {}) as Record<string, any>;
     setMediaUrl(meta.media_url ?? null);
@@ -87,6 +102,27 @@ export default function CreateLinkedInTemplateModal({
     setMediaFilename(meta.media_filename ?? null);
     setErrors({});
   }, [open, editing]);
+
+  // Insert a personalization token at the cursor in the body textarea. The UI
+  // <Textarea> is a plain component (no ref forwarding), so reach the element by id.
+  const insertVariable = (token: string) => {
+    const el = typeof document !== 'undefined'
+      ? (document.getElementById('li-body') as HTMLTextAreaElement | null)
+      : null;
+    if (!el) {
+      setBody((b) => b + token);
+      return;
+    }
+    const start = el.selectionStart ?? body.length;
+    const end = el.selectionEnd ?? body.length;
+    const next = body.slice(0, start) + token + body.slice(end);
+    setBody(next);
+    requestAnimationFrame(() => {
+      el.focus();
+      const pos = start + token.length;
+      el.setSelectionRange(pos, pos);
+    });
+  };
 
   const handleMediaSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -122,17 +158,34 @@ export default function CreateLinkedInTemplateModal({
     setMediaFilename(null);
   };
 
+  // Connection requests are text-only on LinkedIn — drop any attachment when the
+  // user switches the type to connection.
+  const handleTypeChange = (value: string) => {
+    setTemplateType(value);
+    if (value === CONNECTION_TYPE) clearMedia();
+    setErrors((prev) => {
+      const next = { ...prev };
+      delete next.body;
+      delete next.connection;
+      delete next.media;
+      return next;
+    });
+  };
+
   const saving = createMutation.isPending || updateMutation.isPending;
 
   const validate = (): boolean => {
     const e: Record<string, string> = {};
     if (!name.trim()) e.name = 'Template name is required';
-    // A media-only template is valid — the attachment rides the follow-up DM.
-    if (!connectionMessage.trim() && !followupMessage.trim() && !mediaUrl) {
-      e.messages = 'Provide a connection message, a follow-up message, or an attachment';
+
+    const hasMedia = !isConnection && !!mediaUrl; // media only rides a follow-up
+    if (!body.trim() && !hasMedia) {
+      e.body = isConnection
+        ? 'A connection request message is required'
+        : 'Provide a message or an attachment';
     }
-    if (connectionMessage.length > LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH) {
-      e.connection = `Connection message must be ${LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH} characters or less`;
+    if (isConnection && body.length > LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH) {
+      e.body = `Connection request messages must be ${LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH} characters or less`;
     }
     setErrors(e);
     return Object.keys(e).length === 0;
@@ -140,19 +193,19 @@ export default function CreateLinkedInTemplateModal({
 
   const handleSave = async () => {
     if (!validate()) return;
+    const attachMedia = !isConnection && !!mediaUrl;
     const payload: CreateLinkedInTemplateRequest = {
       name: name.trim(),
       description: description.trim() || undefined,
-      connection_message: connectionMessage.trim() || undefined,
-      followup_message: followupMessage.trim() || undefined,
-      category,
+      category: templateType,
+      content: body.trim() || undefined,
       is_default: isDefault,
       is_active: true,
-      // Media (flat fields — backend folds them into metadata). On edit, an
-      // explicit null clears a previously-attached file.
-      media_url: mediaUrl ?? (editing ? null : undefined),
-      media_type: mediaUrl ? mediaType : null,
-      media_filename: mediaUrl ? mediaFilename : null,
+      // Media rides follow-up templates only. On edit, an explicit null clears a
+      // previously-attached file (and always clears it for a connection type).
+      media_url: attachMedia ? mediaUrl : (editing ? null : undefined),
+      media_type: attachMedia ? mediaType : null,
+      media_filename: attachMedia ? mediaFilename : null,
     };
 
     try {
@@ -178,7 +231,7 @@ export default function CreateLinkedInTemplateModal({
   };
 
   return (
-    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+    <Dialog open={open} onOpenChange={(isOpen: boolean) => !isOpen && onClose()}>
       <DialogContent className="max-h-[90vh] overflow-y-auto">
         <DialogHeader>
           <div className="flex items-center gap-3">
@@ -188,7 +241,7 @@ export default function CreateLinkedInTemplateModal({
             <div className="flex flex-col">
               <DialogTitle>{editing ? 'Edit LinkedIn Template' : 'New LinkedIn Template'}</DialogTitle>
               <DialogDescription>
-                Reusable connection request &amp; follow-up messages for LinkedIn outreach
+                A reusable message for a connection request or a follow-up
               </DialogDescription>
             </div>
           </div>
@@ -225,121 +278,125 @@ export default function CreateLinkedInTemplateModal({
             />
           </div>
 
-          {/* Connection message */}
+          {/* Template type (what the body is used for) */}
           <div className="space-y-1.5">
-            <div className="flex items-center justify-between">
-              <Label htmlFor="li-conn">Connection Message</Label>
-              <span className={`text-xs ${connectionMessage.length > LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH ? 'text-red-600' : 'text-muted-foreground'}`}>
-                {connectionMessage.length}/{LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH}
-              </span>
-            </div>
-            <Textarea
-              id="li-conn"
-              placeholder="Hi {{first_name}}, I came across your work at {{company}} and would love to connect."
-              value={connectionMessage}
-              onChange={(e) => setConnectionMessage(e.target.value)}
-              rows={3}
-              className={`resize-none text-sm ${errors.connection ? 'border-red-500' : ''}`}
-            />
-            {errors.connection && (
-              <p className="text-xs text-red-600 flex items-center gap-1">
-                <AlertCircle className="h-3 w-3" /> {errors.connection}
-              </p>
-            )}
-          </div>
-
-          {/* Follow-up message */}
-          <div className="space-y-1.5">
-            <Label htmlFor="li-followup">Follow-up Message</Label>
-            <Textarea
-              id="li-followup"
-              placeholder="Thanks for connecting, {{first_name}}! I wanted to share…"
-              value={followupMessage}
-              onChange={(e) => setFollowupMessage(e.target.value)}
-              rows={4}
-              className="resize-none text-sm"
-            />
-          </div>
-
-          <p className="text-[11px] text-muted-foreground">
-            Use <code className="px-1 py-0.5 rounded bg-muted">{'{{first_name}}'}</code>,{' '}
-            <code className="px-1 py-0.5 rounded bg-muted">{'{{company}}'}</code>,{' '}
-            <code className="px-1 py-0.5 rounded bg-muted">{'{{title}}'}</code> for personalization.
-          </p>
-
-          {/* Media attachment (image / video / voice note / document) */}
-          <div className="space-y-1.5">
-            <Label>Attachment (optional)</Label>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept={MEDIA_ACCEPT}
-              onChange={handleMediaSelect}
-              className="hidden"
-            />
-            {mediaUrl ? (
-              <div className="flex items-center gap-3 p-2 border rounded-md">
-                {mediaType === 'image' ? (
-                  // eslint-disable-next-line @next/next/no-img-element
-                  <img src={mediaUrl} alt={mediaFilename || 'attachment'} className="h-14 w-14 rounded object-cover border" />
-                ) : (
-                  <div className="h-14 w-14 rounded bg-muted flex items-center justify-center text-muted-foreground">
-                    {mediaType === 'video' ? <Film className="h-6 w-6" />
-                      : mediaType === 'audio' ? <Music className="h-6 w-6" />
-                      : <FileText className="h-6 w-6" />}
-                  </div>
-                )}
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium truncate">{mediaFilename || 'Attachment'}</p>
-                  <p className="text-xs text-muted-foreground capitalize">{mediaType || 'file'}</p>
-                </div>
-                <Button type="button" variant="ghost" size="sm" onClick={clearMedia} title="Remove attachment">
-                  <X className="h-4 w-4" />
-                </Button>
-              </div>
-            ) : (
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={uploadingMedia}
-                className="w-full justify-start text-muted-foreground"
-              >
-                {uploadingMedia ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Paperclip className="mr-2 h-4 w-4" />}
-                {uploadingMedia ? 'Uploading…' : 'Attach image, video, voice note, or document'}
-              </Button>
-            )}
-            <p className="text-[11px] text-muted-foreground">
-              Sent with the follow-up message — the connection invite is text-only,
-              so a media-only template needs a follow-up leg to deliver. Max 25MB.
-            </p>
-            {errors.media && (
-              <p className="text-xs text-red-600 flex items-center gap-1">
-                <AlertCircle className="h-3 w-3" /> {errors.media}
-              </p>
-            )}
-          </div>
-
-          {errors.messages && (
-            <p className="text-xs text-red-600 flex items-center gap-1">
-              <AlertCircle className="h-3 w-3" /> {errors.messages}
-            </p>
-          )}
-
-          {/* Category */}
-          <div className="space-y-1.5">
-            <Label htmlFor="li-cat">Category</Label>
+            <Label htmlFor="li-type">Use this template for</Label>
             <select
-              id="li-cat"
-              value={category}
-              onChange={(e) => setCategory(e.target.value)}
-              className="w-full h-9 px-3 py-2 text-sm border border-input rounded-md bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring capitalize"
+              id="li-type"
+              value={templateType}
+              onChange={(e) => handleTypeChange(e.target.value)}
+              className="w-full h-9 px-3 py-2 text-sm border border-input rounded-md bg-transparent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
             >
-              {CATEGORIES.map((c) => (
-                <option key={c} value={c} className="capitalize">{c}</option>
+              {LINKEDIN_TEMPLATE_TYPES.map((t) => (
+                <option key={t.value} value={t.value}>{t.label}</option>
               ))}
             </select>
+            <p className="text-[11px] text-muted-foreground">
+              {isConnection
+                ? 'Connection request note — text-only and limited to 300 characters.'
+                : 'Follow-up message — sent after a connection is accepted. Supports an attachment.'}
+            </p>
           </div>
+
+          {/* Message body + variable picker */}
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="li-body">Message</Label>
+              <div className="flex items-center gap-2">
+                {isConnection && (
+                  <span className={`text-xs ${body.length > LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH ? 'text-red-600' : 'text-muted-foreground'}`}>
+                    {body.length}/{LINKEDIN_CONNECTION_MESSAGE_MAX_LENGTH}
+                  </span>
+                )}
+                {/* Variable picker — inserts a token at the cursor. */}
+                <select
+                  aria-label="Insert variable"
+                  value=""
+                  onChange={(e) => { if (e.target.value) insertVariable(e.target.value); e.currentTarget.selectedIndex = 0; }}
+                  className="h-7 pl-2 pr-1 text-xs border border-input rounded-md bg-transparent text-[#0A66C2] font-medium focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring cursor-pointer"
+                >
+                  <option value="">+ Add variable</option>
+                  {VARIABLE_OPTIONS.map((v) => (
+                    <option key={v.token} value={v.token}>{v.label}</option>
+                  ))}
+                </select>
+              </div>
+            </div>
+            <Textarea
+              id="li-body"
+              placeholder={
+                isConnection
+                  ? 'Hi {{first_name}}, I came across your work at {{company}} and would love to connect.'
+                  : 'Thanks for connecting, {{first_name}}! I wanted to share…'
+              }
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              rows={isConnection ? 3 : 5}
+              className={`resize-none text-sm ${errors.body ? 'border-red-500' : ''}`}
+            />
+            {errors.body && (
+              <p className="text-xs text-red-600 flex items-center gap-1">
+                <AlertCircle className="h-3 w-3" /> {errors.body}
+              </p>
+            )}
+            <p className="text-[11px] text-muted-foreground">
+              Use the <span className="inline-flex items-center gap-0.5 font-medium text-[#0A66C2]"><Plus className="h-3 w-3" />Add variable</span> menu to personalize with the recipient&apos;s name, company, title, or location.
+            </p>
+          </div>
+
+          {/* Media attachment — follow-up templates only */}
+          {!isConnection && (
+            <div className="space-y-1.5">
+              <Label>Attachment (optional)</Label>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept={MEDIA_ACCEPT}
+                onChange={handleMediaSelect}
+                className="hidden"
+              />
+              {mediaUrl ? (
+                <div className="flex items-center gap-3 p-2 border rounded-md">
+                  {mediaType === 'image' ? (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img src={mediaUrl} alt={mediaFilename || 'attachment'} className="h-14 w-14 rounded object-cover border" />
+                  ) : (
+                    <div className="h-14 w-14 rounded bg-muted flex items-center justify-center text-muted-foreground">
+                      {mediaType === 'video' ? <Film className="h-6 w-6" />
+                        : mediaType === 'audio' ? <Music className="h-6 w-6" />
+                        : <FileText className="h-6 w-6" />}
+                    </div>
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm font-medium truncate">{mediaFilename || 'Attachment'}</p>
+                    <p className="text-xs text-muted-foreground capitalize">{mediaType || 'file'}</p>
+                  </div>
+                  <Button type="button" variant="ghost" size="sm" onClick={clearMedia} title="Remove attachment">
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              ) : (
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => fileInputRef.current?.click()}
+                  disabled={uploadingMedia}
+                  className="w-full justify-start text-muted-foreground"
+                >
+                  {uploadingMedia ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Paperclip className="mr-2 h-4 w-4" />}
+                  {uploadingMedia ? 'Uploading…' : 'Attach image, video, voice note, or document'}
+                </Button>
+              )}
+              <p className="text-[11px] text-muted-foreground">
+                Sent with the follow-up message. Max 25MB.
+              </p>
+              {errors.media && (
+                <p className="text-xs text-red-600 flex items-center gap-1">
+                  <AlertCircle className="h-3 w-3" /> {errors.media}
+                </p>
+              )}
+            </div>
+          )}
 
           {/* Default toggle */}
           <div className="flex items-center justify-between p-3 border rounded-md">


### PR DESCRIPTION
## What & why

The LinkedIn template editor forced every template into **two boxes** — *Connection Message* and *Follow-up Message*. Users want **one message body** with a **Type dropdown** (Connection request / Follow-up message), reusing one editor for either purpose, and a **variable picker** instead of typing `{{first_name}}` by hand.

This is the **frontend** for that. Pairs with backend **techiemaya-admin/LAD-Backend#399** (single-row typed templates: `content` + `category`).

## Changes

**`CreateLinkedInTemplateModal` (the editor):**
- **Type dropdown** (Connection request / Follow-up message) drives the rules:
  - *Connection request* → shows the 300-char counter, enforces the cap, text-only (no attachment).
  - *Follow-up message* → any length, attachment allowed.
- **One body** `<Textarea>` + an **"+ Add variable"** picker that inserts `{{first_name}}`/`{{company}}`/`{{title}}`/… at the cursor (reuses the SDK `MESSAGE_VARIABLES`).
- The old `sales/recruiting` "category" dropdown — which **the backend ignored** — is repurposed into this Type selector (the backend `category` column *is* the type).
- Payload sends `{ category, content }` (+ media only for follow-up); hydrates edits from `content` with `connection_message`/`followup_message` fallbacks.

**SDK types:** add `content`/`message` to `LinkedInMessageTemplate` and `content` to the create/update requests (legacy `connection_message`/`followup_message` kept, marked `@deprecated`). Add `TEMPLATE_TYPES` + `templateTypeLabel()`, exported/aliased through the barrels.

**Supporting surfaces:**
- Templates page LinkedIn card → single-body preview + friendly type badge (was raw `linkedin_connection`).
- `TemplateManagerModal` → one **Message** section (300 counter for connection type) + attachment indicator, instead of two message blocks; friendly type badge.
- `TemplateSaveModal` (save a composed message from the builder) → Type dropdown; saves the matching message as one typed body.

**Unchanged:** the campaign-builder connect/follow-up template pickers still filter by `category`, so a template shows in the picker matching its type — no picker rewiring needed.

## Screenshot context
The rich `{{1}}`/Footer editor in the original request is the **WhatsApp** template editor; per the follow-up decision this keeps the **current LinkedIn styling** and adds a variable *selector* (not a full formatting toolbar).

## Verification
- `web` TypeScript: **clean** on all touched files (`tsc --noEmit`).
- ESLint: **0 errors** on touched files.
- Backend unit suites (in #399): 27 template + 109 follow-up tests green.
- ⚠️ End-to-end preview pending: needs backend #399 deployed to **stage** (and an authed session). The API is back-compatible either way. Recommend a quick stage smoke test after both land: create a connection-type template (>300 → blocked), a follow-up-type template with media, confirm builder pickers still filter by type.

## Rollout
Deploy to **stage**. Land backend #399 first so the new `content`/`category` payload is understood (though both sides are back-compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)