### PR TITLE
feat: Zoho CRM integration UI (connect, sync, records, push, auto-sync)

### DIFF
--- a/web/src/components/campaigns/CampaignActionsMenu.tsx
+++ b/web/src/components/campaigns/CampaignActionsMenu.tsx
@@ -1,6 +1,6 @@
 'use client';
-import React from 'react';
-import { Edit, Eye, Play, Pause, Square, Trash2, RotateCcw, PlayCircle } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
+import { Edit, Eye, Play, Pause, Square, Trash2, RotateCcw, PlayCircle, UploadCloud, Loader2 } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -10,6 +10,9 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { useRouter } from 'next/navigation';
 import type { Campaign } from '@lad/frontend-features/campaigns';
+import { fetchWithTenant } from '@/lib/fetch-with-tenant';
+
+const ZOHO_API = '/api/social-integration/zoho';
 
 interface CampaignActionsMenuProps {
   anchorEl: HTMLElement | null;
@@ -35,6 +38,47 @@ export default function CampaignActionsMenu({
   onDelete,
 }: CampaignActionsMenuProps) {
   const router = useRouter();
+
+  // Zoho "Push to Zoho" — only shown when Zoho CRM is connected for this tenant.
+  const [zohoConnected, setZohoConnected] = useState(false);
+  const [pushingZoho, setPushingZoho] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetchWithTenant(`${ZOHO_API}/status`);
+        if (!cancelled && res.ok) {
+          const data = await res.json();
+          setZohoConnected(!!data?.data?.connected);
+        }
+      } catch { /* fail-closed: hide the action */ }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  const handlePushToZoho = async (campaignId: string) => {
+    setPushingZoho(true);
+    try {
+      const res = await fetchWithTenant(`${ZOHO_API}/push`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ module: 'Leads', campaign_id: campaignId }),
+      });
+      const data = await res.json();
+      if (res.ok && data?.success) {
+        const d = data.data;
+        alert(`Pushed campaign leads to Zoho: ${d.inserted} inserted, ${d.updated} updated${d.failed ? `, ${d.failed} failed` : ''}${d.skipped_no_email ? ` (${d.skipped_no_email} skipped — no email)` : ''}.`);
+      } else {
+        alert(`Push to Zoho failed: ${data?.error || 'unknown error'}`);
+      }
+    } catch {
+      alert('Push to Zoho failed.');
+    } finally {
+      setPushingZoho(false);
+    }
+  };
+
   if (!selectedCampaign) return null;
 
   const { status } = selectedCampaign;
