### PR TITLE
fix(campaigns): route Edit Campaign to the advanced-search-ai edit flow

### DIFF
--- a/web/src/app/campaigns/[id]/analytics/page.tsx
+++ b/web/src/app/campaigns/[id]/analytics/page.tsx
@@ -446,7 +446,7 @@ export default function CampaignAnalyticsPage() {
             <span className="text-white !text-white">View Leads</span>
           </Button>
           <Button
-            onClick={() => router.push(`/onboarding?campaignId=${campaignId}`)}
+            onClick={() => router.push(`/onboarding/advanced-search-ai?campaignId=${campaignId}`)}
             className="h-10 px-4 rounded-xl font-semibold text-sm tracking-wide text-white !text-white transition-all duration-200 cursor-pointer border-none outline-none active:scale-[0.99]
               bg-[#0b1957] hover:bg-[#122572] shadow-[0_4px_12px_rgba(11,25,87,0.15)]
               dark:bg-[#2563eb] dark:hover:bg-blue-700 dark:shadow-[0_4px_12px_rgba(37,99,235,0.2)]"

--- a/web/src/app/onboarding/page.tsx
+++ b/web/src/app/onboarding/page.tsx
@@ -1,13 +1,27 @@
 'use client';
-import React from 'react';
-import { useSearchParams } from 'next/navigation';
+import React, { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { motion } from 'framer-motion';
 import OnboardingLayout from './components/OnboardingLayout';
 export default function OnboardingPage() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const campaignId = searchParams.get('campaignId');
+
+  // Campaign EDITING lives in the advanced-search-ai setup flow, which hydrates
+  // the saved chat + checkpoint selections from ?campaignId and updates the same
+  // campaign on save. This legacy workflow editor kept receiving stale
+  // "Edit Campaign" links/bookmarks and opened a disconnected 4-step editor
+  // instead — redirect any campaignId deep-link to the real edit experience.
+  useEffect(() => {
+    if (campaignId) {
+      router.replace(`/onboarding/advanced-search-ai?campaignId=${campaignId}`);
+    }
+  }, [campaignId, router]);
+  if (campaignId) return null;
+
   return (
-    <motion.div 
+    <motion.div
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       transition={{ duration: 0.5 }}

--- a/web/src/components/page.tsx
+++ b/web/src/components/page.tsx
@@ -178,7 +178,7 @@ export default function CampaignAnalyticsPage() {
             </Button>
             <Button 
               variant="outline" 
-              onClick={() => router.push(`/onboarding?campaignId=${campaignId}`)} 
+              onClick={() => router.push(`/onboarding/advanced-search-ai?campaignId=${campaignId}`)}
               className="border-white text-white hover:bg-white/10"
             >
               Edit Campaign


### PR DESCRIPTION
## Problem
"Edit Campaign" from the campaign **analytics page** routed to `/onboarding?campaignId=<id>` — the legacy 4-step workflow editor ("I've loaded your campaign 'Karen-ImpactAMC-July' with 4 steps…"), which is disconnected from the setup chat and its config.

Campaign editing actually lives in **`/onboarding/advanced-search-ai?campaignId=<id>`**: it hydrates the saved conversation (`config.conversation_history`) and config selections (`config.checkpoint_selections`), opens the pre-filled checkpoint form, and updates the same campaign on save. Three entry points already use it (campaign detail page, `campaigns/[id]/edit` redirect, actions menu) — two stragglers didn't.

## Changes
- `campaigns/[id]/analytics/page.tsx` + `components/page.tsx` (legacy dashboard): the two remaining **Edit Campaign** buttons now route to `/onboarding/advanced-search-ai?campaignId=<id>`.
- `onboarding/page.tsx`: safety net — any `?campaignId=` deep-link into the legacy page (stale bookmarks, older builds) redirects to the advanced-search-ai edit flow. Plain `/onboarding` (no campaignId) is untouched.

## Verification
- Type-check: zero new errors — the two errors reported in touched files (`analytics/page.tsx:738`, `components/page.tsx:256`) exist identically on unmodified develop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
