### PR TITLE
fix(auth): keep session on /me server errors (stage auto-logout) [stage]

### DIFF
--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -83,24 +83,37 @@ export async function proxy(req: NextRequest) {
 
   // 5. Token exists - validate token by calling auth API
   try {
-    const isTokenValid = await validateAuthToken(token);
+    const { ok, status, sessionInvalid } = await validateAuthToken(token);
 
-    if (!isTokenValid) {
-      logger.warn('[Middleware] Token validation failed - Invalid or expired token', { 
+    if (ok) {
+      logger.debug('[Middleware] Token validation successful - Access granted', { pathname });
+      return NextResponse.next();
+    }
+
+    // Only clear the session + bounce to /login when the token is genuinely
+    // rejected (401/403). For any other non-ok response — chiefly a 5xx when the
+    // backend's DB pool is momentarily exhausted and /api/auth/me times out — KEEP
+    // the session and let the request through. A transient backend hiccup must not
+    // log healthy users out (this was the root cause of stage auto-logouts).
+    if (sessionInvalid) {
+      logger.warn('[Middleware] Token rejected (invalid/expired) - clearing session', {
         pathname,
+        status,
       });
-      
-      // Clear invalid token and redirect to login
+
       const loginUrl = new URL('/login', req.url);
       loginUrl.searchParams.set('redirect_url', pathname);
-      
+
       const response = NextResponse.redirect(loginUrl);
       response.cookies.delete('token');
       response.cookies.delete('refresh_token');
       return response;
     }
 
-    logger.debug('[Middleware] Token validation successful - Access granted', { pathname });
+    logger.warn('[Middleware] Auth check returned a server error - keeping session (fail-open)', {
+      pathname,
+      status,
+    });
     return NextResponse.next();
   } catch (error) {
     logger.error('[Middleware] Token validation error', { 

--- a/web/src/utils/api-client.ts
+++ b/web/src/utils/api-client.ts
@@ -67,18 +67,39 @@ export async function apiFetch(
   }
 }
 
+export interface AuthValidationResult {
+  /** Token was verified — allow access. */
+  ok: boolean;
+  /** HTTP status returned by /api/auth/me. */
+  status: number;
+  /**
+   * True ONLY for 401/403 — the token itself is missing/expired/invalid, so it is
+   * safe to clear the session. A 5xx (e.g. the backend's DB pool is exhausted and
+   * /api/auth/me times out) is a SERVER problem, not an expired session; treating it
+   * as a session failure would log healthy users out on a transient backend hiccup.
+   */
+  sessionInvalid: boolean;
+}
+
 /**
  * Validate authentication token
- * Calls the /api/auth/me endpoint to verify token is valid and authorized
+ * Calls the /api/auth/me endpoint to verify token is valid and authorized.
+ *
+ * Distinguishes "token rejected" (401/403 → clear session) from "backend error"
+ * (5xx → keep session). Network errors are left to propagate — the proxy's catch
+ * block fails open on thrown errors, correctly distinguishing "unreachable" from
+ * "invalid token".
  */
-export async function validateAuthToken(token: string): Promise<boolean> {
-  // Let network errors propagate — the proxy's catch block allows requests through
-  // on thrown errors, so this correctly distinguishes "unreachable" from "invalid token"
+export async function validateAuthToken(token: string): Promise<AuthValidationResult> {
   const response = await apiFetch('/api/auth/me', {
     method: 'GET',
     token,
   });
-  return response.ok;
+  return {
+    ok: response.ok,
+    status: response.status,
+    sessionInvalid: response.status === 401 || response.status === 403,
+  };
 }
 
 /**


### PR DESCRIPTION
## Problem
Stage tenants were getting **auto-logged-out**. Root cause was NOT auth/JWT/cookies: the backend `/api/auth/me` intermittently returned a 5xx (DB connection pool exhausted by campaign workers → 10s connection timeout). The Next middleware treated **any** non-ok from `/me` as an invalid session, deleted cookies, and redirected to `/login`.

## Fix (frontend resilience)
- `validateAuthToken` now returns `{ ok, status, sessionInvalid }`; `sessionInvalid` is true **only for 401/403**.
- `proxy.ts` clears the session + redirects **only when `sessionInvalid`**. On any other non-ok (5xx) it keeps the session and lets the request through (fail-open). Network errors still fail open.

Backend counterpart (pool-starvation fix + `/me` 503-on-timeout) landed directly on LAD-Backend `develop`/`stage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)