### PR TITLE
fix(search): honest empty-state for already-contacted + rate-limited searches

### DIFF
--- a/sdk/features/ai-icp-assistant/hooks/useLinkedInSearch.ts
+++ b/sdk/features/ai-icp-assistant/hooks/useLinkedInSearch.ts
@@ -238,8 +238,20 @@ export function useLinkedInSearch() {
           confidence:       data.confidence       || null,
           confidence_score: data.confidence_score || null,
           needs_refinement: data.needs_refinement || false,
+          refinement_suggestion: data.refinement_suggestion || null,
           stats:            data.stats            || {},
           suggestions:      data.suggestions      || [],
+
+          // Count of matches the backend found but hid because the tenant already
+          // sent them a connection request in a prior campaign. Surfaced so the UI
+          // can explain a "0 results" that is really "all matches already contacted"
+          // instead of showing a bare empty state that looks like a broken search.
+          excluded_already_contacted: data.excluded_already_contacted ?? 0,
+
+          // True when 0 results is caused by a provider rate-limit (HTTP 429),
+          // not an empty match set — lets the UI say "temporarily throttled, retry
+          // shortly" instead of a bare empty state / "broaden your filters".
+          rate_limited: data.rate_limited ?? false,
 
           // Preserve success flag
           success: data.success,

--- a/web/src/app/onboarding/advanced-search-ai/page.tsx
+++ b/web/src/app/onboarding/advanced-search-ai/page.tsx
@@ -3873,6 +3873,13 @@ export default function AdvancedSearchAIPage() {
             let rawSearchResults: any[] = [];
             let searchTotal = 0;
             let icpWasApplied = false;
+            // Count of matches the backend found but hid because they were already
+            // contacted in a prior campaign. Used to explain an otherwise-confusing
+            // "0 results" empty state (search worked; the leads were just filtered).
+            let excludedAlreadyContacted = 0;
+            // True when 0 results is a transient provider rate-limit (HTTP 429),
+            // not an empty match set — surfaced so we tell the user to retry.
+            let searchRateLimited = false;
 
             // Determine effective search query for confirmed searches.
             // When user confirms a preview with "yes", "ok", etc., always use the pre-extracted intent
@@ -4014,6 +4021,8 @@ export default function AdvancedSearchAIPage() {
                     setSearchCursor(nextCursor);
                     setCursorHistory([null, nextCursor]); // page1=null(start), page2=nextCursor
                     icpWasApplied = !!d.icp_applied;
+                    excludedAlreadyContacted = Number(d.excluded_already_contacted) || 0;
+                    searchRateLimited = !!d.rate_limited;
                     if (Array.isArray(d.results) && d.results.length > 0) {
                         rawSearchResults = d.results;
                         realLeads = d.results.map((item: any, idx: number) => {
@@ -4177,6 +4186,19 @@ export default function AdvancedSearchAIPage() {
                 // lead-chat triggered a search and got results
                 finalText += `\n\n🔍 **Found ${searchTotal} leads** matching your criteria.`;
                 setTimeout(() => setShowPanel('leads'), 500);
+            }
+
+            // ── Explain an "empty" result truthfully instead of a bare "0 records" ──
+            // Two very different causes look identical without this: (a) LinkedIn
+            // temporarily rate-limited the search (transient — retry works), or
+            // (b) the search DID find people but all were hidden by the
+            // already-contacted filter. Either way a bare summary reads as
+            // "nothing found / broken search", so say what actually happened.
+            if (realLeads.length === 0 && searchRateLimited && !searchErrorMessage) {
+                finalText += `\n\n⏳ **LinkedIn is temporarily rate-limiting searches** on this account — this is not a problem with your search terms or your account. Please wait a minute and run the same search again.`;
+            } else if (realLeads.length === 0 && excludedAlreadyContacted > 0 && !searchErrorMessage) {
+                const n = excludedAlreadyContacted;
+                finalText += `\n\n🔎 **${n} matching ${n === 1 ? 'lead was' : 'leads were'} found but hidden** — you already sent ${n === 1 ? 'them a' : 'them'} connection request${n === 1 ? '' : 's'} in a previous campaign, so they're not shown again. Try a different search, or a lead you haven't contacted yet.`;
             }
 
             const journey = realLeads.length > 0 ? buildOutreachJourney(realLeads, ext) : undefined;


### PR DESCRIPTION
## Problem
Lead search rendered a bare **"0 records"** for two very different causes, making a working search (and a healthy LinkedIn account) look broken:

1. **All matches were hidden by the already-contacted filter** — the search *did* find the person, but the tenant had already sent them a connection request in a prior campaign (e.g. searching a known test contact like "naveen yelluru" → found 1, hidden 1 → shown 0).
2. **The provider rate-limited the search (HTTP 429)** — transient (e.g. running many searches back-to-back); a retry works. Previously surfaced as "0 results, broaden the Location" — misleading.

The `searchUnified` hook was also **dropping** the backend's `excluded_already_contacted` count and `refinement_suggestion`, so the UI had nothing to explain the zero with.

## Fix
- **`useLinkedInSearch`**: forward `refinement_suggestion`, `excluded_already_contacted`, and `rate_limited` from the `/search/unified` response (they were normalized away).
- **`advanced-search-ai` page**: when the result set is empty, append an honest message instead of a bare summary —
  - 429 → *"⏳ LinkedIn is temporarily rate-limiting searches on this account — not a problem with your search terms or account. Wait a minute and run the same search again."*
  - already-contacted → *"🔎 N matching lead(s) were found but hidden — you already sent them a connection request in a previous campaign…"*
  - Rate-limit message takes priority (the two are mutually exclusive).

## Notes
- Purely additive (34 lines across 2 files); no behavior change when results are non-empty.
- Pairs with **LAD-Backend #405** (429 retry/backoff + the `rate_limited` response flag this reads).
- Type-check: no new errors introduced in either changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)