@@ -54,6 +98,18 @@ export default function CampaignActionsMenu({
         <DropdownMenuItem onClick={() => { router.push(`/campaigns/${selectedCampaign.id}/analytics`); onClose(); }}>
           <Eye className="mr-2 h-4 w-4" /> View Analytics
         </DropdownMenuItem>
+
+        {zohoConnected && (
+          <DropdownMenuItem
+            disabled={pushingZoho}
+            onSelect={(e) => { e.preventDefault(); handlePushToZoho(selectedCampaign.id); }}
+          >
+            {pushingZoho
+              ? <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              : <UploadCloud className="mr-2 h-4 w-4" />}
+            Push Leads to Zoho
+          </DropdownMenuItem>
+        )}
 
         <DropdownMenuSeparator />
 

--- a/web/src/components/settings/IntegrationsSettings.tsx
+++ b/web/src/components/settings/IntegrationsSettings.tsx
@@ -13,6 +13,7 @@ import { PersonalWaTemplateManager } from '../conversations/PersonalWaTemplateMa
 import { LinkedInIntegration } from './LinkedInIntegration';
 import { TenantOnboarding } from './TenantOnboarding';
 import { GoHighLevelIntegration } from './GoHighLevelIntegration';
+import { ZohoIntegration } from './ZohoIntegration';
 import { useTenant } from '@/contexts/TenantContext';
 import { fetchWithTenant } from '@/lib/fetch-with-tenant';
 
@@ -153,6 +154,16 @@ const INTEGRATIONS: IntegrationCard[] = [
       </svg>
     ),
     iconBg: 'bg-white',
+    category: 'CRM',
+  },
+  {
+    id: 'zoho',
+    name: 'Zoho CRM',
+    description: 'Connect Zoho CRM to sync Contacts, Leads, and Deals — and push Mr LAD leads back into Zoho.',
+    icon: (
+      <span className="text-lg font-bold text-red-600 select-none leading-none" aria-label="Zoho">Z</span>
+    ),
+    iconBg: 'bg-red-50',
     category: 'CRM',
   },
   {
@@ -408,6 +419,17 @@ export const IntegrationsSettings: React.FC = () => {
         }
       } catch { setStatus('gohighlevel', 'disconnected'); }
 
+      // Zoho CRM
+      setStatus('zoho', 'loading');
+      try {
+        const res = await fetchWithTenant('/api/social-integration/zoho/status');
+        if (!res.ok) { setStatus('zoho', 'disconnected'); }
+        else {
+          const data = await res.json();
+          setStatus('zoho', data?.data?.connected ? 'connected' : 'disconnected');
+        }
+      } catch { setStatus('zoho', 'disconnected'); }
+
       // MindBody
       try {
         setStatus('mindbody', 'loading');
@@ -450,6 +472,14 @@ export const IntegrationsSettings: React.FC = () => {
   useEffect(() => {
     refreshStatuses();
   }, [tenantId, refreshStatuses]);
+
+  // Returning from the Zoho OAuth redirect (/settings?tab=integrations&zoho=...)
+  // → open the Zoho detail view so its success/error banner + status show.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const zoho = new URLSearchParams(window.location.search).get('zoho');
+    if (zoho) setActiveView('zoho');
+  }, []);
 
   // Flip a WhatsApp channel's tenant-level "AI Replies" master switch. Optimistic UI;
   // revert + toast on failure. Both calls go through the shared chat-settings proxy:
@@ -576,6 +606,7 @@ export const IntegrationsSettings: React.FC = () => {
           )}
           {activeView === 'linkedin' && <LinkedInIntegration />}
           {activeView === 'gohighlevel' && <GoHighLevelIntegration />}
+          {activeView === 'zoho' && <ZohoIntegration />}
           {activeView === 'slack' && (
             <div className="rounded-xl border border-border bg-card p-8 text-center text-muted-foreground">
               Slack integration coming soon.

--- a/web/src/components/settings/ZohoIntegration.tsx
+++ b/web/src/components/settings/ZohoIntegration.tsx
@@ -1,0 +1,607 @@
+'use client';
+
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  CheckCircle2,
+  AlertCircle,
+  Loader2,
+  RefreshCw,
+  Trash2,
+  Users,
+  Search,
+  Download,
+  ChevronLeft,
+  ChevronRight,
+  Mail,
+  Phone,
+  Building2,
+  UploadCloud,
+  Briefcase,
+  Contact,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { fetchWithTenant } from '@/lib/fetch-with-tenant';
+
+const ZOHO_API = '/api/social-integration/zoho';
+
+const ZOHO_REGIONS: { value: string; label: string }[] = [
+  { value: 'us', label: 'United States (.com)' },
+  { value: 'eu', label: 'Europe (.eu)' },
+  { value: 'in', label: 'India (.in)' },
+  { value: 'au', label: 'Australia (.com.au)' },
+  { value: 'jp', label: 'Japan (.jp)' },
+  { value: 'ca', label: 'Canada (.ca)' },
+  { value: 'sa', label: 'Saudi Arabia (.sa)' },
+  { value: 'cn', label: 'China (.com.cn)' },
+];
+
+type RecordType = 'contacts' | 'leads' | 'deals';
+
+interface ZohoAccount {
+  connected: boolean;
+  region?: string;
+  api_domain?: string;
+  connected_user?: { name?: string | null; email?: string | null } | null;
+  connected_at?: string;
+  last_synced?: string;
+  counts?: { contacts?: number; leads?: number; deals?: number } | null;
+  auto_sync_enabled?: boolean;
+}
+
+interface CRMRecord {
+  id: string;
+  source_id: string;
+  name?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  company_name?: string | null;
+  title?: string | null;
+  tags?: string[];
+  synced_at?: string;
+  // deal fields
+  deal_name?: string | null;
+  stage?: string | null;
+  amount?: number | null;
+  closing_date?: string | null;
+  account_name?: string | null;
+  contact_name?: string | null;
+}
+
+export const ZohoIntegration: React.FC = () => {
+  const [loading, setLoading] = useState(true);
+  const [account, setAccount] = useState<ZohoAccount | null>(null);
+  const [region, setRegion] = useState('us');
+  const [connecting, setConnecting] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [syncing, setSyncing] = useState(false);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [testResult, setTestResult] = useState<{ contacts?: number; success: boolean } | null>(null);
+
+  // Records browser
+  const [recordType, setRecordType] = useState<RecordType>('contacts');
+  const [records, setRecords] = useState<CRMRecord[]>([]);
+  const [recordsTotal, setRecordsTotal] = useState(0);
+  const [recordsPage, setRecordsPage] = useState(1);
+  const [recordsSearch, setRecordsSearch] = useState('');
+  const [recordsLoading, setRecordsLoading] = useState(false);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Push panel
+  const [pushOpen, setPushOpen] = useState(false);
+  const [pushModule, setPushModule] = useState<'Leads' | 'Contacts'>('Leads');
+  const [pushForm, setPushForm] = useState({ first_name: '', last_name: '', email: '', phone: '', company_name: '', title: '' });
+  const [pushing, setPushing] = useState(false);
+  const [pushResult, setPushResult] = useState<string | null>(null);
+
+  // Auto-sync toggle
+  const [autoSync, setAutoSync] = useState(false);
+  const [savingAutoSync, setSavingAutoSync] = useState(false);
+
+  const checkStatus = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetchWithTenant(`${ZOHO_API}/status`);
+      if (res.ok) {
+        const data = await res.json();
+        setAccount(data?.data || null);
+        if (data?.data?.region) setRegion(data.data.region);
+        setAutoSync(!!data?.data?.auto_sync_enabled);
+      } else {
+        setAccount(null);
+      }
+    } catch {
+      setAccount(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    checkStatus();
+  }, [checkStatus]);
+
+  // Surface OAuth return state (?zoho=connected|error) once on mount.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    const zoho = params.get('zoho');
+    if (zoho === 'connected') {
+      setSuccess('Zoho CRM connected successfully.');
+      checkStatus();
+    } else if (zoho === 'error') {
+      setError(`Zoho connection failed: ${params.get('reason') || 'unknown error'}`);
+    }
+    if (zoho) {
+      params.delete('zoho');
+      params.delete('reason');
+      const qs = params.toString();
+      window.history.replaceState({}, '', `${window.location.pathname}${qs ? `?${qs}` : ''}`);
+    }
+  }, [checkStatus]);
+
+  const handleConnect = async () => {
+    setConnecting(true);
+    setError(null);
+    try {
+      const res = await fetchWithTenant(`${ZOHO_API}/oauth/start`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ region }),
+      });
+      const data = await res.json();
+      if (res.ok && data?.data?.url) {
+        window.location.href = data.data.url;
+      } else {
+        setError(data?.error || 'Failed to start Zoho connection');
+        setConnecting(false);
+      }
+    } catch (e) {
+      setError('Failed to start Zoho connection');
+      setConnecting(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    setError(null);
+    try {
+      const res = await fetchWithTenant(`${ZOHO_API}/disconnect`, { method: 'POST' });
+      if (res.ok) {
+        setAccount({ connected: false });
+        setRecords([]);
+        setRecordsTotal(0);
+        setSuccess('Zoho disconnected.');
+      } else {
+        setError('Failed to disconnect');
+      }
+    } catch {
+      setError('Failed to disconnect');
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    setTestResult(null);
+    setError(null);
+    try {
+      const res = await fetchWithTenant(`${ZOHO_API}/test`);
+      const data = await res.json();
+      if (res.ok && data?.success) {
+        setTestResult({ success: true, contacts: data?.data?.contacts_count });
+      } else {
+        setTestResult({ success: false });
+        setError(data?.error || 'Connection test failed');
+      }
+    } catch {
+      setTestResult({ success: false });
+      setError('Connection test failed');
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleSync = async () => {
+    setSyncing(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const res = await fetchWithTenant(`${ZOHO_API}/sync`, { method: 'POST' });
+      const data = await res.json();
+      if (res.ok && data?.success) {
+        const c = data?.data?.synced || {};
+        setSuccess(`Synced ${c.contacts || 0} contacts, ${c.leads || 0} leads, ${c.deals || 0} deals.`);
+        checkStatus();
+        loadRecords(recordType, 1, recordsSearch);
+      } else {
+        setError(data?.error || 'Sync failed');
+      }
+    } catch {
+      setError('Sync failed');
+    } finally {
+      setSyncing(false);
+    }
+  };
+
+  const loadRecords = useCallback(async (type: RecordType, page: number, search: string) => {
+    setRecordsLoading(true);
+    try {
+      const q = new URLSearchParams({ type, page: String(page), limit: '50' });
+      if (search) q.set('search', search);
+      const res = await fetchWithTenant(`${ZOHO_API}/records/local?${q.toString()}`);
+      const data = await res.json();
+      if (res.ok && data?.success) {
+        setRecords(data.data || []);
+        setRecordsTotal(data.total || 0);
+        setRecordsPage(page);
+      } else {
+        setRecords([]);
+        setRecordsTotal(0);
+      }
+    } catch {
+      setRecords([]);
+      setRecordsTotal(0);
+    } finally {
+      setRecordsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (account?.connected) loadRecords(recordType, 1, '');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [account?.connected, recordType]);
+
+  const onSearchChange = (value: string) => {
+    setRecordsSearch(value);
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    searchTimerRef.current = setTimeout(() => loadRecords(recordType, 1, value), 350);
+  };
+
+  const handlePush = async () => {
+    if (!pushForm.email) {
+      setPushResult('Email is required (Zoho dedupes on Email).');
+      return;
+    }
+    setPushing(true);
+    setPushResult(null);
+    try {
+      const res = await fetchWithTenant(`${ZOHO_API}/push`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ module: pushModule, records: [pushForm] }),
+      });
+      const data = await res.json();
+      if (res.ok && data?.success) {
+        const d = data.data;
+        setPushResult(`Pushed to Zoho ${d.module}: ${d.inserted} inserted, ${d.updated} updated${d.failed ? `, ${d.failed} failed` : ''}.`);
+        setPushForm({ first_name: '', last_name: '', email: '', phone: '', company_name: '', title: '' });
+      } else {
+        setPushResult(data?.error || 'Push failed');
+      }
+    } catch {
+      setPushResult('Push failed');
+    } finally {
+      setPushing(false);
+    }
+  };
+
+  const handleToggleAutoSync = async () => {
+    const next = !autoSync;
+    setAutoSync(next); // optimistic
+    setSavingAutoSync(true);
+    try {
+      const res = await fetchWithTenant(`${ZOHO_API}/settings`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ auto_sync_enabled: next }),
+      });
+      if (!res.ok) {
+        setAutoSync(!next); // revert
+        setError('Failed to update auto-sync setting');
+      }
+    } catch {
+      setAutoSync(!next);
+      setError('Failed to update auto-sync setting');
+    } finally {
+      setSavingAutoSync(false);
+    }
+  };
+
+  const totalPages = Math.max(1, Math.ceil(recordsTotal / 50));
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-muted-foreground">
+        <Loader2 className="h-5 w-5 animate-spin mr-2" /> Loading Zoho status…
+      </div>
+    );
+  }
+
+  // ── Not connected ──────────────────────────────────────────────────────────
+  if (!account?.connected) {
+    return (
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-3">
+            <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-red-50 flex items-center justify-center">
+              <span className="text-xl font-bold text-red-600 select-none">Z</span>
+            </div>
+            <div>
+              <CardTitle>Zoho CRM</CardTitle>
+              <CardDescription>
+                Connect your Zoho CRM to sync Contacts, Leads, and Deals — and push Mr LAD leads back into Zoho.
+              </CardDescription>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && (
+            <div className="flex items-start gap-2 rounded-lg bg-red-50 border border-red-200 p-3 text-sm text-red-700">
+              <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" /> {error}
+            </div>
+          )}
+          <div className="space-y-2 max-w-sm">
+            <label className="text-sm font-medium text-foreground">Zoho data center (region)</label>
+            <select
+              value={region}
+              onChange={(e) => setRegion(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+            >
+              {ZOHO_REGIONS.map((r) => (
+                <option key={r.value} value={r.value}>{r.label}</option>
+              ))}
+            </select>
+            <p className="text-xs text-muted-foreground">
+              Pick the region where your Zoho account is hosted (shown in your Zoho URL, e.g. crm.zoho.<b>eu</b>).
+            </p>
+          </div>
+          <Button onClick={handleConnect} disabled={connecting}>
+            {connecting ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+            Connect with Zoho
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // ── Connected ──────────────────────────────────────────────────────────────
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-red-50 flex items-center justify-center">
+                <span className="text-xl font-bold text-red-600 select-none">Z</span>
+              </div>
+              <div>
+                <CardTitle className="flex items-center gap-2">
+                  Zoho CRM
+                  <Badge variant="secondary" className="bg-green-100 text-green-700">
+                    <CheckCircle2 className="h-3 w-3 mr-1" /> Connected
+                  </Badge>
+                </CardTitle>
+                <CardDescription>
+                  {account.connected_user?.email
+                    ? `Connected as ${account.connected_user.email}`
+                    : 'Connected'}
+                  {account.region ? ` · ${account.region.toUpperCase()}` : ''}
+                </CardDescription>
+              </div>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {error && (
+            <div className="flex items-start gap-2 rounded-lg bg-red-50 border border-red-200 p-3 text-sm text-red-700">
+              <AlertCircle className="h-4 w-4 mt-0.5 flex-shrink-0" /> {error}
+            </div>
+          )}
+          {success && (
+            <div className="flex items-start gap-2 rounded-lg bg-green-50 border border-green-200 p-3 text-sm text-green-700">
+              <CheckCircle2 className="h-4 w-4 mt-0.5 flex-shrink-0" /> {success}
+            </div>
+          )}
+
+          <div className="grid grid-cols-3 gap-3">
+            <div className="rounded-lg border border-border p-3 text-center">
+              <div className="text-2xl font-semibold text-foreground">{account.counts?.contacts ?? '—'}</div>
+              <div className="text-xs text-muted-foreground">Contacts</div>
+            </div>
+            <div className="rounded-lg border border-border p-3 text-center">
+              <div className="text-2xl font-semibold text-foreground">{account.counts?.leads ?? '—'}</div>
+              <div className="text-xs text-muted-foreground">Leads</div>
+            </div>
+            <div className="rounded-lg border border-border p-3 text-center">
+              <div className="text-2xl font-semibold text-foreground">{account.counts?.deals ?? '—'}</div>
+              <div className="text-xs text-muted-foreground">Deals</div>
+            </div>
+          </div>
+
+          {account.last_synced && (
+            <p className="text-xs text-muted-foreground">
+              Last synced {new Date(account.last_synced).toLocaleString()}
+            </p>
+          )}
+
+          <label className="flex items-center gap-2 text-sm text-foreground cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={autoSync}
+              disabled={savingAutoSync}
+              onChange={handleToggleAutoSync}
+              className="h-4 w-4 rounded border-input accent-red-600"
+            />
+            Auto-sync from Zoho every 6 hours
+            {savingAutoSync && <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />}
+          </label>
+
+          <div className="flex flex-wrap gap-2">
+            <Button onClick={handleSync} disabled={syncing}>
+              {syncing ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <Download className="h-4 w-4 mr-2" />}
+              {syncing ? 'Syncing…' : 'Sync from Zoho'}
+            </Button>
+            <Button variant="outline" onClick={handleTest} disabled={testing}>
+              {testing ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <RefreshCw className="h-4 w-4 mr-2" />}
+              Test
+            </Button>
+            <Button variant="outline" onClick={() => setPushOpen((v) => !v)}>
+              <UploadCloud className="h-4 w-4 mr-2" /> Push to Zoho
+            </Button>
+            <Button variant="ghost" className="text-red-600 hover:text-red-700" onClick={handleDisconnect} disabled={disconnecting}>
+              {disconnecting ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <Trash2 className="h-4 w-4 mr-2" />}
+              Disconnect
+            </Button>
+          </div>
+
+          {testResult && (
+            <p className={`text-sm ${testResult.success ? 'text-green-600' : 'text-red-600'}`}>
+              {testResult.success
+                ? `Connection OK — ${testResult.contacts ?? 0} contacts reachable.`
+                : 'Connection test failed.'}
+            </p>
+          )}
+
+          {/* Push-to-Zoho panel */}
+          {pushOpen && (
+            <div className="rounded-lg border border-border bg-muted/30 p-4 space-y-3">
+              <div className="flex items-center gap-2 text-sm font-medium text-foreground">
+                <UploadCloud className="h-4 w-4" /> Push a lead into Zoho
+              </div>
+              <div className="flex items-center gap-2">
+                <label className="text-sm text-muted-foreground">Module</label>
+                <select
+                  value={pushModule}
+                  onChange={(e) => setPushModule(e.target.value as 'Leads' | 'Contacts')}
+                  className="rounded-md border border-input bg-background px-2 py-1 text-sm"
+                >
+                  <option value="Leads">Leads</option>
+                  <option value="Contacts">Contacts</option>
+                </select>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                <Input placeholder="First name" value={pushForm.first_name} onChange={(e) => setPushForm({ ...pushForm, first_name: e.target.value })} />
+                <Input placeholder="Last name" value={pushForm.last_name} onChange={(e) => setPushForm({ ...pushForm, last_name: e.target.value })} />
+                <Input placeholder="Email (required)" value={pushForm.email} onChange={(e) => setPushForm({ ...pushForm, email: e.target.value })} />
+                <Input placeholder="Phone" value={pushForm.phone} onChange={(e) => setPushForm({ ...pushForm, phone: e.target.value })} />
+                <Input placeholder="Company" value={pushForm.company_name} onChange={(e) => setPushForm({ ...pushForm, company_name: e.target.value })} />
+                <Input placeholder="Title" value={pushForm.title} onChange={(e) => setPushForm({ ...pushForm, title: e.target.value })} />
+              </div>
+              <div className="flex items-center gap-3">
+                <Button size="sm" onClick={handlePush} disabled={pushing}>
+                  {pushing ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <UploadCloud className="h-4 w-4 mr-2" />}
+                  Push
+                </Button>
+                {pushResult && <span className="text-sm text-muted-foreground">{pushResult}</span>}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Upserts on Email — re-pushing the same email updates the existing Zoho record. Use the <code>/zoho/push</code> API with <code>lead_ids[]</code> to push campaign leads in bulk.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Synced records browser */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <div className="flex gap-1">
+              {(['contacts', 'leads', 'deals'] as RecordType[]).map((t) => (
+                <button
+                  key={t}
+                  onClick={() => { setRecordType(t); setRecordsSearch(''); }}
+                  className={`px-3 py-1.5 rounded-md text-sm font-medium capitalize flex items-center gap-1.5 transition-colors ${
+                    recordType === t ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:bg-muted'
+                  }`}
+                >
+                  {t === 'contacts' && <Contact className="h-3.5 w-3.5" />}
+                  {t === 'leads' && <Users className="h-3.5 w-3.5" />}
+                  {t === 'deals' && <Briefcase className="h-3.5 w-3.5" />}
+                  {t}
+                </button>
+              ))}
+            </div>
+            <div className="relative w-full sm:w-64">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input className="pl-8" placeholder={`Search ${recordType}…`} value={recordsSearch} onChange={(e) => onSearchChange(e.target.value)} />
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {recordsLoading ? (
+            <div className="flex items-center justify-center py-10 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin mr-2" /> Loading…
+            </div>
+          ) : records.length === 0 ? (
+            <div className="text-center py-10 text-muted-foreground text-sm">
+              No {recordType} synced yet. Click “Sync from Zoho” to pull them in.
+            </div>
+          ) : (
+            <ScrollArea className="max-h-[420px]">
+              <div className="divide-y divide-border">
+                {records.map((r) => (
+                  <div key={r.id} className="py-2.5 flex items-center justify-between gap-3">
+                    {recordType === 'deals' ? (
+                      <>
+                        <div className="min-w-0">
+                          <div className="text-sm font-medium text-foreground truncate">{r.deal_name || 'Untitled deal'}</div>
+                          <div className="text-xs text-muted-foreground truncate">
+                            {[r.account_name, r.contact_name].filter(Boolean).join(' · ') || '—'}
+                          </div>
+                        </div>
+                        <div className="text-right flex-shrink-0">
+                          {r.stage && <Badge variant="secondary">{r.stage}</Badge>}
+                          {r.amount != null && <div className="text-sm font-medium text-foreground mt-1">{r.amount.toLocaleString()}</div>}
+                        </div>
+                      </>
+                    ) : (
+                      <>
+                        <div className="min-w-0">
+                          <div className="text-sm font-medium text-foreground truncate">{r.name || '—'}</div>
+                          <div className="text-xs text-muted-foreground flex flex-wrap gap-x-3 gap-y-0.5">
+                            {r.email && <span className="inline-flex items-center gap-1"><Mail className="h-3 w-3" />{r.email}</span>}
+                            {r.phone && <span className="inline-flex items-center gap-1"><Phone className="h-3 w-3" />{r.phone}</span>}
+                            {r.company_name && <span className="inline-flex items-center gap-1"><Building2 className="h-3 w-3" />{r.company_name}</span>}
+                          </div>
+                        </div>
+                        {r.title && <span className="text-xs text-muted-foreground flex-shrink-0">{r.title}</span>}
+                      </>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+          )}
+
+          {recordsTotal > 50 && (
+            <div className="flex items-center justify-between pt-3 mt-2 border-t border-border">
+              <span className="text-xs text-muted-foreground">
+                Page {recordsPage} of {totalPages} · {recordsTotal} {recordType}
+              </span>
+              <div className="flex gap-1">
+                <Button variant="outline" size="sm" disabled={recordsPage <= 1}
+                  onClick={() => loadRecords(recordType, recordsPage - 1, recordsSearch)}>
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <Button variant="outline" size="sm" disabled={recordsPage >= totalPages}
+                  onClick={() => loadRecords(recordType, recordsPage + 1, recordsSearch)}>
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default ZohoIntegration;


### PR DESCRIPTION
Frontend for the Zoho CRM integration. Pairs with the backend change already on `develop` (LAD-Backend `feat/zoho-crm-integration`, endpoints under `/api/social-integration/zoho`).

## What's included
- **`ZohoIntegration` settings component** — OAuth connect with data-center/region select, connection status + record counts, sync-from-Zoho, test, disconnect, a tabbed Contacts/Leads/Deals browser, a push-to-Zoho panel, and an "auto-sync every 6h" opt-in toggle.
- **`IntegrationsSettings`** — new Zoho CRM card (CRM category) with status refresh, detail-view render, and OAuth-return (`?zoho=`) auto-open.
- **`CampaignActionsMenu`** — a "Push Leads to Zoho" action (shown only when Zoho is connected) that pushes the campaign's enrolled leads.

## Verification
- `tsc --noEmit` clean on all three touched files (0 errors in changed files; repo-wide pre-existing errors unchanged).
- Applied via 3-way onto the current `develop` (preserves the recently-merged settings restyle).

## Requires (backend/env)
`ZOHO_CLIENT_ID`, `ZOHO_CLIENT_SECRET`, `ZOHO_REDIRECT_URI` set on the backend, and a registered Zoho API app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)